### PR TITLE
Validations for AppID and Subscription key - MINI-578

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -84,7 +84,7 @@
                         <barButtonItem key="backBarButtonItem" title=" " id="6gZ-4N-NPm"/>
                         <barButtonItem key="rightBarButtonItem" title="Item" image="Settings" id="QKl-NE-KE1">
                             <connections>
-                                <segue destination="TVZ-Rp-2Bg" kind="presentation" modalPresentationStyle="fullScreen" id="6nU-Qi-B5w"/>
+                                <segue destination="TVZ-Rp-2Bg" kind="presentation" identifier="CustomConfiguration" id="6nU-Qi-B5w"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -110,7 +110,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Zsb-zf-A01" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="229.59999999999999" y="385.45727136431788"/>
+            <point key="canvasLocation" x="-50" y="358"/>
         </scene>
         <!--Mini Apps-->
         <scene sceneID="oLG-1t-f3c">
@@ -132,16 +132,16 @@
         <!--Navigation Controller-->
         <scene sceneID="5pZ-hz-1d8">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bb9-pQ-R82" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <navigationController id="TVZ-Rp-2Bg" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="oiR-SE-CN6">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
                         <segue destination="hxN-ta-hmR" kind="relationship" relationship="rootViewController" id="Fp9-YY-LHb"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="bb9-pQ-R82" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="734" y="-328"/>
         </scene>
@@ -150,7 +150,7 @@
             <objects>
                 <tableViewController id="hxN-ta-hmR" customClass="SettingsTableViewController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="PU0-gj-2yN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <sections>

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hzK-gd-cH8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hzK-gd-cH8">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -84,7 +84,7 @@
                         <barButtonItem key="backBarButtonItem" title=" " id="6gZ-4N-NPm"/>
                         <barButtonItem key="rightBarButtonItem" title="Item" image="Settings" id="QKl-NE-KE1">
                             <connections>
-                                <segue destination="TVZ-Rp-2Bg" kind="presentation" id="6nU-Qi-B5w"/>
+                                <segue destination="TVZ-Rp-2Bg" kind="presentation" modalPresentationStyle="fullScreen" id="6nU-Qi-B5w"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -134,7 +134,7 @@
             <objects>
                 <navigationController id="TVZ-Rp-2Bg" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="oiR-SE-CN6">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -150,7 +150,7 @@
             <objects>
                 <tableViewController id="hxN-ta-hmR" customClass="SettingsTableViewController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="PU0-gj-2yN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <sections>
@@ -290,9 +290,9 @@
             <point key="canvasLocation" x="1983" y="385"/>
         </scene>
     </scenes>
-    <color key="tintColor" red="0.68448054790000001" green="0.1388459802" blue="0.090140916409999994" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
     <resources>
         <image name="Settings" width="24" height="24"/>
         <image name="app-list" width="24" height="24"/>
     </resources>
+    <color key="tintColor" red="0.68448054790000001" green="0.1388459802" blue="0.090140916409999994" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
 </document>

--- a/Example/Config.swift
+++ b/Example/Config.swift
@@ -17,5 +17,8 @@ class Config: NSObject {
                                          subscriptionKey: Config.userDefaults?.string(forKey: Config.Key.subscriptionKey.rawValue),
                                          hostAppVersion: Config.userDefaults?.string(forKey: Config.Key.version.rawValue))
     }
+}
 
+protocol ConfigProtocol {
+    func didConfigChanged()
 }

--- a/Example/Config.swift
+++ b/Example/Config.swift
@@ -20,5 +20,5 @@ class Config: NSObject {
 }
 
 protocol ConfigProtocol {
-    func didConfigChanged()
+    func didConfigChanged(miniAppList: [MiniAppInfo])
 }

