### PR TITLE
Fix for the memory leak

### DIFF
--- a/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
+++ b/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
@@ -14,7 +14,7 @@ class MiniAppExternalWebViewController: UIViewController {
     public class func presentModally(url: URL, externalLinkResponseHandler: MiniAppNavigationResponseHandler?) {
         let window: UIWindow?
         if #available(iOS 13, *) {
-            window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+            window = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
         } else {
             window = UIApplication.shared.keyWindow
         }
@@ -36,6 +36,7 @@ class MiniAppExternalWebViewController: UIViewController {
         config.preferences.javaScriptEnabled = true
         config.allowsInlineMediaPlayback = true
         config.allowsPictureInPictureMediaPlayback = true
+        config.mediaTypesRequiringUserActionForPlayback = []
 
         self.webView = WKWebView(frame: self.view.frame, configuration: config)
         self.webView.allowsBackForwardNavigationGestures = true
@@ -52,6 +53,11 @@ class MiniAppExternalWebViewController: UIViewController {
         if let url = currentURL {
             self.webView.load(URLRequest(url: url))
         }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(true)
+        self.miniAppExternalUrlLoader = nil
     }
 }
 

--- a/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
+++ b/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
@@ -56,7 +56,7 @@ class MiniAppExternalWebViewController: UIViewController {
     }
 
     override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(true)
+        super.viewDidDisappear(animated)
         self.miniAppExternalUrlLoader = nil
     }
 }

--- a/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
+++ b/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
@@ -54,11 +54,6 @@ class MiniAppExternalWebViewController: UIViewController {
             self.webView.load(URLRequest(url: url))
         }
     }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        self.miniAppExternalUrlLoader = nil
-    }
 }
 
 extension MiniAppExternalWebViewController: WKNavigationDelegate {

--- a/MiniApp/Classes/Utilities/MiniAppExternalUrlLoader.swift
+++ b/MiniApp/Classes/Utilities/MiniAppExternalUrlLoader.swift
@@ -1,7 +1,7 @@
 import WebKit
 
 public class MiniAppExternalUrlLoader {
-    public var currentWebViewController: UIViewController?
+    public weak var currentWebViewController: UIViewController?
     public var currentResponseHandler: MiniAppNavigationResponseHandler?
 
     /// This class supports the scenario that external loader redirects url that are only supported in mini app view,


### PR DESCRIPTION
# Description
Fixing this memory leak will make the MiniApp object released when it is dismissed. This will fix the video-playing-in-background fix.

## Links
[MINI-1936](https://jira.rakuten-it.com/jira/browse/MINI-1936)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
