### PR TITLE
Feature/offline loading

### DIFF
--- a/MiniApp/Classes/Display/Displayer.swift
+++ b/MiniApp/Classes/Display/Displayer.swift
@@ -1,6 +1,6 @@
 internal class Displayer {
 
-    func getMiniAppView(miniAppId: String, hostAppMessageDelegate: MiniAppMessageProtocol) -> MiniAppDisplayProtocol {
-        return RealMiniAppView(miniAppId: miniAppId, hostAppMessageDelegate: hostAppMessageDelegate)
+    func getMiniAppView(miniAppId: String, versionId: String, hostAppMessageDelegate: MiniAppMessageProtocol) -> MiniAppDisplayProtocol {
+        return RealMiniAppView(miniAppId: miniAppId, versionId: versionId, hostAppMessageDelegate: hostAppMessageDelegate)
     }
 }

--- a/MiniApp/Classes/Display/MiniAppWebView.swift
+++ b/MiniApp/Classes/Display/MiniAppWebView.swift
@@ -2,13 +2,13 @@ import WebKit
 
 internal class MiniAppWebView: WKWebView {
 
-    convenience init(miniAppId: String) {
+    convenience init(miniAppId: String, versionId: String) {
         let schemeName = Constants.miniAppSchemePrefix + miniAppId
         let urlRequest = URLRequest(url: URL(string: schemeName + "://miniapp/" + Constants.rootFileName)!)
         let config = WKWebViewConfiguration()
         config.preferences.javaScriptEnabled = true
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
-        config.setURLSchemeHandler(URLSchemeHandler(), forURLScheme: schemeName)
+        config.setURLSchemeHandler(URLSchemeHandler(versionId: versionId), forURLScheme: schemeName)
         self.init(frame: .zero, configuration: config)
         contentMode = .scaleToFill
         load(urlRequest)

--- a/MiniApp/Classes/Display/RealMiniAppView.swift
+++ b/MiniApp/Classes/Display/RealMiniAppView.swift
@@ -4,8 +4,8 @@ internal class RealMiniAppView: UIView, MiniAppDisplayProtocol, MiniAppCallbackP
     internal var webView: WKWebView
     internal weak var hostAppMessageDelegate: MiniAppMessageProtocol?
 
-    init(miniAppId: String, hostAppMessageDelegate: MiniAppMessageProtocol) {
-        webView = MiniAppWebView(miniAppId: miniAppId)
+    init(miniAppId: String, versionId: String, hostAppMessageDelegate: MiniAppMessageProtocol) {
+        webView = MiniAppWebView(miniAppId: miniAppId, versionId: versionId)
         self.hostAppMessageDelegate = hostAppMessageDelegate
         super.init(frame: .zero)
         webView.configuration.userContentController.addMiniAppScriptMessageHandler(delegate: self, hostAppMessageDelegate: hostAppMessageDelegate)

--- a/MiniApp/Classes/MiniAppDownloader.swift
+++ b/MiniApp/Classes/MiniAppDownloader.swift
@@ -23,7 +23,7 @@ class MiniAppDownloader {
 
     func download(appId: String, versionId: String, completionHandler: @escaping (Result<URL, Error>) -> Void) {
         let miniAppStoragePath = FileManager.getMiniAppVersionDirectory(with: appId, and: versionId)
-        if !isMiniAppDownloadedAlready(appId: appId, versionId: versionId) {
+        if !isMiniAppAlreadyDownloaded(appId: appId, versionId: versionId) {
             self.manifestDownloader.fetchManifest(apiClient: self.miniAppClient, appId: appId, versionId: versionId) { (result) in
                  switch result {
                  case .success(let responseData):
@@ -51,7 +51,7 @@ class MiniAppDownloader {
         }
     }
 
-    func isMiniAppDownloadedAlready(appId: String, versionId: String) -> Bool {
+    func isMiniAppAlreadyDownloaded(appId: String, versionId: String) -> Bool {
         if miniAppStatus.isDownloaded(appId: appId, versionId: versionId) {
             let versionDirectory = FileManager.getMiniAppVersionDirectory(with: appId, and: versionId)
             var isDirectory: ObjCBool = true

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -48,6 +48,10 @@ internal class RealMiniApp {
                 }
                 self.downloadMiniApp(appInfo: appInfo, completionHandler: completionHandler)
             case .failure(let error):
+                let createError = error as NSError
+                if createError.code == NSURLErrorNotConnectedToInternet {
+                    self.downloadMiniApp(appInfo: appInfo, completionHandler: completionHandler)
+                }
                 completionHandler(.failure(error))
         }}
     }

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -49,8 +49,11 @@ internal class RealMiniApp {
                 self.downloadMiniApp(appInfo: appInfo, completionHandler: completionHandler)
             case .failure(let error):
                 let createError = error as NSError
-                if createError.code == NSURLErrorNotConnectedToInternet {
-                    self.downloadMiniApp(appInfo: appInfo, completionHandler: completionHandler)
+                if Constants.offlineErrorCodeList.contains(createError.code) {
+                    if self.miniAppDownloader.getCachedMiniApp(appId: appInfo.id) == nil {
+                        return completionHandler(.failure(error))
+                    }
+                    self.getMiniAppView(appInfo: appInfo, completionHandler: completionHandler, messageInterface: messageInterface)
                 }
                 completionHandler(.failure(error))
         }}
@@ -65,14 +68,18 @@ internal class RealMiniApp {
         return miniAppDownloader.download(appId: appInfo.id, versionId: appInfo.version.versionId) { (result) in
             switch result {
             case .success:
-                DispatchQueue.main.async {
-                    let miniAppDisplayProtocol = self.displayer.getMiniAppView(miniAppId: appInfo.id, hostAppMessageDelegate: messageInterface ?? self)
-                    self.miniAppStatus.setDownloadStatus(true, appId: appInfo.id, versionId: appInfo.version.versionId)
-                    completionHandler(.success(miniAppDisplayProtocol))
-                }
+                self.getMiniAppView(appInfo: appInfo, completionHandler: completionHandler, messageInterface: messageInterface)
             case .failure(let error):
                 completionHandler(.failure(error))
             }
+        }
+    }
+
+    func getMiniAppView(appInfo: MiniAppInfo, completionHandler: @escaping (Result<MiniAppDisplayProtocol, Error>) -> Void, messageInterface: MiniAppMessageProtocol? = nil) {
+        DispatchQueue.main.async {
+            let miniAppDisplayProtocol = self.displayer.getMiniAppView(miniAppId: appInfo.id, hostAppMessageDelegate: messageInterface ?? self)
+            self.miniAppStatus.setDownloadStatus(true, appId: appInfo.id, versionId: appInfo.version.versionId)
+            completionHandler(.success(miniAppDisplayProtocol))
         }
     }
 }

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -5,6 +5,7 @@ internal class RealMiniApp {
     var manifestDownloader: ManifestDownloader
     var displayer: Displayer
     var miniAppStatus: MiniAppStatus
+    let offlineErrorCodeList: [Int] = [NSURLErrorNotConnectedToInternet, NSURLErrorTimedOut]
 
     convenience init() {
         self.init(with: nil)
@@ -48,14 +49,7 @@ internal class RealMiniApp {
                 }
                 self.downloadMiniApp(appInfo: appInfo, completionHandler: completionHandler, messageInterface: messageInterface)
             case .failure(let error):
-                let createError = error as NSError
-                if Constants.offlineErrorCodeList.contains(createError.code) {
-                    if self.miniAppDownloader.getCachedMiniApp(appId: appInfo.id) == nil {
-                        return completionHandler(.failure(error))
-                    }
-                    self.getMiniAppView(appInfo: appInfo, completionHandler: completionHandler, messageInterface: messageInterface)
-                }
-                completionHandler(.failure(error))
+                self.handleError(appId: appInfo.id, versionId: appInfo.version.versionId, error: error, completionHandler: completionHandler, messageInterface: messageInterface)
         }}
     }
 
@@ -70,17 +64,32 @@ internal class RealMiniApp {
             case .success:
                 self.getMiniAppView(appInfo: appInfo, completionHandler: completionHandler, messageInterface: messageInterface)
             case .failure(let error):
-                completionHandler(.failure(error))
+                self.handleError(appId: appInfo.id, versionId: appInfo.version.versionId, error: error, completionHandler: completionHandler, messageInterface: messageInterface)
             }
         }
     }
 
     func getMiniAppView(appInfo: MiniAppInfo, completionHandler: @escaping (Result<MiniAppDisplayProtocol, Error>) -> Void, messageInterface: MiniAppMessageProtocol? = nil) {
         DispatchQueue.main.async {
-            let miniAppDisplayProtocol = self.displayer.getMiniAppView(miniAppId: appInfo.id, hostAppMessageDelegate: messageInterface ?? self)
+            let miniAppDisplayProtocol = self.displayer.getMiniAppView(miniAppId: appInfo.id, versionId: appInfo.version.versionId, hostAppMessageDelegate: messageInterface ?? self)
             self.miniAppStatus.setDownloadStatus(true, appId: appInfo.id, versionId: appInfo.version.versionId)
+            self.miniAppStatus.setCachedVersion(appInfo.version.versionId, for: appInfo.id)
             completionHandler(.success(miniAppDisplayProtocol))
         }
+    }
+
+    func handleError(appId: String, versionId: String, error: Error, completionHandler: @escaping (Result<MiniAppDisplayProtocol, Error>) -> Void, messageInterface: MiniAppMessageProtocol? = nil) {
+        let downloadError = error as NSError
+        if self.offlineErrorCodeList.contains(downloadError.code) {
+            guard let cachedVersion = miniAppDownloader.getCachedMiniAppVersion(appId: appId, versionId: versionId) else {
+                return completionHandler(.failure(downloadError))
+            }
+            DispatchQueue.main.async {
+                let miniAppDisplayProtocol = self.displayer.getMiniAppView(miniAppId: appId, versionId: cachedVersion, hostAppMessageDelegate: messageInterface ?? self)
+                completionHandler(.success(miniAppDisplayProtocol))
+            }
+        }
+        return completionHandler(.failure(error))
     }
 }
 

--- a/MiniApp/Classes/Storage/MiniAppStatus.swift
+++ b/MiniApp/Classes/Storage/MiniAppStatus.swift
@@ -20,4 +20,12 @@ class MiniAppStatus {
     func isDownloaded(key: String) -> Bool {
         return defaults?.bool(forKey: key) ?? false
     }
+
+    func setCachedVersion(_ version: String, for key: String) {
+        defaults?.setValue(version, forKey: key)
+    }
+
+    func getCachedVersion(key: String) -> String {
+        return defaults?.string(forKey: key) ?? ""
+    }
 }

--- a/MiniApp/Classes/Utilities/Constants.swift
+++ b/MiniApp/Classes/Utilities/Constants.swift
@@ -4,5 +4,4 @@ struct Constants {
     static let javascriptInterfaceName = "MiniAppiOS"
     static let javascriptSuccessCallback = "MiniAppBridge.execSuccessCallback"
     static let javascriptErrorCallback = "MiniAppBridge.execErrorCallback"
-    static let offlineErrorCodeList: [Int] = [NSURLErrorNotConnectedToInternet, NSURLErrorTimedOut]
 }

--- a/MiniApp/Classes/Utilities/Constants.swift
+++ b/MiniApp/Classes/Utilities/Constants.swift
@@ -4,4 +4,5 @@ struct Constants {
     static let javascriptInterfaceName = "MiniAppiOS"
     static let javascriptSuccessCallback = "MiniAppBridge.execSuccessCallback"
     static let javascriptErrorCallback = "MiniAppBridge.execErrorCallback"
+    static let offlineErrorCodeList: [Int] = [NSURLErrorNotConnectedToInternet, NSURLErrorTimedOut]
 }

--- a/Tests/Unit/DisplayerTests.swift
+++ b/Tests/Unit/DisplayerTests.swift
@@ -10,7 +10,7 @@ class DisplayerTests: QuickSpec {
                 it("will return MiniAppView") {
                     let miniAppDisplayer = Displayer()
                     let mockMessageInterface = MockMessageInterface()
-                    let miniAppView = miniAppDisplayer.getMiniAppView(miniAppId: "miniappid-testing", hostAppMessageDelegate: mockMessageInterface)
+                    let miniAppView = miniAppDisplayer.getMiniAppView(miniAppId: "miniappid-testing", versionId: "version-id", hostAppMessageDelegate: mockMessageInterface)
                     expect(miniAppView).toEventually(beAnInstanceOf(RealMiniAppView.self))
                 }
             }

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -97,6 +97,10 @@ class MockManifestDownloader: ManifestDownloader {
 
     override func fetchManifest(apiClient: MiniAppClient, appId: String, versionId: String, completionHandler: @escaping (Result<ManifestResponse, Error>) -> Void) {
 
+        if error != nil {
+            return completionHandler(.failure(error ?? NSError(domain: "Test", code: 0, userInfo: nil)))
+        }
+
         apiClient.getAppManifest(appId: appId, versionId: versionId) { (result) in
             switch result {
             case .success(let responseData):

--- a/Tests/Unit/MiniAppDownloaderTests.swift
+++ b/Tests/Unit/MiniAppDownloaderTests.swift
@@ -170,7 +170,7 @@ class MiniAppDownloaderTests: QuickSpec {
               }
             }
             context("when isMiniAppDownloadedAlready is called with valid appId and versionId - which is  downloaded") {
-              it("will download all files and mini app path is created") {
+              it("will return true") {
                     let appId = "Apple"
                     let versionId = "Mac"
                     let mockAPIClient = MockAPIClient()

--- a/Tests/Unit/MiniAppDownloaderTests.swift
+++ b/Tests/Unit/MiniAppDownloaderTests.swift
@@ -22,7 +22,36 @@ class MiniAppDownloaderTests: QuickSpec {
                     downloader.download(appId: "Apple", versionId: "Mac") { (_) in }
                     let miniAppDirectory = FileManager.getMiniAppVersionDirectory(with: "Apple", and: "Mac")
                     var isDir: ObjCBool = true
-                    expect(FileManager.default.fileExists(atPath: miniAppDirectory.path, isDirectory: &isDir)).toEventually(equal(true), timeout: 50)
+                    expect(FileManager.default.fileExists(atPath: miniAppDirectory.path, isDirectory: &isDir)).toEventually(equal(true), timeout: 10)
+                }
+            }
+            context("when downloader fails due to no network availability") {
+                it("will return last version of mini app that is already download") {
+                    let mockAPIClient = MockAPIClient()
+                    let mockManifestDownloader = MockManifestDownloader()
+                    let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
+                    let responseString = """
+                      {
+                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                      }
+                    """
+                    mockAPIClient.data = responseString.data(using: .utf8)
+                    downloader.download(appId: "Apple", versionId: "Mac") { (_) in }
+                    mockManifestDownloader.error = NSError(domain: "URLErrorDomain", code: -1009, userInfo: nil)
+                    mockAPIClient.data = nil
+                    mockManifestDownloader.data = nil
+                    var miniAppCachedURL: URL?
+
+                    downloader.download(appId: "Apple", versionId: "Mac1") { (result) in
+                        switch result {
+                        case .success(let url):
+                            miniAppCachedURL = url
+                        case .failure:
+                            break
+                        }
+                    }
+                    let miniAppDirectory = FileManager.getMiniAppVersionDirectory(with: "Apple", and: "Mac")
+                    expect(miniAppCachedURL?.path).toEventually(equal(miniAppDirectory.path), timeout: 10)
                 }
             }
         }
@@ -47,8 +76,8 @@ class MiniAppDownloaderTests: QuickSpec {
                     let oldMiniAppDirectory = FileManager.getMiniAppVersionDirectory(with: "testApp", and: "1")
                     var isDir: ObjCBool = true
 
-                    expect(FileManager.default.fileExists(atPath: miniAppDirectory.path, isDirectory: &isDir)).toEventually(equal(true), timeout: 50)
-                    expect(FileManager.default.fileExists(atPath: oldMiniAppDirectory.path, isDirectory: &isDir)).toEventually(equal(false), timeout: 50)
+                    expect(FileManager.default.fileExists(atPath: miniAppDirectory.path, isDirectory: &isDir)).toEventually(equal(true), timeout: 10)
+                    expect(FileManager.default.fileExists(atPath: oldMiniAppDirectory.path, isDirectory: &isDir)).toEventually(equal(false), timeout: 10)
                 }
             }
         }
@@ -76,7 +105,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     }
                     let miniAppPath = FileManager.getMiniAppVersionDirectory(with: "Apple", and: "Mac")
                     let expectedPath = miniAppPath.appendingPathComponent("HelloWorld.txt")
-                    expect(FileManager.default.fileExists(atPath: expectedPath.path)).toEventually(equal(true), timeout: 50)
+                    expect(FileManager.default.fileExists(atPath: expectedPath.path)).toEventually(equal(true), timeout: 10)
                 }
             }
         }
@@ -124,6 +153,40 @@ class MiniAppDownloaderTests: QuickSpec {
                         }
                     }
                     expect(testError?.code).toEventually(equal(0), timeout: 10)
+                }
+            }
+        }
+
+        describe("mini app downloader") {
+            context("when isMiniAppDownloadedAlready is called with valid appId and versionId - which is not downloaded") {
+              it("will return false") {
+                miniAppStatus.setDownloadStatus(true, for: "mini-app/testing")
+                let mockAPIClient = MockAPIClient()
+                let mockManifestDownloader = MockManifestDownloader()
+                let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
+                let isDownloaded = downloader.isMiniAppDownloadedAlready(appId: "mini-app", versionId: "testing")
+                expect(isDownloaded).toEventually(equal(false))
+                UserDefaults().removePersistentDomain(forName: "com.rakuten.tech.mobile.miniapp")
+              }
+            }
+            context("when isMiniAppDownloadedAlready is called with valid appId and versionId - which is  downloaded") {
+              it("will download all files and mini app path is created") {
+                    let appId = "Apple"
+                    let versionId = "Mac"
+                    let mockAPIClient = MockAPIClient()
+                    let mockManifestDownloader = MockManifestDownloader()
+                    let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
+                    let responseString = """
+                    {
+                      "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                    }
+                    """
+                    mockAPIClient.data = responseString.data(using: .utf8)
+                    downloader.download(appId: appId, versionId: versionId) { (_) in }
+                    miniAppStatus.setDownloadStatus(true, appId: appId, versionId: versionId)
+                    let isDownloaded = downloader.isMiniAppDownloadedAlready(appId: appId, versionId: versionId)
+                    expect(isDownloaded).toEventually(equal(true))
+                    UserDefaults().removePersistentDomain(forName: "com.rakuten.tech.mobile.miniapp")
                 }
             }
         }

