### PR TITLE
Revert back changes related to First launch flow

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -83,7 +83,7 @@
                             <fragment content="Pull to fetch Mini App List">
                                 <attributes>
                                     <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <font key="NSFont" metaFont="menu" size="11"/>
+                                    <font key="NSFont" metaFont="message" size="11"/>
                                     <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                 </attributes>
                             </fragment>
@@ -94,12 +94,11 @@
                     </refreshControl>
                     <connections>
                         <segue destination="eW9-Vs-PTN" kind="presentation" identifier="DisplayMiniApp" modalPresentationStyle="fullScreen" id="6x7-eF-gjJ"/>
-                        <segue destination="Hdf-Tn-FfN" kind="show" identifier="ShowFirstTimeSettings" id="9l1-op-hT5"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Zsb-zf-A01" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-604" y="385"/>
+            <point key="canvasLocation" x="-50" y="358"/>
         </scene>
         <!--Mini Apps-->
         <scene sceneID="oLG-1t-f3c">
@@ -111,12 +110,12 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
-                        <segue destination="YI1-4h-cvm" kind="relationship" relationship="rootViewController" id="6Vk-Ln-Ydd"/>
+                        <segue destination="PYJ-k9-q8M" kind="relationship" relationship="rootViewController" id="mCy-XW-KqD"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fuO-cR-uS5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1452" y="385"/>
+            <point key="canvasLocation" x="-1644" y="358"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="5pZ-hz-1d8">
@@ -132,7 +131,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bb9-pQ-R82" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="238" y="385"/>
+            <point key="canvasLocation" x="734" y="-328"/>
         </scene>
         <!--Settings-->
         <scene sceneID="7fb-nw-Qcz">
@@ -257,7 +256,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bJO-tx-zfF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1159" y="385"/>
+            <point key="canvasLocation" x="1565.5999999999999" y="-329.68515742128938"/>
         </scene>
         <!--Display Navigation Controller-->
         <scene sceneID="zzX-v6-zei">
@@ -273,7 +272,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Cs1-cQ-D16" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-604" y="1107"/>
+            <point key="canvasLocation" x="1190" y="385"/>
         </scene>
         <!--Display Controller-->
         <scene sceneID="poG-Jp-R00">
@@ -298,12 +297,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wmx-vD-Phy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="239" y="1107"/>
+            <point key="canvasLocation" x="1983" y="385"/>
         </scene>
         <!--First Launch View Controller-->
         <scene sceneID="V5O-3V-s60">
             <objects>
-                <viewController modalPresentationStyle="currentContext" id="PYJ-k9-q8M" customClass="FirstLaunchViewController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="PYJ-k9-q8M" customClass="FirstLaunchViewController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="kk8-aI-8Ur"/>
                         <viewControllerLayoutGuide type="bottom" id="Krt-em-zT8"/>
@@ -445,28 +444,12 @@
                         <outlet property="imageViewArrow" destination="yT1-zs-EtE" id="Wl1-su-yPw"/>
                         <outlet property="labelHint" destination="t3z-2Z-1dP" id="I0T-jC-A6n"/>
                         <outlet property="labelMiniApp" destination="KcI-k9-czF" id="U8m-uo-zgP"/>
+                        <segue destination="YI1-4h-cvm" kind="show" identifier="ShowList" animates="NO" id="1cI-AJ-6w8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W7Y-0J-gpd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1158" y="-385"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="ShL-7Y-pT9">
-            <objects>
-                <navigationController modalPresentationStyle="fullScreen" id="Hdf-Tn-FfN" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="oKE-N8-GH6"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="N30-Tf-8XS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="PYJ-k9-q8M" kind="relationship" relationship="rootViewController" id="KzD-2Y-X1m"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="z1N-3y-QoB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="238" y="-385"/>
+            <point key="canvasLocation" x="-850.39999999999998" y="357.57121439280365"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/Example/FirstLaunchViewController.swift
+++ b/Example/FirstLaunchViewController.swift
@@ -1,19 +1,24 @@
 import UIKit
 import MiniApp
-
 class FirstLaunchViewController: UIViewController {
-
     @IBOutlet weak var imageViewArrow: UIImageView!
     @IBOutlet weak var labelHint: UILabel!
     @IBOutlet weak var labelMiniApp: UILabel!
-
     override func viewDidLoad() {
         super.viewDidLoad()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        animateViews()
+        if checkSettingsOK() {
+            self.performSegue(withIdentifier: "ShowList", sender: nil)
+        } else {
+            animateViews()
+        }
+    }
+
+    func checkSettingsOK() -> Bool {
+        return Config.userDefaults?.string(forKey: Config.Key.applicationIdentifier.rawValue) != nil && Config.userDefaults?.string(forKey: Config.Key.subscriptionKey.rawValue) != nil
     }
 
     func animateViews() {
@@ -32,12 +37,16 @@ class FirstLaunchViewController: UIViewController {
                 let customSettingsController = navigationController.topViewController as? SettingsTableViewController {
                 customSettingsController.configUpdateDelegate = self
             }
+        } else if segue.identifier == "ShowList" {
+            if let viewController = segue.destination as? ViewController {
+                viewController.decodeResponse = sender as? [MiniAppInfo]
+            }
         }
     }
 }
 
 extension FirstLaunchViewController: SettingsDelegate {
     func didSettingsUpdated(controller: SettingsTableViewController, updated miniAppList: [MiniAppInfo]?) {
-        dismiss(animated: true, completion: nil)
+        self.performSegue(withIdentifier: "ShowList", sender: miniAppList)
     }
 }

--- a/Example/ViewController+MiniApp.swift
+++ b/Example/ViewController+MiniApp.swift
@@ -24,17 +24,12 @@ extension ViewController {
                     }
                 case .failure(let error):
                     print(error.localizedDescription)
-                    if !inBackground && self.checkSettingsOK() {
+                    if !inBackground {
                         self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_list_message", comment: ""), dismissController: true)
                     }
                 }
                 if !inBackground {
                     self.dismissProgressIndicator()
-                }
-                if !self.checkSettingsOK() {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                        self.performSegue(withIdentifier: "ShowFirstTimeSettings", sender: nil)
-                    }
                 }
             }
         }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -39,10 +39,6 @@ class ViewController: UITableViewController {
             }
         }
     }
-
-    func checkSettingsOK() -> Bool {
-        return Config.userDefaults?.string(forKey: Config.Key.applicationIdentifier.rawValue) != nil && Config.userDefaults?.string(forKey: Config.Key.subscriptionKey.rawValue) != nil
-    }
 }
 
 // MARK: - Actions


### PR DESCRIPTION
# Description
* Reverted back changes on how to show the first launch screen
* Changes to sync up with Android behavior
    * Table view will not fetch the list until the config is saved for the first time.


# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
