### PR TITLE
ci: Change 'jazzy' command to run with 'bundle exec'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
 
 after_success:
 # Upload code coverage
-- jazzy
+- bundle exec jazzy
   --xcodebuild-arguments -scheme,Tests
   --module MiniApp
   --source-directory MiniApp


### PR DESCRIPTION
# Description
This ensures that jazzy is run with the version installed by the bundler from the Gemfile

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
