### PR TITLE
ci: Change App Center prod build to build from tag instead of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ after_success:
   if [[ $IS_RELEASE ]]; then
     set -e
     git remote add github https://${GITHUB_TOKEN}@github.com/rakutentech/ios-miniapp.git
-    git fetch github master:prod
+    git fetch github $TRAVIS_TAG:prod
     git push github prod
   fi
 # Deploy Pod spec when tagged as release


### PR DESCRIPTION
# Description
Describe the changes in this pull request.
App center should build the release tag instead of the master branch when performing a release.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
