### PR TITLE
[BUGFIX] Can't load Mini App by ID in demo 

### DIFF
--- a/Example/ViewController+MiniApp.swift
+++ b/Example/ViewController+MiniApp.swift
@@ -45,7 +45,6 @@ extension ViewController {
                         self.fetchMiniAppUsingId(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_single_message", comment: ""))
                     }
                 }
-                self.dismissProgressIndicator()
             }
         }
     }


### PR DESCRIPTION
# Description
Developer can't open his MiniApp by ID in demo. Nasty bug, easy fix.

## Links
MINI-888

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