--- a/Example/Progress+UIViewController.swift
+++ b/Example/Progress+UIViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-extension UIViewController {
+extension UIViewController: UITextFieldDelegate {
 
     func showProgressIndicator(silently: Bool = false, completion: (() -> Void)? = nil) {
         DispatchQueue.main.async {
@@ -63,6 +63,7 @@ extension UIViewController {
                 message: message,
                 preferredStyle: .alert)
             alert.addTextField { (textField) in
+                textField.delegate = self
                 if let type = keyboardType {
                     textField.keyboardType = type
                 }
@@ -76,7 +77,7 @@ extension UIViewController {
                     self.present(alert, animated: true, completion: nil)
                 }
             }
-
+            okAction.isEnabled = false
             alert.addAction(UIAlertAction(title: NSLocalizedString("cancel", comment: ""), style: .cancel, handler: { (_) in
                     self.dismiss(animated: true, completion: nil)
                 }))
@@ -98,5 +99,18 @@ extension UIViewController {
             NSAttributedString.Key.foregroundColor: UIColor.red
         ])
         alertController.setValue(attributedString, forKey: "attributedMessage")
+    }
+
+    /// Method to enable/disable OK button in UIAlertController
+    public func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let alertController = self.presentedViewController as? UIAlertController else {
+            return
+        }
+        let okButtonAction: UIAlertAction = alertController.actions[1]
+        guard let textFieldValue = textField.text, !textFieldValue.isEmpty else {
+            okButtonAction.isEnabled = false
+            return
+        }
+        okButtonAction.isEnabled = true
     }
 }

--- a/Example/Progress+UIViewController.swift
+++ b/Example/Progress+UIViewController.swift
@@ -69,15 +69,11 @@ extension UIViewController {
             }
 
             let okAction = UIAlertAction(title: NSLocalizedString("ok", comment: ""), style: .default) { (action) in
-                if UUID(uuidString: alert.textFields![0].text!) != nil {
+                if alert.textFields![0].text!.isValidUUID() {
                     handler?(action, alert.textFields?.first)
                 } else {
                     self.displayErrorInAlertController(alertController: alert, message: NSLocalizedString("error_invalid_miniapp_id", comment: ""))
                     self.present(alert, animated: true, completion: nil)
-                    // The below code is to remove the error message after three seconds
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        self.displayErrorInAlertController(alertController: alert, message: "")
-                    }
                 }
             }
 

--- a/Example/SettingsTableViewController.swift
+++ b/Example/SettingsTableViewController.swift
@@ -25,12 +25,14 @@ class SettingsTableViewController: UITableViewController {
     }
 
     @IBAction func actionSaveConfig() {
-        save(field: self.textFieldAppID, for: .applicationIdentifier)
-        save(field: self.textFieldSubKey, for: .subscriptionKey)
-        displayAlert(title: NSLocalizedString("message_save_title", comment: ""),
-            message: NSLocalizedString("message_save_text", comment: ""),
-            autoDismiss: true) { _ in
-            self.dismiss(animated: true, completion: nil)
+        if isValidKeyEntered(text: self.textFieldAppID.text, key: .applicationIdentifier) && isValidKeyEntered(text: self.textFieldSubKey.text, key: .subscriptionKey) {
+            save(field: self.textFieldAppID, for: .applicationIdentifier)
+            save(field: self.textFieldSubKey, for: .subscriptionKey)
+            displayAlert(title: NSLocalizedString("message_save_title", comment: ""),
+                message: NSLocalizedString("message_save_text", comment: ""),
+                autoDismiss: true) { _ in
+                self.dismiss(animated: true, completion: nil)
+            }
         }
     }
 
@@ -54,4 +56,44 @@ class SettingsTableViewController: UITableViewController {
         }
     }
 
+    func isValidKeyEntered(text: String?, key: Config.Key) -> Bool {
+        guard let textFieldValue = text, !textFieldValue.isEmpty else {
+            displayNoValueFoundErrorMessage(forKey: key)
+            return false
+        }
+        if textFieldValue.isValidUUID() {
+            return true
+        }
+        displayInvalidValueErrorMessage(forKey: key)
+        return false
+    }
+
+    func displayInvalidValueErrorMessage(forKey: Config.Key) {
+        switch forKey {
+        case .applicationIdentifier:
+        displayAlert(title: NSLocalizedString("error_title", comment: ""),
+            message: NSLocalizedString("error_incorrect_appid_message", comment: ""),
+            autoDismiss: true)
+        case .subscriptionKey:
+        displayAlert(title: NSLocalizedString("error_title", comment: ""),
+            message: NSLocalizedString("error_incorrect_subscription_key_message", comment: ""),
+            autoDismiss: false)
+        default:
+        break
+        }
+    }
+    func displayNoValueFoundErrorMessage(forKey: Config.Key) {
+        switch forKey {
+        case .applicationIdentifier:
+        displayAlert(title: NSLocalizedString("error_title", comment: ""),
+            message: NSLocalizedString("error_empty_appid_key_message", comment: ""),
+            autoDismiss: true)
+        case .subscriptionKey:
+        displayAlert(title: NSLocalizedString("error_title", comment: ""),
+            message: NSLocalizedString("error_empty_subscription_key_message", comment: ""),
+            autoDismiss: false)
+        default:
+        break
+        }
+    }
 }

