### PR TITLE
Refactoring download mini app operation

### DIFF
--- a/MiniApp/Classes/DownloadOperation.swift
+++ b/MiniApp/Classes/DownloadOperation.swift
@@ -1,70 +1,13 @@
 class DownloadOperation {
     typealias DownloadCompletionHandler = (Result<URL, Error>) -> Void
 
-    private var completionHandler: DownloadCompletionHandler?
-    private var urlToDirectoryMap = [String: URL]()
-    private var miniAppClient: MiniAppClient
-    private var miniAppStorage: MiniAppStorage
-    private var miniAppPath: URL
+    var fileStoragePath: URL
+    var miniAppDirectoryPath: URL
+    var completionHanlder: DownloadCompletionHandler
 
-    private var queue: OperationQueue = {
-        let operationQueue = OperationQueue()
-        operationQueue.name = "MiniAppDownloader"
-        operationQueue.maxConcurrentOperationCount = 4
-        return operationQueue
-    }()
-
-    init(miniAppStorage: MiniAppStorage, miniAppClient: MiniAppClient, miniAppPath: URL, completionHandler: @escaping DownloadCompletionHandler) {
-        self.miniAppClient = miniAppClient
-        self.miniAppStorage = miniAppStorage
-        self.miniAppPath = miniAppPath
-        self.completionHandler = completionHandler
-    }
-
-    func downloadFiles(urls: [String]) {
-        self.miniAppClient.delegate = self
-        for url in urls {
-            guard let fileDirectory = UrlParser.parseForFileDirectory(with: url) else {
-                self.completionHandler?(.failure(NSError.downloadingFailed()))
-                return
-            }
-            if !FileManager.default.fileExists(atPath: self.miniAppPath.appendingPathComponent(fileDirectory).path) {
-                urlToDirectoryMap[url] = self.miniAppPath.appendingPathComponent(fileDirectory)
-                queue.addOperation {
-                    self.miniAppClient.download(url: url)
-                }
-            }
-        }
-        if urlToDirectoryMap.isEmpty {
-            self.completionHandler?(.success(self.miniAppPath))
-        }
-    }
-
-    func cancelAllOperations() {
-        queue.cancelAllOperations()
-    }
-}
-
-extension DownloadOperation: MiniAppDownloaderProtocol {
-
-    func fileDownloaded(sourcePath: URL, destinationPath: String) {
-        guard let filePath = urlToDirectoryMap[destinationPath] else {
-            return
-        }
-        guard let error = self.miniAppStorage.save(sourcePath: sourcePath, destinationPath: filePath) else {
-            return
-        }
-        self.completionHandler?(.failure(error))
-    }
-
-    func downloadCompleted(url: String, error: Error?) {
-        guard let error = error else {
-            urlToDirectoryMap.removeValue(forKey: url)
-            if urlToDirectoryMap.isEmpty {
-                self.completionHandler?(.success(self.miniAppPath))
-            }
-            return
-        }
-        self.completionHandler?(.failure(error))
+    init(fileStoragePath: URL, miniAppDirectoryPath: URL, completionHanlder: @escaping DownloadCompletionHandler) {
+        self.fileStoragePath = fileStoragePath
+        self.miniAppDirectoryPath = miniAppDirectoryPath
+        self.completionHanlder = completionHanlder
     }
 }

--- a/MiniApp/Classes/DownloadOperation.swift
+++ b/MiniApp/Classes/DownloadOperation.swift
@@ -1,0 +1,70 @@
+class DownloadOperation {
+    typealias DownloadCompletionHandler = (Result<URL, Error>) -> Void
+
+    private var completionHandler: DownloadCompletionHandler?
+    private var urlToDirectoryMap = [String: URL]()
+    private var miniAppClient: MiniAppClient
+    private var miniAppStorage: MiniAppStorage
+    private var miniAppPath: URL
+
+    private var queue: OperationQueue = {
+        let operationQueue = OperationQueue()
+        operationQueue.name = "MiniAppDownloader"
+        operationQueue.maxConcurrentOperationCount = 4
+        return operationQueue
+    }()
+
+    init(miniAppStorage: MiniAppStorage, miniAppClient: MiniAppClient, miniAppPath: URL, completionHandler: @escaping DownloadCompletionHandler) {
+        self.miniAppClient = miniAppClient
+        self.miniAppStorage = miniAppStorage
+        self.miniAppPath = miniAppPath
+        self.completionHandler = completionHandler
+    }
+
+    func downloadFiles(urls: [String]) {
+        self.miniAppClient.delegate = self
+        for url in urls {
+            guard let fileDirectory = UrlParser.parseForFileDirectory(with: url) else {
+                self.completionHandler?(.failure(NSError.downloadingFailed()))
+                return
+            }
+            if !FileManager.default.fileExists(atPath: self.miniAppPath.appendingPathComponent(fileDirectory).path) {
+                urlToDirectoryMap[url] = self.miniAppPath.appendingPathComponent(fileDirectory)
+                queue.addOperation {
+                    self.miniAppClient.download(url: url)
+                }
+            }
+        }
+        if urlToDirectoryMap.isEmpty {
+            self.completionHandler?(.success(self.miniAppPath))
+        }
+    }
+
+    func cancelAllOperations() {
+        queue.cancelAllOperations()
+    }
+}
+
+extension DownloadOperation: MiniAppDownloaderProtocol {
+
+    func fileDownloaded(sourcePath: URL, destinationPath: String) {
+        guard let filePath = urlToDirectoryMap[destinationPath] else {
+            return
+        }
+        guard let error = self.miniAppStorage.save(sourcePath: sourcePath, destinationPath: filePath) else {
+            return
+        }
+        self.completionHandler?(.failure(error))
+    }
+
+    func downloadCompleted(url: String, error: Error?) {
+        guard let error = error else {
+            urlToDirectoryMap.removeValue(forKey: url)
+            if urlToDirectoryMap.isEmpty {
+                self.completionHandler?(.success(self.miniAppPath))
+            }
+            return
+        }
+        self.completionHandler?(.failure(error))
+    }
+}

--- a/MiniApp/Classes/Extensions/MiniApp+FileManager.swift
+++ b/MiniApp/Classes/Extensions/MiniApp+FileManager.swift
@@ -8,9 +8,9 @@ extension FileManager {
      * cache directory with AppID and VersionID.
      * @param { appId: String } - AppID of the MiniApp.
      * @param { versionId: String } - VersionID of the MiniApp.
-     * @return { URL? } - URL path to the MiniApp.
+     * @return { URL } - URL path to the MiniApp.
      */
-    class func getMiniAppDirectory(with appId: String, and versionId: String) -> URL? {
+    class func getMiniAppDirectory(with appId: String, and versionId: String) -> URL {
         let cachePath =
             FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
 

--- a/MiniApp/Classes/MiniAppClient.swift
+++ b/MiniApp/Classes/MiniAppClient.swift
@@ -100,17 +100,17 @@ class MiniAppClient: NSObject, URLSessionDownloadDelegate {
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         guard let destinationURL = downloadTask.currentRequest?.url?.absoluteString else {
-            delegate?.downloadCompleted(url: "", error: NSError.downloadingFailed())
+            delegate?.downloadFileTaskCompleted(url: "", error: NSError.downloadingFailed())
             return
         }
-        delegate?.fileDownloaded(sourcePath: location, destinationPath: destinationURL)
+        delegate?.fileDownloaded(at: location, downloadedURL: destinationURL)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let url = task.currentRequest?.url?.absoluteString else {
-            delegate?.downloadCompleted(url: "", error: NSError.downloadingFailed())
+            delegate?.downloadFileTaskCompleted(url: "", error: NSError.downloadingFailed())
             return
         }
-        delegate?.downloadCompleted(url: url, error: error)
+        delegate?.downloadFileTaskCompleted(url: url, error: error)
     }
 }

--- a/MiniApp/Classes/MiniAppDownloader.swift
+++ b/MiniApp/Classes/MiniAppDownloader.swift
@@ -3,8 +3,16 @@ class MiniAppDownloader {
     private var miniAppClient: MiniAppClient
     private var miniAppStorage: MiniAppStorage
     private var manifestDownloader: ManifestDownloader
-    private var urlToDirectoryMap = [String: URL]()
+    private var urlToDirectoryMap = [String: DownloadOperation]()
     private var miniAppStatus: MiniAppStatus
+
+    private var queue: OperationQueue = {
+        let operationQueue = OperationQueue()
+        operationQueue.name = "MiniAppDownloader"
+        operationQueue.maxConcurrentOperationCount = 4
+
+        return operationQueue
+    }()
 
     init(apiClient: MiniAppClient, manifestDownloader: ManifestDownloader, status: MiniAppStatus) {
         self.miniAppClient = apiClient
@@ -22,11 +30,71 @@ class MiniAppDownloader {
         self.manifestDownloader.fetchManifest(apiClient: self.miniAppClient, appId: appId, versionId: versionId) { (result) in
             switch result {
             case .success(let responseData):
-                let downloadOperation = DownloadOperation(miniAppStorage: self.miniAppStorage, miniAppClient: self.miniAppClient, miniAppPath: miniAppStoragePath, completionHandler: completionHandler)
-                downloadOperation.downloadFiles(urls: responseData.manifest)
+                self.downloadMiniApp(urls: responseData.manifest, to: miniAppStoragePath, completionHandler: completionHandler)
             case .failure(let error):
                 return completionHandler(.failure(error))
             }
         }
+    }
+
+    private func downloadMiniApp(urls: [String], to miniAppPath: URL, completionHandler: @escaping (Result<URL, Error>) -> Void) {
+        self.miniAppClient.delegate = self
+        for url in urls {
+            guard let fileDirectory = UrlParser.parseForFileDirectory(with: url) else {
+                completionHandler(.failure(NSError.downloadingFailed()))
+                return
+            }
+            let filePath = miniAppPath.appendingPathComponent(fileDirectory)
+            if !FileManager.default.fileExists(atPath: filePath.path) {
+                urlToDirectoryMap[url] = DownloadOperation(fileStoragePath: filePath, miniAppDirectoryPath: miniAppPath, completionHanlder: completionHandler)
+                queue.addOperation {
+                    self.miniAppClient.download(url: url)
+                }
+            }
+        }
+        if urlToDirectoryMap.isEmpty {
+            completionHandler(.success(miniAppPath))
+        }
+    }
+}
+
+extension MiniAppDownloader: MiniAppDownloaderProtocol {
+
+    /// Delegate called only when file is downloaded successfully
+    /// Downloaded file should be taken care by moving them to any directory before returning the function.
+    ///
+    /// - Parameters:
+    ///     - tempFilePath: Temporary file path where the downloaded file is stored
+    ///     - downloadedURL: URL of the file which was downloaded
+    func fileDownloaded(at sourcePath: URL, downloadedURL destinationPath: String) {
+        guard let filePath = urlToDirectoryMap[destinationPath]?.fileStoragePath else {
+            return
+        }
+        guard let error = miniAppStorage.save(sourcePath: sourcePath, destinationPath: filePath) else {
+            return
+        }
+        urlToDirectoryMap[destinationPath]?.completionHanlder(.failure(error))
+    }
+
+    /// Delegate called whenever download task is completed/failed.
+    /// This method will be called everytime any download file task is completed/failed
+    /// 
+    /// - Parameters:
+    ///   - url: URL of the file which was downloaded
+    ///   - error: Error information if the downloading is failed with error
+    func downloadFileTaskCompleted(url: String, error: Error?) {
+        let completionHandler = urlToDirectoryMap[url]?.completionHanlder
+        guard let error = error else {
+            guard let miniAppDirectoryPath = urlToDirectoryMap[url]?.miniAppDirectoryPath else {
+                completionHandler?(.failure(NSError.downloadingFailed()))
+                return
+            }
+            urlToDirectoryMap.removeValue(forKey: url)
+            if urlToDirectoryMap.isEmpty {
+                completionHandler?(.success(miniAppDirectoryPath))
+            }
+            return
+        }
+        completionHandler?(.failure(error))
     }
 }

--- a/MiniApp/Classes/MiniAppDownloader.swift
+++ b/MiniApp/Classes/MiniAppDownloader.swift
@@ -1,21 +1,10 @@
 class MiniAppDownloader {
 
-    typealias DownloadCompletionHandler = (Result<Bool, Error>) -> Void
-
     private var miniAppClient: MiniAppClient
     private var miniAppStorage: MiniAppStorage
     private var manifestDownloader: ManifestDownloader
-    private var completionHandler: DownloadCompletionHandler?
     private var urlToDirectoryMap = [String: URL]()
     private var miniAppStatus: MiniAppStatus
-
-    private var queue: OperationQueue = {
-        let operationQueue = OperationQueue()
-        operationQueue.name = "MiniAppDownloader"
-        operationQueue.maxConcurrentOperationCount = 4
-
-        return operationQueue
-    }()
 
     init(apiClient: MiniAppClient, manifestDownloader: ManifestDownloader, status: MiniAppStatus) {
         self.miniAppClient = apiClient
@@ -24,70 +13,20 @@ class MiniAppDownloader {
         self.miniAppStatus = status
     }
 
-    func download(appId: String, versionId: String, completionHandler: @escaping (Result<Bool, Error>) -> Void) {
-
+    func download(appId: String, versionId: String, completionHandler: @escaping (Result<URL, Error>) -> Void) {
+        let miniAppStoragePath = FileManager.getMiniAppDirectory(with: appId, and: versionId)
         if miniAppStatus.isDownloaded(key: "\(appId)/\(versionId)") {
-            completionHandler(.success(true))
+            completionHandler(.success(miniAppStoragePath))
             return
         }
         self.manifestDownloader.fetchManifest(apiClient: self.miniAppClient, appId: appId, versionId: versionId) { (result) in
             switch result {
             case .success(let responseData):
-                self.completionHandler = completionHandler
-                self.downloadManifestFiles(with: appId, versionId: versionId, files: responseData.manifest)
+                let downloadOperation = DownloadOperation(miniAppStorage: self.miniAppStorage, miniAppClient: self.miniAppClient, miniAppPath: miniAppStoragePath, completionHandler: completionHandler)
+                downloadOperation.downloadFiles(urls: responseData.manifest)
             case .failure(let error):
                 return completionHandler(.failure(error))
             }
         }
-    }
-
-    private func downloadManifestFiles(with appId: String, versionId: String, files: [String]) {
-        guard let miniAppStoragePath = FileManager.getMiniAppDirectory(with: appId, and: versionId) else {
-            return
-        }
-        downloadMiniApp(files, to: miniAppStoragePath)
-    }
-
-    private func downloadMiniApp(_ urls: [String], to miniAppPath: URL) {
-        self.miniAppClient.delegate = self
-        for url in urls {
-            guard let fileDirectory = UrlParser.parseForFileDirectory(with: url) else {
-                self.completionHandler?(.failure(NSError.downloadingFailed()))
-                return
-            }
-            if !FileManager.default.fileExists(atPath: miniAppPath.appendingPathComponent(fileDirectory).path) {
-                urlToDirectoryMap[url] = miniAppPath.appendingPathComponent(fileDirectory)
-                queue.addOperation {
-                    self.miniAppClient.download(url: url)
-                }
-            }
-        }
-        if urlToDirectoryMap.isEmpty {
-            self.completionHandler?(.success(true))
-        }
-    }
-}
-
-extension MiniAppDownloader: MiniAppDownloaderProtocol {
-
-    func fileDownloaded(sourcePath: URL, destinationPath: String) {
-        guard let filePath = urlToDirectoryMap[destinationPath] else {
-            return
-        }
-        guard let error = miniAppStorage.save(sourcePath: sourcePath, destinationPath: filePath) else {
-            return
-        }
-        self.completionHandler?(.failure(error))
-    }
-
-    func downloadCompleted(url: String, error: Error?) {
-        guard let error = error else {
-            urlToDirectoryMap.removeValue(forKey: url)
-            if urlToDirectoryMap.isEmpty {
-                self.completionHandler?(.success(true))
-            }
-            return
-        }
-        self.completionHandler?(.failure(error))
     }
 }

--- a/MiniApp/Classes/Protocols/MiniAppDownloaderProtocol.swift
+++ b/MiniApp/Classes/Protocols/MiniAppDownloaderProtocol.swift
@@ -3,7 +3,7 @@
  */
 protocol MiniAppDownloaderProtocol: class {
 
-    func fileDownloaded(sourcePath: URL, destinationPath: String)
+    func fileDownloaded(at tempFilePath: URL, downloadedURL: String)
 
-    func downloadCompleted(url: String, error: Error?)
+    func downloadFileTaskCompleted(url: String, error: Error?)
 }

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -27,11 +27,7 @@ internal class RealMiniApp {
     func createMiniApp(appInfo: MiniAppInfo, completionHandler: @escaping (Result<MiniAppDisplayProtocol, Error>) -> Void) {
         return miniAppDownloader.download(appId: appInfo.id, versionId: appInfo.version.versionId) { (result) in
                 switch result {
-                case .success:
-                    guard let miniAppPath = FileManager.getMiniAppDirectory(with: appInfo.id, and: appInfo.version.versionId) else {
-                        completionHandler(.failure(NSError.downloadingFailed()))
-                        return
-                    }
+                case .success(let miniAppPath):
                     DispatchQueue.main.async {
                         guard let miniAppDisplayProtocol = self.displayer.getMiniAppView(miniAppPath: miniAppPath) else {
                             completionHandler(.failure(NSError.downloadingFailed()))

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -65,26 +65,26 @@ class MockAPIClient: MiniAppClient {
 
     override func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         guard let destinationURL = downloadTask.currentRequest?.url?.absoluteString else {
-            delegate?.downloadCompleted(url: "", error: NSError.downloadingFailed())
+            delegate?.downloadFileTaskCompleted(url: "", error: NSError.downloadingFailed())
             return
         }
         guard let fileName = downloadTask.currentRequest?.url?.lastPathComponent else {
-            delegate?.downloadCompleted(url: "", error: NSError.downloadingFailed())
+            delegate?.downloadFileTaskCompleted(url: "", error: NSError.downloadingFailed())
             return
         }
         guard let mockSourceFileURL =  MockFile.createTestFile(fileName: fileName) else {
-            delegate?.downloadCompleted(url: "", error: NSError.downloadingFailed())
+            delegate?.downloadFileTaskCompleted(url: "", error: NSError.downloadingFailed())
             return
         }
-        delegate?.fileDownloaded(sourcePath: mockSourceFileURL, destinationPath: destinationURL)
+        delegate?.fileDownloaded(at: mockSourceFileURL, downloadedURL: destinationURL)
     }
 
     override func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let url = task.currentRequest?.url?.absoluteString else {
-            delegate?.downloadCompleted(url: "", error: NSError.downloadingFailed())
+            delegate?.downloadFileTaskCompleted(url: "", error: NSError.downloadingFailed())
             return
         }
-        delegate?.downloadCompleted(url: url, error: error)
+        delegate?.downloadFileTaskCompleted(url: url, error: error)
     }}
 
 class MockManifestDownloader: ManifestDownloader {


### PR DESCRIPTION
# Description
Moved existing download operation logic into a new class for two reasons below,
* Avoid completion handler memory leak
* To return the Mini App path once the downloading is complete.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
