### PR TITLE
Fix for Custom permissions override at Keychain

### DIFF
--- a/MiniApp/Classes/Storage/MiniAppKeyChain.swift
+++ b/MiniApp/Classes/Storage/MiniAppKeyChain.swift
@@ -16,7 +16,7 @@ import Foundation
             return getDefaultSupportedPermissions()
         }
         guard let permissionList = allKeys[keyId] as [MASDKCustomPermissionModel]? else {
-            return setDefaultPermissionsInKeyChain(forMiniApp: keyId)
+            return setDefaultPermissionsInKeyChain(forMiniApp: keyId, allKeys: allKeys)
         }
         return permissionList
     }
@@ -43,10 +43,12 @@ import Foundation
         }
     }
 
-    internal func setDefaultPermissionsInKeyChain(forMiniApp id: String) -> [MASDKCustomPermissionModel] {
-        let defaultList = getDefaultSupportedPermissions()
-        write(keys: [id: defaultList])
-        return defaultList
+    internal func setDefaultPermissionsInKeyChain(forMiniApp id: String, allKeys: KeysDictionary) -> [MASDKCustomPermissionModel] {
+        var allKeysDict = allKeys
+        let defaultPermissionList = getDefaultSupportedPermissions()
+        allKeysDict[id] = defaultPermissionList
+        write(keys: allKeysDict)
+        return defaultPermissionList
     }
 
     private func getDefaultSupportedPermissions() -> [MASDKCustomPermissionModel] {

--- a/Tests/Unit/MiniAppKeyChainTests.swift
+++ b/Tests/Unit/MiniAppKeyChainTests.swift
@@ -9,7 +9,7 @@ class MiniAppKeyChainTests: QuickSpec {
             context("when setDefaultPermissionsInKeyChain is called") {
                 it("will return all default permissions with denied status ") {
                     let miniAppKeyStore = MiniAppKeyChain()
-                    let allPermissions = miniAppKeyStore.setDefaultPermissionsInKeyChain(forMiniApp: "123")
+                    let allPermissions = miniAppKeyStore.setDefaultPermissionsInKeyChain(forMiniApp: "123", allKeys: ["Test": []])
                     expect(allPermissions.count).toEventually(equal(MiniAppCustomPermissionType.allCases.count))
                 }
             }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -187,11 +187,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         name: "", body: "{\"action\":\"requestCustomPermissions\",\"param\":{\"permissions\":" + "[{\"name\":\"rakuten.miniapp.user.USER_NAME\"," +
                             "\"description\":\"Description for the requesting permission\"}]},\"id\":\"1.0343410245054572\"}" as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                    guard let errorMessage = decodeMiniAppError(message: callbackProtocol.errorMessage) else {
-                        fail()
-                        return
-                    }
-                    expect(errorMessage.title).toEventually(equal(.invalidCustomPermissionRequest), timeout: 10)
+                    expect(callbackProtocol.errorMessage).toEventually(equal("Restricted") || equal("NotDetermined"))
                  }
             }
             context("when MiniAppScriptMessageHandler receives valid custom permissions command but there is an error in the host app delegate") {


### PR DESCRIPTION
# Description
There seem to a glitch in the flow where the custom permissions for different miniapp is overridden when no keys were found. This PR will fix it.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
