### PR TITLE
fix: Update URL file parser to look for map-published-v2

### DIFF
--- a/MiniApp/Classes/Utilities/UrlParser.swift
+++ b/MiniApp/Classes/Utilities/UrlParser.swift
@@ -3,7 +3,7 @@
  */
 struct UrlParser {
 
-    static let separatorKey: String = "map-published/"
+    static let separatorKey: String = "map-published-v2/"
     static let dropLimit = 2
 
     /**

--- a/Tests/Unit/MiniAppDownloaderTests.swift
+++ b/Tests/Unit/MiniAppDownloaderTests.swift
@@ -25,7 +25,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -42,7 +42,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -72,7 +72,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -98,8 +98,8 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt",
-                                    "https://google.com/map-published/min-abc/ver-abc/Testing.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt",
+                                    "https://google.com/map-published-v2/min-abc/ver-abc/Testing.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -126,7 +126,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["http://example.com/map-published/min-abc/ver-abc/Mac/Testing.txt"]
+                        "manifest": ["http://example.com/map-published-v2/min-abc/ver-abc/Mac/Testing.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -181,7 +181,7 @@ class MiniAppDownloaderTests: QuickSpec {
                 it("will return true") {
                     let responseString = """
                     {
-                      "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                      "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                     }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -210,7 +210,7 @@ class MiniAppDownloaderTests: QuickSpec {
                 it("will return version that is already downloaded") {
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -233,7 +233,7 @@ class MiniAppDownloaderTests: QuickSpec {
 
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -260,7 +260,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/SmallMA.zip"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/SmallMA.zip"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -279,7 +279,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/SmallMAerror.zip"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/SmallMAerror.zip"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -154,7 +154,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -194,7 +194,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -228,7 +228,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -261,7 +261,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     realMiniApp.miniAppInfoFetcher = mockMiniAppInfoFetcher
@@ -297,7 +297,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)

--- a/Tests/Unit/URLSchemeHandlerTests.swift
+++ b/Tests/Unit/URLSchemeHandlerTests.swift
@@ -35,7 +35,7 @@ class URLSchemeHandlerTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)

--- a/Tests/Unit/UrlParserTests.swift
+++ b/Tests/Unit/UrlParserTests.swift
@@ -7,7 +7,7 @@ class UrlParserTests: QuickSpec {
         describe("Url parser") {
             context("when getFileStoragePath is called with valid url") {
                 it("will returns the path to store the file") {
-                    let urlString = "https://www.example.com/map-published/mini-abc/ver-abc/img/onload/file.png"
+                    let urlString = "https://www.example.com/map-published-v2/mini-abc/ver-abc/img/onload/file.png"
                     let path = UrlParser.getFileStoragePath(from: urlString)
                     expect(path).toEventually(equal("img/onload/file.png"))
                 }
@@ -21,7 +21,7 @@ class UrlParserTests: QuickSpec {
             }
             context("when getFileStoragePath is called with invalid url") {
                 it("will return nil") {
-                    let urlString = "https://www.example.com/map-published/"
+                    let urlString = "https://www.example.com/map-published-v2/"
                     let path = UrlParser.getFileStoragePath(from: urlString)
                     expect(path).toEventually(beNil())
                 }


### PR DESCRIPTION
# Description
Changes in the format of the URL returned in the manifest have broken our SDK because we depend on the map-published key in the URL. However, this key changed to map-published-v2.

Actually, it would be better to not depend on this key anymore. The reason it was depended upon is because we needed to know what path to save files into, however now that we have a ZIP file we no longer need that information. But this is just a quick fix for now to update the key.

## Links
MINI-1407

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