--- a/Example/SettingsTableViewController.swift
+++ b/Example/SettingsTableViewController.swift
@@ -29,8 +29,11 @@ class SettingsTableViewController: UITableViewController {
     }
 
     @IBAction func actionSaveConfig() {
-        if isValidKeyEntered(text: self.textFieldAppID.text, key: .applicationIdentifier) && isValidKeyEntered(text: self.textFieldSubKey.text, key: .subscriptionKey) {
-            fetchAppList(withConfig: createConfig(hostAppId: self.textFieldAppID.text!, subscriptionKey: self.textFieldSubKey.text!))
+        if isValueEntered(text: self.textFieldAppID.text, key: .applicationIdentifier) && isValueEntered(text: self.textFieldSubKey.text, key: .subscriptionKey) {
+            if self.textFieldAppID.text!.isValidUUID() {
+                fetchAppList(withConfig: createConfig(hostAppId: self.textFieldAppID.text!, subscriptionKey: self.textFieldSubKey.text!))
+            }
+            displayInvalidValueErrorMessage(forKey: .applicationIdentifier)
         }
     }
 
@@ -105,16 +108,12 @@ class SettingsTableViewController: UITableViewController {
         }
     }
 
-    func isValidKeyEntered(text: String?, key: Config.Key) -> Bool {
+    func isValueEntered(text: String?, key: Config.Key) -> Bool {
         guard let textFieldValue = text, !textFieldValue.isEmpty else {
             displayNoValueFoundErrorMessage(forKey: key)
             return false
         }
-        if textFieldValue.isValidUUID() {
-            return true
-        }
-        displayInvalidValueErrorMessage(forKey: key)
-        return false
+        return true
     }
 
     func displayInvalidValueErrorMessage(forKey: Config.Key) {

--- a/Example/SettingsTableViewController.swift
+++ b/Example/SettingsTableViewController.swift
@@ -1,12 +1,15 @@
 import UIKit
 
-class SettingsTableViewController: UITableViewController {
+class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
 
     @IBOutlet weak var textFieldAppID: UITextField!
     @IBOutlet weak var textFieldSubKey: UITextField!
+    var configUpdateProtocol: ConfigProtocol?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.textFieldAppID.delegate = self
+        self.textFieldSubKey.delegate = self
         addTapGesture()
     }
 
@@ -32,6 +35,7 @@ class SettingsTableViewController: UITableViewController {
                 message: NSLocalizedString("message_save_text", comment: ""),
                 autoDismiss: true) { _ in
                 self.dismiss(animated: true, completion: nil)
+                self.configUpdateProtocol?.didConfigChanged()
             }
         }
     }
@@ -95,5 +99,22 @@ class SettingsTableViewController: UITableViewController {
         default:
         break
         }
+    }
+
+    func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        self.navigationItem.rightBarButtonItem?.isEnabled = false
+        return true
+    }
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let hostAppIdText = self.textFieldAppID.text, !hostAppIdText.isEmpty else {
+            self.navigationItem.rightBarButtonItem?.isEnabled = false
+            return
+        }
+        guard let subscriptionKeyText = self.textFieldSubKey.text, !subscriptionKeyText.isEmpty else {
+            self.navigationItem.rightBarButtonItem?.isEnabled = false
+            return
+        }
+        self.navigationItem.rightBarButtonItem?.isEnabled = true
     }
 }

--- a/Example/String+MiniApp.swift
+++ b/Example/String+MiniApp.swift
@@ -3,10 +3,9 @@ import Foundation
 extension String {
 
     func isValidUUID() -> Bool {
-        if(self.range(of: #"[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}+$"#,
-                         options: .regularExpression) != nil) {
-             return true
-         }
-         return false
+        if UUID(uuidString: self) != nil {
+            return true
+        }
+        return false
     }
 }

