### PR TITLE
Do not dismiss Settings screen automatically after settings is saved

### DIFF
--- a/Example/FirstLaunchViewController.swift
+++ b/Example/FirstLaunchViewController.swift
@@ -49,7 +49,7 @@ class FirstLaunchViewController: UIViewController {
 }
 
 extension FirstLaunchViewController: SettingsDelegate {
-    func settingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?) {
+    func didSettingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?) {
         self.performSegue(withIdentifier: "ShowList", sender: miniAppList)
     }
 }

--- a/Example/FirstLaunchViewController.swift
+++ b/Example/FirstLaunchViewController.swift
@@ -49,7 +49,7 @@ class FirstLaunchViewController: UIViewController {
 }
 
 extension FirstLaunchViewController: SettingsDelegate {
-    func settings(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]) {
+    func settingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?) {
         self.performSegue(withIdentifier: "ShowList", sender: miniAppList)
     }
 }

--- a/Example/SettingsTableViewController.swift
+++ b/Example/SettingsTableViewController.swift
@@ -84,10 +84,10 @@ class SettingsTableViewController: UITableViewController {
             autoDismiss: true) { _ in
                 self.dismiss(animated: true, completion: nil)
                 guard let miniAppList = responseData else {
-                    self.configUpdateDelegate?.settingsUpdated(controller: self, updated: nil)
+                    self.configUpdateDelegate?.didSettingsUpdated(controller: self, updated: nil)
                     return
                 }
-                self.configUpdateDelegate?.settingsUpdated(controller: self, updated: miniAppList)
+                self.configUpdateDelegate?.didSettingsUpdated(controller: self, updated: miniAppList)
             }
     }
 
@@ -197,5 +197,5 @@ class SettingsTableViewController: UITableViewController {
 }
 
 protocol SettingsDelegate: class {
-    func settingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?)
+    func didSettingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?)
 }

--- a/Example/SettingsTableViewController.swift
+++ b/Example/SettingsTableViewController.swift
@@ -55,9 +55,8 @@ class SettingsTableViewController: UITableViewController {
                 switch result {
                 case .success(let responseData):
                     DispatchQueue.main.async {
-                        self.configUpdateDelegate?.settings(controller: self, updated: responseData)
                         self.dismissProgressIndicator()
-                        self.saveCustomConfiguration()
+                        self.saveCustomConfiguration(responseData: responseData)
                     }
                 case .failure(let error):
                     let errorInfo = error as NSError
@@ -67,7 +66,7 @@ class SettingsTableViewController: UITableViewController {
                     } else {
                         DispatchQueue.main.async {
                             self.displayAlert(title: "Information", message: NSLocalizedString("error_no_miniapp_found", comment: ""), dismissController: true) { _ in
-                                self.saveCustomConfiguration()
+                                self.saveCustomConfiguration(responseData: nil)
                                 self.dismiss(animated: true, completion: nil)
                             }
                         }
@@ -77,13 +76,18 @@ class SettingsTableViewController: UITableViewController {
         }
     }
 
-    func saveCustomConfiguration() {
+    func saveCustomConfiguration(responseData: [MiniAppInfo]?) {
         self.save(field: self.textFieldAppID, for: .applicationIdentifier)
         self.save(field: self.textFieldSubKey, for: .subscriptionKey)
         self.displayAlert(title: NSLocalizedString("message_save_title", comment: ""),
             message: NSLocalizedString("message_save_text", comment: ""),
             autoDismiss: true) { _ in
                 self.dismiss(animated: true, completion: nil)
+                guard let miniAppList = responseData else {
+                    self.configUpdateDelegate?.settingsUpdated(controller: self, updated: nil)
+                    return
+                }
+                self.configUpdateDelegate?.settingsUpdated(controller: self, updated: miniAppList)
             }
     }
 
@@ -193,5 +197,5 @@ class SettingsTableViewController: UITableViewController {
 }
 
 protocol SettingsDelegate: class {
-    func settings(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo])
+    func settingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?)
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -85,7 +85,7 @@ extension ViewController {
 
 // MARK: - SettingsDelegate
 extension ViewController: SettingsDelegate {
-    func settingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?) {
+    func didSettingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?) {
         self.decodeResponse?.removeAll()
         self.decodeResponse = miniAppList
         self.tableView.reloadData()

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -85,7 +85,7 @@ extension ViewController {
 
 // MARK: - SettingsDelegate
 extension ViewController: SettingsDelegate {
-    func settings(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]) {
+    func settingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?) {
         self.decodeResponse?.removeAll()
         self.decodeResponse = miniAppList
         self.tableView.reloadData()


### PR DESCRIPTION
# Description
Custom Settings screen is getting dismissed automatically for the first time launch flow.
Added fix to not dismiss the Settings screen until user taps on OK button in the confirmation alert

## Links
[MINI-945](https://jira.rakuten-it.com/jira/browse/MINI-945)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
