### PR TITLE
Added Fixed Display Mini app by ID button in header view

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -15,21 +15,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <button key="tableHeaderView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="xay-r6-1v2">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" red="0.68448054790000001" green="0.1388459802" blue="0.090140916409999994" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                            <state key="normal" title="Display Miniapp from ID">
-                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </state>
-                            <connections>
-                                <action selector="actionShowMiniAppById" destination="YI1-4h-cvm" eventType="touchUpInside" id="1uI-8N-QKv"/>
-                            </connections>
-                        </button>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MiniAppCell" rowHeight="70" id="enh-z9-xZy" customClass="MiniAppCell" customModule="MiniApp_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="98" width="375" height="70"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="70"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="enh-z9-xZy" id="Q6Z-ra-k9B">
                                     <rect key="frame" x="0.0" y="0.0" width="348" height="70"/>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -72,6 +72,14 @@ extension ViewController {
         return UITableViewCell()
     }
 
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return getHeaderView()
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 60.0
+    }
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         self.showProgressIndicator {
@@ -80,6 +88,18 @@ extension ViewController {
                 self.fetchMiniApp(for: miniAppInfo)
             }
         }
+    }
+
+    func getHeaderView() -> UIView? {
+        let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 60))
+        let miniAppByIdButton = UIButton(frame: headerView.bounds)
+        miniAppByIdButton.setTitle("Display Miniapp from ID", for: .normal)
+        miniAppByIdButton.contentHorizontalAlignment = .center
+        miniAppByIdButton.autoresizingMask = .flexibleWidth
+        miniAppByIdButton.addTarget(self, action: #selector(actionShowMiniAppById), for: .touchUpInside)
+        headerView.addSubview(miniAppByIdButton)
+        headerView.backgroundColor = #colorLiteral(red: 0.7472071648, green: 0, blue: 0, alpha: 1)
+        return headerView
     }
 }
 


### PR DESCRIPTION
# Description
Display Mini app by ID button should be a static cell at the top and it needs to be displayed even when the user scrolls the list.
Removed the cell from the Storyboard tableview and added it as HeaderView to remain static at the top.

## Links
[MINI-963](https://jira.rakuten-it.com/jira/browse/MINI-963)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