--- a/Example/String+MiniApp.swift
+++ b/Example/String+MiniApp.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension String {
+
+    func isValidUUID() -> Bool {
+        if(self.range(of: #"[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}+$"#,
+                         options: .regularExpression) != nil) {
+             return true
+         }
+         return false
+    }
+}

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -7,6 +7,7 @@ class ViewController: UITableViewController {
     var currentMiniAppInfo: MiniAppInfo?
     var currentMiniAppView: MiniAppDisplayProtocol?
     let imageCache = ImageCache()
+    let config = Config.getCurrent()
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(true)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import MiniApp
 
-class ViewController: UITableViewController {
+class ViewController: UITableViewController, ConfigProtocol {
 
     var decodeResponse: [MiniAppInfo]?
     var currentMiniAppInfo: MiniAppInfo?
@@ -26,6 +26,11 @@ class ViewController: UITableViewController {
             displayController?.miniAppDisplay = miniAppDisplay
             self.currentMiniAppInfo = nil
             self.currentMiniAppView = nil
+        } else if segue.identifier == "CustomConfiguration" {
+            if let navigationController = segue.destination as? UINavigationController,
+                let customSettingsController = navigationController.topViewController as? SettingsTableViewController {
+                customSettingsController.configUpdateProtocol = self
+            }
         }
     }
 }
@@ -80,5 +85,12 @@ extension ViewController {
                 self.fetchMiniApp(for: miniAppInfo)
             }
         }
+    }
+
+    /// Delegate called whenever Runtime configuration is changed from SettingsTableViewController
+    func didConfigChanged() {
+        self.decodeResponse?.removeAll()
+        self.tableView.reloadData()
+        fetchAppList()
     }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -88,9 +88,9 @@ extension ViewController {
     }
 
     /// Delegate called whenever Runtime configuration is changed from SettingsTableViewController
-    func didConfigChanged() {
+    func didConfigChanged(miniAppList: [MiniAppInfo]) {
         self.decodeResponse?.removeAll()
+        self.decodeResponse = miniAppList
         self.tableView.reloadData()
-        fetchAppList()
     }
 }

--- a/MiniApp.xcodeproj/project.pbxproj
+++ b/MiniApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		18C59F2B241094F600F66632 /* SettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C59F2A241094F600F66632 /* SettingsTableViewController.swift */; };
 		18C59F2D2410ADE300F66632 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C59F2C2410ADE300F66632 /* Config.swift */; };
 		18D764392419D08600150A30 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C59F2C2410ADE300F66632 /* Config.swift */; };
+		380B69B0245000EA0054DD30 /* String+MiniApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380B69AF245000EA0054DD30 /* String+MiniApp.swift */; };
 		3813F32324051E1D002703D7 /* MiniAppStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3813F32224051E1D002703D7 /* MiniAppStatusTests.swift */; };
 		38252B9923DFFBAB008A4E93 /* ListingAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38252B9823DFFBAB008A4E93 /* ListingAPITests.swift */; };
 		38252B9B23DFFBBE008A4E93 /* ManifestAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38252B9A23DFFBBE008A4E93 /* ManifestAPITests.swift */; };
@@ -61,6 +62,7 @@
 		188F5922243DCBAB0042618E /* DisplayNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DisplayNavigationController.swift; path = ../Example/DisplayNavigationController.swift; sourceTree = "<group>"; };
 		18C59F2A241094F600F66632 /* SettingsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SettingsTableViewController.swift; path = Example/SettingsTableViewController.swift; sourceTree = SOURCE_ROOT; };
 		18C59F2C2410ADE300F66632 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Config.swift; path = Example/Config.swift; sourceTree = SOURCE_ROOT; };
+		380B69AF245000EA0054DD30 /* String+MiniApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+MiniApp.swift"; path = "Example/String+MiniApp.swift"; sourceTree = SOURCE_ROOT; };
 		3813F32224051E1D002703D7 /* MiniAppStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniAppStatusTests.swift; sourceTree = "<group>"; };
 		38252B9823DFFBAB008A4E93 /* ListingAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListingAPITests.swift; sourceTree = "<group>"; };
 		38252B9A23DFFBBE008A4E93 /* ManifestAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManifestAPITests.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				18694AD12449883300F97BAA /* UIImageView+Extensions.swift */,
 				1867996A243EF6C200CD6A8E /* ImageCache.swift */,
 				18C59F2C2410ADE300F66632 /* Config.swift */,
