### PR TITLE
ci: Move pod publishing to 'after_success'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,30 +62,29 @@ after_success:
 # Merge master into prod branch to trigger production build on App Center
 - |
   if [[ $IS_RELEASE ]]; then
+    set -e
     git remote add github https://${GITHUB_TOKEN}@github.com/rakutentech/ios-miniapp.git
     git fetch github master:prod
     git push github prod
   fi
+# Deploy Pod spec when tagged as release
+- |
+  if [[ $IS_RELEASE ]]; then
+    set -e
+    pod spec lint --allow-warnings 
+    pod trunk push --allow-warnings
+  fi
 
 deploy:
-  # Deploy Pod spec when tagged as release
-  - provider: script
-    cleanup: false
-    script:
-      - pod spec lint --allow-warnings 
-      - pod trunk push --allow-warnings
-    on:
-      tags: true
-      condition: $TRAVIS_TAG =~ ^v
   # Deploy Docs to Github Pages when tagged as release
-  - provider: pages
-    cleanup: false
-    github_token: $GITHUB_TOKEN
-    keep_history: true
-    local_dir: docs
-    on:
-      tags: true
-      condition: $TRAVIS_TAG =~ ^v
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  keep_history: true
+  local_dir: docs
+  on:
+    tags: true
+    condition: $TRAVIS_TAG =~ ^v
 
 notifications:
   slack:


### PR DESCRIPTION
# Description
This script doesn't seem to work from the deploy section (similar to the App Center script). The scripts are getting a little lengthy in the `after_success` section, so probably we should refactor into external script files eventually...

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
