### PR TITLE
Feat/share msg content

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,10 +3,10 @@ ignore:
    - "Tests"
    - "Example"
 coverage:
-   range: 70..100
-   round: down
-   precision: 2
-   status:
-      project:
-         default:
-            threshold: 5%
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 5%
+        base: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,4 @@ coverage:
   range: 70..100
   round: down
   precision: 2
+  threshold: 5%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,4 +6,8 @@ coverage:
   range: 70..100
   round: down
   precision: 2
-  threshold: 5%
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,3 +2,8 @@ ignore:
    - "Pods"
    - "Tests"
    - "Example"
+
+coverage:
+  range: 70..100
+  round: down
+  precision: 2

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,6 @@ ignore:
    - "Pods"
    - "Tests"
    - "Example"
-
 coverage:
   range: 70..100
   round: down

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,11 +3,10 @@ ignore:
    - "Tests"
    - "Example"
 coverage:
-  range: 70..100
-  round: down
-  precision: 2
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 5%
+   range: 70..100
+   round: down
+   precision: 2
+   status:
+      project:
+         default:
+            threshold: 5%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,10 @@ ignore:
    - "Tests"
    - "Example"
 coverage:
+   range: 70..100
+   round: down
+   precision: 2
+coverage:
   status:
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,14 +3,16 @@ ignore:
    - "Tests"
    - "Example"
 coverage:
-   range: 70..100
-   round: down
-   precision: 2
-coverage:
   status:
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        base: auto 
+        if_ci_failed: error
     project:
       default:
-        # basic
-        target: auto
+        target: 70%
         threshold: 5%
         base: auto
+        if_ci_failed: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG
 
-### 2.x.0 (2020-08-DD)
+### 2.x.0 (2020-10-DD)
 
 **SDK**
 
@@ -9,11 +9,17 @@
 - **Feature:** Added support in Javascript bridge for requesting Custom permission.
 `requestCustomPermissions(permissionType)`
 
