### PR TITLE
Fix issues that occurs in Offline loading

### DIFF
--- a/Example/ViewController+MiniApp.swift
+++ b/Example/ViewController+MiniApp.swift
@@ -28,7 +28,6 @@ extension ViewController {
                         self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_list_message", comment: ""), dismissController: true)
                     }
                 }
-                /// Dismiss progress indicator only if it is not in background
                 if !inBackground {
                     self.dismissProgressIndicator()
                 }

--- a/Example/ViewController+MiniApp.swift
+++ b/Example/ViewController+MiniApp.swift
@@ -10,9 +10,8 @@ extension ViewController: MiniAppMessageProtocol {
 }
 
 extension ViewController {
-    func fetchAppList() {
-        let silent = self.decodeResponse?.count ?? 0 > 0
-        showProgressIndicator(silently: silent) {
+    func fetchAppList(inBackground: Bool) {
+        showProgressIndicator(silently: inBackground) {
             MiniApp.shared(with: Config.getCurrent()).list { (result) in
                 DispatchQueue.main.async {
                     self.refreshControl?.endRefreshing()
@@ -25,9 +24,14 @@ extension ViewController {
                     }
                 case .failure(let error):
                     print(error.localizedDescription)
-                    self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_list_message", comment: ""), dismissController: true)
+                    if !inBackground {
+                        self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_list_message", comment: ""), dismissController: true)
+                    }
                 }
-                self.dismissProgressIndicator()
+                /// Dismiss progress indicator only if it is not in background
+                if !inBackground {
+                    self.dismissProgressIndicator()
+                }
             }
         }
     }
@@ -59,7 +63,7 @@ extension ViewController {
                 }
             case .failure(let error):
                 self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_miniapp_download_message", comment: ""), dismissController: true) { _ in
-                    self.fetchAppList()
+                    self.fetchAppList(inBackground: true)
                 }
                 print("Errored: ", error.localizedDescription)
             }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UITableViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(true)
-        fetchAppList()
+        fetchAppList(inBackground: self.decodeResponse?.count ?? 0 > 0)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -44,7 +44,7 @@ class ViewController: UITableViewController {
 // MARK: - Actions
 extension ViewController {
     @IBAction func refreshList(_ sender: UIRefreshControl) {
-        fetchAppList()
+        fetchAppList(inBackground: false)
     }
 
     @IBAction func actionShowMiniAppById() {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MiniApp (1.0.0)
+  - MiniApp (1.1.0)
   - Nimble (8.0.5)
   - Quick (2.2.0)
 
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  MiniApp: e93d6c81979130e2792e52cdfb56d93845246cbb
+  MiniApp: da41ebc93b808d56c62c60704ed55cd789b8d272
   Nimble: 4ab1aeb9b45553c75b9687196b0fa0713170a332
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
 
 PODFILE CHECKSUM: 73865deea491c41e4c4edff3bff606af1e29d969
 
-COCOAPODS: 1.9.2
+COCOAPODS: 1.9.1


### PR DESCRIPTION
# Description
Offline mode for Mini apps is already supported in iOS, but there are some issues that need to be fixed.

* Display only downloading failed error when a mini-app is failed to download, if it is downloaded already, display the mini-app
* Mini app getting auto-dismissed when switching fast between different mini-apps. This is fixed.

## Links
[MINI-1019](https://jira.rakuten-it.com/jira/browse/MINI-1019)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
