### PR TITLE
docs: Add development guide and other doc improvements

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,54 @@
+# SDK Developer Guide
+
+This guide targets Developers of this SDK. It explains how to build the project and how the CI setup works.
+
+## <a name="sample-app" /> How to Build the Sample App
+
+First, you must setup some environment variables which are required by the project.
+
+```
+RMAAPIEndpoint=https://www.example.com
+RASApplicationIdentifier=test-app-id
+RASProjectSubscriptionKey=test-subscription-key
+```
+
+Next, run `pod install` from the root directory, open `MiniApp.xcworkspace`, and you should be able to successfully build the Sample App.
+
+*Note:* You must define the environment variables before installing the pods because there is a post install script which sets up the project with your environment variables.
+
+## How to Test with the Sample App
+
+We currently don't provide an API for public use, so you must provide your own API.
+
+## Continuous Integration and Deployment
+
+[TravisCI](https://travis-ci.org/github/rakutentech/ios-miniapp) is used for building and testing the project for every pull request. It is also used for publishing the SDK and Sample App.
+
+Note that two Sample App builds are created on merge to master or during a release: 
+- One build for the iOS Simulator (built on TravisCI and then uploaded to App Center - App Center does not support building for the Simulator target)
+- One build for iOS Devices (built directly on App Center in order to keep the certificate and provisioning profile secret)
+
+### Merge to Master
+
+The following describes the steps that CI performs when a branch is merged to master.
+
+1. We trigger a build on TravisCI by merging a branch to master.
+2. CI builds SDK and Sample App, run tests, linting, etc.
+3. CI creates a ZIP file for the iOS Simulator (Staging) build of the Sample App.
+    - Publishes build to App Center "Testers" group.
+4. App Center builds the Sample App for iOS Devices (Staging).
+    - Publishes build to App Center "Testers" group.
+
+### Release
+
+The following describes the steps that CI performs when releasing a new version of the SDK.
+
+1. We trigger a build on TravisCI by pushing a Git tag to the repo in the format `vX.X.X`.
+2. CI builds SDK and Sample App, run tests, linting, etc.
+3. CI publishes the SDK to [Cocoapods](https://cocoapods.org/pods/MiniApp).
+4. CI creates ZIP file for the iOS Simulator (Production) build of the Sample App.
+    - Publishes build to App Center "Production" group.
+5. CI merges the `master` branch into the `prod` branch.
+    - This triggers a build on App Center for the iOS Device (Production) build of the Sample App.
+    - Publishes build to App Center "Production" group.
+6. CI publishes documentation to [Github Pages site](https://rakutentech.github.io/ios-miniapp).

--- a/MiniApp.podspec
+++ b/MiniApp.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/rakutentech/ios-miniapp"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.source       = { :git => "https://github.com/rakutentech/ios-miniapp.git", :tag => 'v' + s.version.to_s }
+  s.documentation_url = "https://rakutentech.github.io/ios-miniapp/"
 
   s.ios.deployment_target = '11.0'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
+[![Cocoapods](https://img.shields.io/cocoapods/v/MiniApp)](https://cocoapods.org/pods/MiniApp)
 [![Build Status](https://travis-ci.org/rakutentech/ios-miniapp.svg?branch=master)](https://travis-ci.org/rakutentech/ios-miniapp)
 [![codecov](https://codecov.io/gh/rakutentech/ios-miniapp/branch/master/graph/badge.svg)](https://codecov.io/gh/rakutentech/ios-miniapp)
-[![ios](https://cocoapod-badges.herokuapp.com/p/MiniApp/badge.png)](https://cocoapods.org/pods/MiniApp)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
@@ -9,40 +9,33 @@
 This open-source library allows you to integrate Mini App ecosystem into your iOS applications. 
 Mini App SDK also facilitates communication between a mini app and the host app via a message bridge.
 
+For instructions on implementing in an iOS application, see the [User Guide](https://rakutentech.github.io/ios-miniapp/).
+
 ## Features
 
 - Load MiniApp list
 - Load MiniApp metadata
 - Create a MiniApp view
-- Facilitate comm between host app and mini app
+- Facilitate communcation between host app and mini app
 
-All the MiniApp files downloaded by the MiniApp iOS library are cached locally
+All the MiniApp files downloaded by the MiniApp iOS library are cached locally.
 
-# Getting started
+## Getting started
 
-* [Requirements](USERGUIDE.md#requirements)
-* [Documentation](https://rakutentech.github.io/ios-miniapp/)
-* [Installation](#installation)
-* [Configuration](USERGUIDE.md#configuration)
-* [Usage](USERGUIDE.md#usage)
-* [Sample App](USERGUIDE.md#example)
+* [Requirements](https://rakutentech.github.io/ios-miniapp#requirements)
+* [Documentation & User Guide](https://rakutentech.github.io/ios-miniapp/)
+* [Installation](https://rakutentech.github.io/ios-miniapp#installation)
+* [Configuration](https://rakutentech.github.io/ios-miniapp#configuration)
+* [Usage](https://rakutentech.github.io/ios-miniapp#usage)
 
-# Installation
+## Contributing
 
-Mini App SDK is available through [CocoaPods](https://cocoapods.org). To install it, simply add the following line to your Podfile:
+See the [SDK Developer Guide](https://github.com/rakutentech/ios-miniapp/blob/master/DEV.md) and the [Contribution guide](https://github.com/rakutentech/ios-miniapp/blob/master/.github/CONTRIBUTING.md).
 
-```ruby
-pod 'MiniApp'
-```
-
-How to implement on your iOS application? Check the [USERGUIDE](USERGUIDE.md)
-
-# License
+## License
 
 See the *[LICENSE](https://github.com/rakutentech/ios-miniapp/blob/master/LICENSE)* file for more info.
 
-<div id="change-log"></div>
-
-# Changelog
+## Changelog
 
 See the full [CHANGELOG](https://github.com/rakutentech/ios-miniapp/blob/master/CHANGELOG.md).

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -19,7 +19,6 @@ All the MiniApp files downloaded by the MiniApp iOS library are cached locally
 * [Installation](#installation)
 * [Configuration](#configuration)
 * [Usage](#usage)
-* [Sample App](#example)
 
 ## Requirements
 
@@ -182,20 +181,6 @@ MiniApp.shared(with: Config.getCurrent(), navigationSettings: navConfig).info(mi
 ...
 }
 ```
-
-<div id="sample-app"></div>
-
-## Example
-
-To run the example project, clone the repo, and run `pod install` from the Example directory first.
-
-### Custom parameters
-
-In order to load your MiniApp, you will have to use your own Host App ID and your Subscription key. These can either be set in project configuration plist (`RASApplicationIdentifier`, `RASProjectSubscriptionKey`) or by taping the top right configuration icon in the example application. Also we don't currently host a public API, so you will need to provide your own Base URL for API requests by setting it in project configuration plist (`RMAAPIEndpoint`)
-
-## License
-
-See the *[LICENSE](https://github.com/rakutentech/ios-miniapp/blob/master/LICENSE)* file for more info.
 
 <div id="change-log"></div>
 


### PR DESCRIPTION
# Description
The main 'README.md' is used by CocoaPods as the project readme (here https://cocoapods.org/pods/MiniApp), so it will look strange to have instructions which target SDK developers. So instead, I have separated those into 'DEV.md'. This also contains information about the CI setup.

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