+				380B69AF245000EA0054DD30 /* String+MiniApp.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
 				3878D4D223B44F85001E27F8 /* Images.xcassets */,
@@ -337,6 +340,7 @@
 				386A913C23F653E800F5DB1B /* DisplayController.swift in Sources */,
 				38777D9323F67BD2008716A7 /* Progress+UIViewController.swift in Sources */,
 				18C59F2D2410ADE300F66632 /* Config.swift in Sources */,
+				380B69B0245000EA0054DD30 /* String+MiniApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MiniApp/en.lproj/Localizable.strings
+++ b/MiniApp/en.lproj/Localizable.strings
@@ -1,10 +1,10 @@
 "error_title" = "Error";
 "error_list_message" = "Couldn't retrieve Miniapp list, please try again later";
 "error_single_message" = "Couldn't retrieve Miniapp info, please try again later";
-"error_incorrect_appid_message" = "Incorrect Miniapp ID, please try again";
-"error_empty_appid_key_message" = "Miniapp ID cannot be empty, enter valid Miniapp ID and try again";
-"error_incorrect_subscription_key_message" = "Incorrect Miniapp subscription key, please try again";
-"error_empty_subscription_key_message" = "Miniapp subscription key cannot be empty, enter valid subscription key and try again";
+"error_incorrect_appid_message" = "Incorrect Host app ID, please try again";
+"error_empty_appid_key_message" = "Host app ID cannot be empty, enter valid ID and try again";
+"error_incorrect_subscription_key_message" = "Incorrect subscription key, please try again";
+"error_empty_subscription_key_message" = "Subscription key cannot be empty, enter valid subscription key and try again";
 "error_miniapp_message" = "Couldn't retrieve Miniapp, please try again later";
 "error_miniapp_download_message" = "Downloading failed, please try again later";
 "error_invalid_miniapp_id" = "Invalid Miniapp ID";

--- a/MiniApp/en.lproj/Localizable.strings
+++ b/MiniApp/en.lproj/Localizable.strings
@@ -8,11 +8,12 @@
 "error_miniapp_message" = "Couldn't retrieve Miniapp, please try again later";
 "error_miniapp_download_message" = "Downloading failed, please try again later";
 "error_invalid_miniapp_id" = "Invalid Miniapp ID";
+"error_no_miniapp_found" = "No Miniapp found, please contact your administrator";
 
 "input_miniapp_title" = "Please enter Miniapp ID";
 
 "message_save_title" = "Parameters saved";
-"message_save_text" = "You can now refresh your Miniapp list";
+"message_save_text" = "Configuration is saved and Miniapp list is updated";
 
 "wait_message" = "Please wait...";
 "ok" = "OK";

--- a/MiniApp/en.lproj/Localizable.strings
+++ b/MiniApp/en.lproj/Localizable.strings
@@ -2,6 +2,9 @@
 "error_list_message" = "Couldn't retrieve Miniapp list, please try again later";
 "error_single_message" = "Couldn't retrieve Miniapp info, please try again later";
 "error_incorrect_appid_message" = "Incorrect Miniapp ID, please try again";
+"error_empty_appid_key_message" = "Miniapp ID cannot be empty, enter valid Miniapp ID and try again";
+"error_incorrect_subscription_key_message" = "Incorrect Miniapp subscription key, please try again";
+"error_empty_subscription_key_message" = "Miniapp subscription key cannot be empty, enter valid subscription key and try again";
 "error_miniapp_message" = "Couldn't retrieve Miniapp, please try again later";
 "error_miniapp_download_message" = "Downloading failed, please try again later";
 "error_invalid_miniapp_id" = "Invalid Miniapp ID";


### PR DESCRIPTION
# Description
* Changes to validate Mini App ID and Subscription key in the Settings UI
* Enable/Disable Save button only when the user enters a value in TextField
* Fetch mini-app list only when valid host app id and subscription entered in Custom Config
* Save custom configuration only when valid Host app id and subscription entered
* Enable/Disable 'OK' Button in 'Load Mini app by ID' flow

## Links
[MINI-578](https://jira.rakuten-it.com/jira/browse/MINI-578)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
