### PR TITLE
docs: PR template - change gradle command to fastlane command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,4 @@ Add links to github/jira issues, design documents and other relevant resources (
 # Checklist
 - [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
 - [ ] I wrote/updated tests for new/changed code
-- [ ] I ran `./gradlew check` without errors
+- [ ] I ran `fastlane ci` without errors


### PR DESCRIPTION
# Description
This template was copied and pasted from the Android one and forgot to change the `gradle` command to `fastlane`.

## Links

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