-- **Feature:** Added requestCustomPermissions function to MiniAppMessageProtocol. This function requests the host app to implement and return the list of Custom permissions that User responds with allow/deny option.[See here](USERGUIDE.md#request-custom-permission)
+- **Feature:** Added `requestCustomPermissions` function to MiniAppMessageProtocol. This function requests the host app to implement and return the list of Custom permissions that User responds with allow/deny option.[See here](USERGUIDE.md#request-custom-permission)
+
+- **Feature:** Added support for Javascript bridge interface for sharing message string from Mini app.
+`shareInfo(info)`
+
+- **Feature:** Added `shareContent(info:completionHandler:)` function to MiniAppMessageProtocol. Host app can make use of this function to display the Sharing feature/Controller [See here](USERGUIDE.md#share-mini-app-content)
 
 **Sample App**
 
 - **Feature:** Added example for showing list of Custom permissions (on request from Mini app) and response back to Mini app.
+- **Feature:** Added sample implementation for Sharing the message from Mini app
 
 ### 2.1.0 (2020-09-03)
 

--- a/Example/ViewController+MiniAppMessageProtocol.swift
+++ b/Example/ViewController+MiniAppMessageProtocol.swift
@@ -47,6 +47,15 @@ extension ViewController: MiniAppMessageProtocol, CLLocationManagerDelegate {
         return deviceId
     }
 
+    func shareContent(info: MiniAppShareContent, completionHandler: @escaping (Result<String, Error>) -> Void) {
+        let activityController = UIActivityViewController(activityItems: [info.messageContent],
+                                                          applicationActivities: nil)
+        UIViewController.topViewController()?.present(activityController,
+                                                      animated: true,
+                                                      completion: nil)
+        completionHandler(.success("SUCCESS"))
+    }
+
     func displayLocationDisabledAlert() {
         let alert = UIAlertController(title: "Location Services are disabled", message: "Please enable Location Services in your Settings", preferredStyle: .alert)
         let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)

--- a/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -3,6 +3,7 @@ enum MiniAppJSActionCommand: String {
     case getCurrentPosition
     case requestPermission
     case requestCustomPermissions
+    case shareInfo
 }
 
 enum JavaScriptExecResult: String {

--- a/MiniApp/Classes/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -98,6 +98,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     func getCurrentPosition(callbackId: String) {
+
         self.executeJavaScriptCallback(responseStatus: .onSuccess, messageId: callbackId, response: getLocationInfo())
     }
 

--- a/MiniApp/Classes/Models/MiniAppJavaScriptMessageInfo.swift
+++ b/MiniApp/Classes/Models/MiniAppJavaScriptMessageInfo.swift
@@ -8,10 +8,15 @@ struct RequestParameters: Decodable {
     let permission: String?
     let permissions: [MiniAppCustomPermissionsRequest]?
     let locationOptions: LocationOptions?
+    let shareInfo: ShareInfoParameters?
 }
 
 struct LocationOptions: Decodable {
     let enableHighAccuracy: Bool?
+}
+
+struct ShareInfoParameters: Decodable {
+    var content: String
 }
 
 struct MiniAppCustomPermissionsRequest: Decodable {

--- a/MiniApp/Classes/Protocols/MiniAppMessageModels.swift
+++ b/MiniApp/Classes/Protocols/MiniAppMessageModels.swift
@@ -1,0 +1,3 @@
+public struct MiniAppShareContent {
+    public var messageContent: String
+}

--- a/MiniApp/Classes/Protocols/MiniAppMessageProtocol.swift
+++ b/MiniApp/Classes/Protocols/MiniAppMessageProtocol.swift
@@ -14,4 +14,7 @@ public protocol MiniAppMessageProtocol: class {
     /// Interface that should be implemented in the host app to handle the Custom Permissions.
     /// Host app is responsible to display the alert/dialog with the [MiniAppCustomPermissionType] permissions to the user and the result should be returned back to the SDK
     func requestCustomPermissions(permissions: [MASDKCustomPermissionModel], completionHandler: @escaping (Result<[MASDKCustomPermissionModel], Error>) -> Void)
+
+    /// Interface that is used to share the content from the Mini app
+    func shareContent(info: MiniAppShareContent, completionHandler: @escaping (Result<String, Error>) -> Void)
 }

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -158,4 +158,9 @@ extension RealMiniApp: MiniAppMessageProtocol {
     func getUniqueId() -> String {
         return "MiniAppMessageBridge has not been implemented by the host app"
     }
+
+    func shareContent(info: MiniAppShareContent, completionHandler: @escaping (Result<String, Error>) -> Void) {
+        let error: NSError = NSError.init(domain: "MiniAppMessageBridge has not been implemented by the host app", code: 0, userInfo: nil)
+        completionHandler(.failure(error as Error))
+    }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MiniApp (2.0.0):
+  - MiniApp (2.1.0):
     - RSDKUtils (>= 1.1.0)
     - ZIPFoundation
   - Nimble (8.1.2)
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  MiniApp: 81660bb845ce64d275f9f45ccd7742d6fb45617a
+  MiniApp: d172716d191725d3acbf7a37150a8161a4ab529f
   Nimble: 3864815b4703c7ebffba875973c70e854489fbae
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   RSDKUtils: 9940b99fa0494181b8ee2cfa2ac742bb0958b984

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -201,7 +201,6 @@ class MockFile {
 }
 
 class MockMessageInterface: MiniAppMessageProtocol {
-
     var mockUniqueId: Bool = false
     var locationAllowed: Bool = false
     var customPermissions: Bool = false
@@ -247,7 +246,7 @@ class MockMessageInterface: MiniAppMessageProtocol {
         if messageContentAllowed {
             completionHandler(.success("SUCCESS"))
         } else {
-            completionHandler(.failure(MiniAppPermissionResult.restricted))
+            completionHandler(.failure(NSError(domain: "ShareContentError", code: 0, userInfo: nil)))
         }
     }
 }

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -201,10 +201,12 @@ class MockFile {
 }
 
 class MockMessageInterface: MiniAppMessageProtocol {
+
     var mockUniqueId: Bool = false
     var locationAllowed: Bool = false
     var customPermissions: Bool = false
     var permissionError: Error?
+    var messageContentAllowed: Bool = false
 
     func getUniqueId() -> String {
         if mockUniqueId {
@@ -237,6 +239,14 @@ class MockMessageInterface: MiniAppMessageProtocol {
                 completionHandler(.failure(permissionError!))
                 return
             }
+            completionHandler(.failure(MiniAppPermissionResult.restricted))
+        }
+    }
+
+    func shareContent(info: MiniAppShareContent, completionHandler: @escaping (Result<String, Error>) -> Void) {
+        if messageContentAllowed {
+            completionHandler(.success("SUCCESS"))
+        } else {
             completionHandler(.failure(MiniAppPermissionResult.restricted))
         }
     }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -204,6 +204,27 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     expect(decodedObj.permissions[0].isGranted).toEventually(equal("DENIED"), timeout: 10)
                  }
             }
+            context("when MiniAppScriptMessageHandler receives valid share info message") {
+                 it("will return SUCCESS after host app displays UIActivityController") {
+                     let scriptMessageHandler = MiniAppScriptMessageHandler(delegate: callbackProtocol, hostAppMessageDelegate: mockMessageInterface, miniAppId: "Test")
+                    mockMessageInterface.messageContentAllowed = true
+                    let mockMessage = MockWKScriptMessage(
+                        name: "", body: "{\"action\":\"shareInfo\",\"param\":{\"shareInfo\":{\"content\":\"Test Message\"}},\"id\":\"1.033890137027198\"}"as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(callbackProtocol.response).toEventuallyNot(beNil(), timeout: 10)
+                    expect(callbackProtocol.response).toEventually(equal("SUCCESS"), timeout: 10)
+                 }
+            }
+            context("when MiniAppScriptMessageHandler receives valid share info message but there is an error in host app delegate") {
+                 it("will return Error") {
+                     let scriptMessageHandler = MiniAppScriptMessageHandler(delegate: callbackProtocol, hostAppMessageDelegate: mockMessageInterface, miniAppId: "Test")
+                    mockMessageInterface.messageContentAllowed = false
+                    let mockMessage = MockWKScriptMessage(
+                        name: "", body: "{\"action\":\"shareInfo\",\"param\":{\"shareInfo\":{\"content\":\"Test Message\"}},\"id\":\"1.033890137027198\"}"as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(callbackProtocol.errorMessage).toEventually(contain("ShareContentError"), timeout: 10)
+                 }
+            }
         }
     }
 }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -36,7 +36,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             context("when handleBridgeMessage receive invalid action, valid id") {
                 it("will return error") {
                     let scriptMessageHandler = MiniAppScriptMessageHandler(delegate: callbackProtocol, hostAppMessageDelegate: mockMessageInterface, miniAppId: "Test")
-                    let requestParam = RequestParameters(permission: "location", permissions: nil, locationOptions: nil)
+                    let requestParam = RequestParameters(permission: "location", permissions: nil, locationOptions: nil, shareInfo: ShareInfoParameters(content: ""))
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "", id: "123", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
                     expect(callbackProtocol.errorMessage).toEventually(equal(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue))
@@ -45,7 +45,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             context("when handleBridgeMessage receive valid action, invalid id") {
                 it("will return error") {
                     let scriptMessageHandler = MiniAppScriptMessageHandler(delegate: callbackProtocol, hostAppMessageDelegate: mockMessageInterface, miniAppId: "Test")
-                    let requestParam = RequestParameters(permission: "location", permissions: nil, locationOptions: nil)
+                    let requestParam = RequestParameters(permission: "location", permissions: nil, locationOptions: nil, shareInfo: ShareInfoParameters(content: ""))
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
                     expect(callbackProtocol.errorMessage).toEventually(equal(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue))

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -4,6 +4,7 @@ import Nimble
 
 // swiftlint:disable function_body_length
 // swiftlint:disable cyclomatic_complexity
+// swiftlint:disable type_body_length
 class RealMiniAppTests: QuickSpec {
 
     override func spec() {
@@ -353,6 +354,21 @@ class RealMiniAppTests: QuickSpec {
                 it("will return error") {
                     var testError: NSError?
                     realMiniApp.requestCustomPermissions(permissions: []) { (result) in
+                        switch result {
+                        case .success:
+                        break
+                        case .failure(let error):
+                            testError = error as NSError
+                        }
+                    }
+                    expect(testError?.code).toEventually(equal(0))
+                }
+            }
+            context("when RealMiniApp class has no message interface method object and when requestCustomPermissions is called") {
+                it("will return error") {
+                    var testError: NSError?
+                    realMiniApp.shareContent(info: MiniAppShareContent(
+                        messageContent: "Testing the sample app")) { (result) in
                         switch result {
                         case .success:
                         break

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -196,6 +196,7 @@ extension ViewController: MiniAppMessageProtocol {
             }
     
 ```
+<div id="share-mini-app-content"></div>
 
 ##### Share Mini app content
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -197,6 +197,20 @@ extension ViewController: MiniAppMessageProtocol {
     
 ```
 
+##### Share Mini app content
+
+```swift
+extension ViewController: MiniAppMessageProtocol {
+    func shareContent(info: MiniAppShareContent,
+            completionHandler: @escaping (
+                Result<String, Error>) -> Void) {
+        let activityController = UIActivityViewController(activityItems: [info.messageContent], applicationActivities: nil)
+        present(activityController, animated: true, completion: nil)
+        completionHandler(.success("SUCCESS"))
+    }
+}
+```
+
 <div id="navigation"></div>
 
 ### Add a web navigation interface to the MiniApp view


### PR DESCRIPTION
# Description
* SDK: Share message from Miniapp through host app via public interface. Host app will use UIActitivityController to display the sharing options.
* Sample app: Implementation to show the sharing feature
* Updated submodule as well.
* Updated codecov

## Links
[MINI-1595](https://jira.rakuten-it.com/jira/browse/MINI-1595)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
