### PR TITLE
Enable building on App Center

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 # Xcode
 xcuserdata
 *.xccheckout
-*.xcworkspace
+*.xcworkspace/xcshareddata
+*.xcworkspace/xcuserdata
 *.playground
 build
 

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -39,7 +39,7 @@
 	<string>RAS_APPLICATION_IDENTIFIER</string>
 	<key>RASProjectSubscriptionKey</key>
 	<string>RAS_SUBSCRIPTION_KEY</string>
-	<key>RMAConfigAPIEndpoint</key>
+	<key>RMAAPIEndpoint</key>
 	<string>https://www.example.com</string>
 </dict>
 </plist>

--- a/MiniApp.xcodeproj/project.pbxproj
+++ b/MiniApp.xcodeproj/project.pbxproj
@@ -533,7 +533,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.rakuten.tech.mobile.miniapp.MiniAppDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -547,7 +547,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.rakuten.tech.mobile.miniapp.MiniAppDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/MiniApp.xcworkspace/contents.xcworkspacedata
+++ b/MiniApp.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:MiniApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/MiniApp/Classes/Environment.swift
+++ b/MiniApp/Classes/Environment.swift
@@ -23,8 +23,8 @@ internal class Environment {
     }
 
     var baseUrl: URL? {
-        guard let endpointUrlString = bundle.value(for: "RMAConfigAPIEndpoint") else {
-            Logger.e("Ensure RMAConfigAPIEndpoint value in plist is valid")
+        guard let endpointUrlString = bundle.value(for: "RMAAPIEndpoint") else {
+            Logger.e("Ensure RMAAPIEndpoint value in plist is valid")
             return nil
         }
         return URL(string: "\(endpointUrlString)")

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -38,7 +38,7 @@ class MockBundle: EnvironmentProtocol {
             return mockSubscriptionKey
         case "CFBundleShortVersionString":
             return mockAppVersion
-        case "RMAConfigAPIEndpoint":
+        case "RMAAPIEndpoint":
             return mockEndpoint
         default:
             return nil

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,6 +31,20 @@ platform :ios do
       coverage
     end
 
+  desc "Set up environment"
+  lane :setup_env do
+    # Use env variables to set up endpoints/keys in order to keep them secret
+    set_info_plist_value(path: "./Example/Info.plist",
+                         key: "RASApplicationIdentifier",
+                         value: ENV['RAS_APPLICATION_IDENTIFIER'] || "APP_ID")
+    set_info_plist_value(path: "./Example/Info.plist",
+                         key: "RASProjectSubscriptionKey",
+                         value: ENV['RAS_PROJECT_SUBSCRIPTION_KEY'] || "SUBSCRIPTION_KEY")
+    set_info_plist_value(path: "./Example/Info.plist",
+                         key: "RMAAPIEndpoint",
+                         value: ENV['RMA_API_ENDPOINT'] || "https://www.example.com")
+  end
+
     desc "Generate code coverage"
     lane :coverage do |options|
       Dir.chdir("..") do


### PR DESCRIPTION
- Change demo app bundle id to com.rakuten.tech.mobile.miniapp.MiniAppDemo
- Add MiniApp.xcworkspace/contents.xcworkspacedata to repo
  - This is required for building the App on App Center - App Center will automatically install the pods, but it will still try to build using xcodeproj if the xcworkspace is not committed
- Set Demo Apps app id, key, and endpoint from environment variables