--- a/Tests/Unit/MiniAppDownloaderTests.swift
+++ b/Tests/Unit/MiniAppDownloaderTests.swift
@@ -158,18 +158,18 @@ class MiniAppDownloaderTests: QuickSpec {
         }
 
         describe("mini app downloader") {
-            context("when isMiniAppDownloadedAlready is called with valid appId and versionId - which is not downloaded") {
+            context("when isMiniAppAlreadyDownloaded is called with valid appId and versionId - which is not downloaded") {
               it("will return false") {
                 miniAppStatus.setDownloadStatus(true, for: "mini-app/testing")
                 let mockAPIClient = MockAPIClient()
                 let mockManifestDownloader = MockManifestDownloader()
                 let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
-                let isDownloaded = downloader.isMiniAppDownloadedAlready(appId: "mini-app", versionId: "testing")
+                let isDownloaded = downloader.isMiniAppAlreadyDownloaded(appId: "mini-app", versionId: "testing")
                 expect(isDownloaded).toEventually(equal(false))
                 UserDefaults().removePersistentDomain(forName: "com.rakuten.tech.mobile.miniapp")
               }
             }
-            context("when isMiniAppDownloadedAlready is called with valid appId and versionId - which is  downloaded") {
+            context("when isMiniAppAlreadyDownloaded is called with valid appId and versionId - which is  downloaded") {
               it("will return true") {
                     let appId = "Apple"
                     let versionId = "Mac"
@@ -184,7 +184,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     mockAPIClient.data = responseString.data(using: .utf8)
                     downloader.download(appId: appId, versionId: versionId) { (_) in }
                     miniAppStatus.setDownloadStatus(true, appId: appId, versionId: versionId)
-                    let isDownloaded = downloader.isMiniAppDownloadedAlready(appId: appId, versionId: versionId)
+                    let isDownloaded = downloader.isMiniAppAlreadyDownloaded(appId: appId, versionId: versionId)
                     expect(isDownloaded).toEventually(equal(true))
                     UserDefaults().removePersistentDomain(forName: "com.rakuten.tech.mobile.miniapp")
                 }

--- a/Tests/Unit/RealMiniAppViewTests.swift
+++ b/Tests/Unit/RealMiniAppViewTests.swift
@@ -9,14 +9,14 @@ class RealMiniAppViewTests: QuickSpec {
             let mockMessageInterface = MockMessageInterface()
             context("when initialized with valid parameters") {
                 it("will return MiniAppView object") {
-                    let miniAppView = RealMiniAppView(miniAppId: "miniappid-testing", hostAppMessageDelegate: mockMessageInterface)
+                    let miniAppView = RealMiniAppView(miniAppId: "miniappid-testing", versionId: "version-id", hostAppMessageDelegate: mockMessageInterface)
 
                     expect(miniAppView).toEventually(beAnInstanceOf(RealMiniAppView.self))
                 }
             }
             context("when getMiniAppView is called") {
                 it("will return object of UIView type") {
-                    let miniAppView = RealMiniAppView(miniAppId: "miniappid-testing", hostAppMessageDelegate: mockMessageInterface)
+                    let miniAppView = RealMiniAppView(miniAppId: "miniappid-testing", versionId: "version-id", hostAppMessageDelegate: mockMessageInterface)
                     expect(miniAppView.getMiniAppView()).toEventually(beAKindOf(UIView.self))
                 }
             }

--- a/Tests/Unit/URLSchemeHandlerTests.swift
+++ b/Tests/Unit/URLSchemeHandlerTests.swift
@@ -5,7 +5,7 @@ import Nimble
 class URLSchemeHandlerTests: QuickSpec {
     override func spec() {
         describe("URL Scheme Handler") {
-            let schemeHandler = URLSchemeHandler()
+            let schemeHandler = URLSchemeHandler(versionId: "version-id")
             var components = URLComponents(string: "mscheme.MINI_APP_ID")
             context("when getAppIdFromScheme is called with scheme") {
                 it("will return mini app id") {
@@ -41,16 +41,9 @@ class URLSchemeHandlerTests: QuickSpec {
                     mockAPIClient.data = responseString.data(using: .utf8)
                     downloader.download(appId: "Apple", versionId: "Mac") { (_) in }
                     let fileURL = schemeHandler.getFilePath(relativeFilePath: "HelloWorld.txt", appId: "Apple")
-                    var expectedFilePath = FileManager.getMiniAppVersionDirectory(with: "Apple", and: "Mac")
+                    var expectedFilePath = FileManager.getMiniAppVersionDirectory(with: "Apple", and: "version-id")
                     expectedFilePath.appendPathComponent("HelloWorld.txt")
                     expect(fileURL).toEventually(equal(expectedFilePath))
-                }
-            }
-            context("when getFilePath is called with path that doesn't exists") {
-                it("will return root file path") {
-                    components?.path = ""
-                    let fileURL = schemeHandler.getFilePath(relativeFilePath: "/images/home.png", appId: "MINI_APP_ID")
-                    expect(fileURL).toEventually(beNil())
                 }
             }
         }


### PR DESCRIPTION
# Description
Added a missing flow for Offline load support. Offline mode will work as follows,
* Get the mini-app info from the host app and check if it is the latest version available. If there is a latest version available, download it else download the version which is passed from the host-app
* If the device is offline and it will lookup for the mini-app info is downloaded already and if it is the same will be returned.
* If the mini-info is not downloaded already, it will return the previously cached version of the mini-app.


## Links
[MINI-1019](https://jira.rakuten-it.com/jira/browse/MINI-1019)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
