### PR TITLE
JS Bridge updates for Custom Permission support

### DIFF
--- a/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptPermissionManager.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptPermissionManager.swift
@@ -48,7 +48,7 @@ extension MiniAppScriptMessageHandler {
                 cachedUnknownCustomPermissionRequest.append(
                     MiniAppCustomPermissionsListResponse(
                         name: $0.name ?? "UNKNOWN_REQUEST",
-                        isGranted:
+                        status:
                         MiniAppCustomPermissionGrantedStatus.permissionNotAvailable.rawValue))
                 return
             }
@@ -76,7 +76,7 @@ extension MiniAppScriptMessageHandler {
     func sendCachedSuccessResponse(result: [MASDKCustomPermissionModel], callbackId: String) {
         var permissionListResponse = [MiniAppCustomPermissionsListResponse]()
         result.forEach {
-            permissionListResponse.append(MiniAppCustomPermissionsListResponse(name: $0.permissionName.rawValue, isGranted: $0.isPermissionGranted.rawValue))
+            permissionListResponse.append(MiniAppCustomPermissionsListResponse(name: $0.permissionName.rawValue, status: $0.isPermissionGranted.rawValue))
         }
         cachedUnknownCustomPermissionRequest.forEach {
             permissionListResponse.append($0)
@@ -102,10 +102,10 @@ extension MiniAppScriptMessageHandler {
     func retrieveAllPermissionsMiniAppRequested(result: [MASDKCustomPermissionModel]) -> [MiniAppCustomPermissionsListResponse] {
         var permissionListResponse = [MiniAppCustomPermissionsListResponse]()
         result.forEach {
-            permissionListResponse.append(MiniAppCustomPermissionsListResponse(name: $0.permissionName.rawValue, isGranted: $0.isPermissionGranted.rawValue))
+            permissionListResponse.append(MiniAppCustomPermissionsListResponse(name: $0.permissionName.rawValue, status: $0.isPermissionGranted.rawValue))
         }
         userAlreadyRespondedRequestList.forEach {
-            permissionListResponse.append(MiniAppCustomPermissionsListResponse(name: $0.permissionName.rawValue, isGranted: $0.isPermissionGranted.rawValue))
+            permissionListResponse.append(MiniAppCustomPermissionsListResponse(name: $0.permissionName.rawValue, status: $0.isPermissionGranted.rawValue))
         }
         cachedUnknownCustomPermissionRequest.forEach {
             permissionListResponse.append($0)
@@ -114,7 +114,7 @@ extension MiniAppScriptMessageHandler {
     }
 
     /// For a given [MiniAppCustomPermissionsListResponse], this method will use JSONEncoder to encode the [objects] to JSON string
-    /// - Parameter result: [MiniAppCustomPermissionsListResponse] that contains the name and isGranted status of every permission that will be sent back to the Mini app as JSON
+    /// - Parameter result: [MiniAppCustomPermissionsListResponse] that contains the name and status of every permission that will be sent back to the Mini app as JSON
     /// - Returns: JSON Response string
     func getJsonSuccessResponse(result: [MiniAppCustomPermissionsListResponse]) -> String {
         let responseObject = MiniAppCustomPermissionsResponse(permissions: result)

--- a/MiniApp/Classes/Models/MiniAppJavaScriptMessageInfo.swift
+++ b/MiniApp/Classes/Models/MiniAppJavaScriptMessageInfo.swift
@@ -29,5 +29,5 @@ struct MiniAppCustomPermissionsResponse: Codable {
 }
 
 struct MiniAppCustomPermissionsListResponse: Codable {
-    let name, isGranted: String
+    let name, status: String
 }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -119,7 +119,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                  }
             }
             context("when MiniAppScriptMessageHandler receives valid custom permissions command") {
-                 it("will return response with name and isGranted status for all permission that is requested") {
+                 it("will return response with name and status for all permission that is requested") {
                      let scriptMessageHandler = MiniAppScriptMessageHandler(delegate: callbackProtocol, hostAppMessageDelegate: mockMessageInterface, miniAppId: "Test")
                     mockMessageInterface.customPermissions = true
                     let mockMessage = MockWKScriptMessage(
@@ -132,7 +132,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     }
                     let decodedObj = try JSONDecoder().decode(MiniAppCustomPermissionsResponse.self, from: responseData)
                     expect(decodedObj.permissions[0].name).toEventually(equal("rakuten.miniapp.user.USER_NAME"), timeout: 10)
-                    expect(decodedObj.permissions[0].isGranted).toEventually(equal("ALLOWED"), timeout: 10)
+                    expect(decodedObj.permissions[0].status).toEventually(equal("ALLOWED"), timeout: 10)
                  }
             }
             context("when MiniAppScriptMessageHandler receives valid custom permissions command but invalid permission object title instead of name") {


### PR DESCRIPTION
# Description
- build: Update JS Bridge submodule to latest version
  - This fixes an issue where the response was being returned to the user as as string rather than an object
- refactor: (Custom permissions) Rename 'isGranted' param to 'status'
  - This param doesn't represent a boolean - it represents a status of allowed, denied, or not available so it should be named accordingly.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
