### PR TITLE
fix: (demo app) Callback was not triggered after requesting location permission

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -34,6 +34,7 @@ class ViewController: UIViewController {
         self.navigationItem.hidesBackButton = true
         refreshControl.addTarget(self, action: #selector(refreshList(_:)), for: .valueChanged)
         self.tableView.refreshControl = refreshControl
+        locationManager.delegate = self
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
# Description
Set CLLocationManager.delegate to self in ViewController. The CLLocationManagerDelegate was defined, but it wasn't getting set to the locationManager, so this means that the callback wasn't called after the user accepted/denied the location permission

## Links
MINI-1558

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
