### PR TITLE
Orientation lock support for Mini app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## CHANGELOG
 
+### 2.x.x (IN-PROGRESS)
+
+**SDK**
+
+- **Feature:** Added support for Orientation lock, that enables the mini app to lock `portrait` or `landscape` orientation for the mini-app. [Please check here](USERGUIDE.md#orientation-lock)
+
+**Sample App**
+
+- **Feature:** Added implementation for orientation lock
+---
+
 ### 2.3.0 (2020-10-22)
 
 **SDK**

--- a/Example/Controllers/DisplayController.swift
+++ b/Example/Controllers/DisplayController.swift
@@ -1,11 +1,14 @@
 import UIKit
 import MiniApp
+import AVKit
 
 class DisplayController: UIViewController {
 
     @IBOutlet var backButton: UIBarButtonItem!
     @IBOutlet var forwardButton: UIBarButtonItem!
     weak var navBarDelegate: MiniAppNavigationBarDelegate?
+    weak var miniAppDisplayDelegate: MiniAppDisplayProtocol?
+    static var miniAppSupportedOrientation: UIInterfaceOrientationMask = []
 
     override func viewDidAppear(_ animated: Bool) {
         guard let controller = self.navigationController as? DisplayNavigationController, let info = controller.miniAppInfo, let miniAppDisplay = controller.miniAppDisplay else {
@@ -13,11 +16,12 @@ class DisplayController: UIViewController {
         }
 
         self.title = info.displayName
-
+        self.miniAppDisplayDelegate = miniAppDisplay
         let view = miniAppDisplay.getMiniAppView()
         view.frame = self.view.bounds
         self.navBarDelegate = miniAppDisplay as? MiniAppNavigationBarDelegate
         self.view.addSubview(view)
+        self.navigationController?.delegate = self
     }
 
     @IBAction func done(_ sender: UIBarButtonItem) {
@@ -35,5 +39,22 @@ class DisplayController: UIViewController {
         default:
             break
         }
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        DisplayController.miniAppSupportedOrientation = self.miniAppDisplayDelegate?.getSupportedOrientation() ?? .all
+        return DisplayController.miniAppSupportedOrientation
+    }
+}
+
+extension DisplayController: UINavigationControllerDelegate {
+    public func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        return navigationController.topViewController?.supportedInterfaceOrientations ?? .all
+    }
+}
+
+extension AVPlayerViewController {
+    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return DisplayController.miniAppSupportedOrientation
     }
 }

--- a/Example/Controllers/Storyboards/Base.lproj/Main.storyboard
+++ b/Example/Controllers/Storyboards/Base.lproj/Main.storyboard
@@ -624,7 +624,7 @@
         <!--Mini App Sample-->
         <scene sceneID="yHS-0v-Pch">
             <objects>
-                <viewController id="BQV-uy-8GQ" customClass="ViewController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="BQV-uy-8GQ" customClass="ViewController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="XCF-cL-5kF"/>
                         <viewControllerLayoutGuide type="bottom" id="tdn-rl-TH3"/>
@@ -752,7 +752,7 @@
         <!--Display Controller-->
         <scene sceneID="poG-Jp-R00">
             <objects>
-                <viewController id="EFj-rP-o8F" customClass="DisplayController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="EFj-rP-o8F" customClass="DisplayController" customModule="MiniApp_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="uts-jG-JDj"/>
                         <viewControllerLayoutGuide type="bottom" id="2Js-EV-iRO"/>

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -44,7 +44,9 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
 </dict>

--- a/MiniApp/Classes/Display/RealMiniAppView.swift
+++ b/MiniApp/Classes/Display/RealMiniAppView.swift
@@ -9,6 +9,7 @@ internal class RealMiniAppView: UIView {
     internal var webViewBottomConstraintWithNavBar: NSLayoutConstraint?
     internal var navBarVisibility: MiniAppNavigationVisibility
     internal var isNavBarCustom = false
+    internal var supportedMiniAppOrientation: UIInterfaceOrientationMask
 
     internal weak var hostAppMessageDelegate: MiniAppMessageDelegate?
     internal weak var navigationDelegate: MiniAppNavigationDelegate?
@@ -27,6 +28,7 @@ internal class RealMiniAppView: UIView {
         webView = MiniAppWebView(miniAppId: miniAppId, versionId: versionId)
         self.hostAppMessageDelegate = hostAppMessageDelegate
         navBarVisibility = displayNavBar
+        self.supportedMiniAppOrientation = []
         super.init(frame: .zero)
         webView.navigationDelegate = self
 
@@ -106,7 +108,7 @@ internal class RealMiniAppView: UIView {
         if let scheme = requestURL.scheme {
             let schemeType = MiniAppSupportedSchemes(rawValue: scheme)
             switch schemeType {
-            case .about: // mainly implemented to manage buil-in alert dialogs
+            case .about: // mainly implemented to manage built-in alert dialogs
                 return decisionHandler(.allow)
             case .tel:
                 UIApplication.shared.open(requestURL, options: [:], completionHandler: nil)
@@ -129,6 +131,15 @@ internal class RealMiniAppView: UIView {
 }
 
 extension RealMiniAppView: MiniAppDisplayProtocol {
+
+    func getSupportedOrientation() -> UIInterfaceOrientationMask {
+        if self.supportedMiniAppOrientation.isEmpty {
+            return .all
+        } else {
+            return self.supportedMiniAppOrientation
+        }
+    }
+
     public func getMiniAppView() -> UIView {
         return self
     }
@@ -141,6 +152,10 @@ extension RealMiniAppView: MiniAppCallbackDelegate {
 
     func didReceiveScriptMessageError(messageId: String, errorMessage: String) {
         self.webView.evaluateJavaScript(Constants.javascriptErrorCallback + "('\(messageId)'," + "'\(errorMessage)')")
+    }
+
+    func didOrientationChanged(orientation: UIInterfaceOrientationMask) {
+        self.supportedMiniAppOrientation = orientation
     }
 }
 

--- a/MiniApp/Classes/Display/RealMiniAppView.swift
+++ b/MiniApp/Classes/Display/RealMiniAppView.swift
@@ -134,7 +134,11 @@ extension RealMiniAppView: MiniAppDisplayProtocol {
 
     func getSupportedOrientation() -> UIInterfaceOrientationMask {
         if self.supportedMiniAppOrientation.isEmpty {
-            return .all
+            if UIDevice.current.orientation.isPortrait {
+                return .portrait
+            } else {
+                return .landscape
+            }
         } else {
             return self.supportedMiniAppOrientation
         }

--- a/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -6,6 +6,7 @@ enum MiniAppJSActionCommand: String {
     case shareInfo
     case getUserName
     case getProfilePhoto
+    case setScreenOrientation
 }
 
 enum JavaScriptExecResult: String {
@@ -52,6 +53,23 @@ public enum MiniAppCustomPermissionGrantedStatus: String, Codable {
         return true
         default:
         return false
+        }
+    }
+}
+
+enum MiniAppInterfaceOrientation: String, Codable {
+    case lockPortrait = "rakuten.miniapp.screen.LOCK_PORTRAIT"
+    case lockLandscape = "rakuten.miniapp.screen.LOCK_LANDSCAPE"
+    case lockRelease = "rakuten.miniapp.screen.LOCK_RELEASE"
+
+    public var orientation: UIInterfaceOrientationMask {
+        switch self {
+        case .lockPortrait:
+            return .portrait
+        case .lockLandscape:
+            return .landscape
+        case .lockRelease:
+            return .all
         }
     }
 }

--- a/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -69,7 +69,7 @@ enum MiniAppInterfaceOrientation: String, Codable {
         case .lockLandscape:
             return .landscape
         case .lockRelease:
-            return .all
+            return []
         }
     }
 }

--- a/MiniApp/Classes/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -187,12 +187,12 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
 
     func setScreenOrientation(requestParam: RequestParameters?, callbackId: String) {
         guard let requestParamValue = requestParam?.action else {
-            executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: MiniAppJavaScriptError.invalidPermissionType.rawValue)
+            executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.unexpectedMessageFormat))
             return
         }
         if !requestParamValue.isEmpty {
             guard let info = MiniAppInterfaceOrientation(rawValue: requestParamValue) else {
-                self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.valueIsEmpty))
+                self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.unexpectedMessageFormat))
                 return
             }
             delegate?.didOrientationChanged(orientation: info.orientation)

--- a/MiniApp/Classes/Models/MiniAppJavaScriptMessageInfo.swift
+++ b/MiniApp/Classes/Models/MiniAppJavaScriptMessageInfo.swift
@@ -5,6 +5,7 @@ struct MiniAppJavaScriptMessageInfo: Decodable {
 }
 
 struct RequestParameters: Decodable {
+    let action: String?
     let permission: String?
     let permissions: [MiniAppCustomPermissionsRequest]?
     let locationOptions: LocationOptions?

--- a/MiniApp/Classes/Protocols/MiniAppDisplayProtocol.swift
+++ b/MiniApp/Classes/Protocols/MiniAppDisplayProtocol.swift
@@ -3,8 +3,13 @@
  to communicate with the Mini App display module
  */
 
-public protocol MiniAppDisplayProtocol {
+public typealias MiniAppDisplayProtocol = MiniAppDisplayDelegate
+
+public protocol MiniAppDisplayDelegate: class {
 
     /// Get the view of the Mini app
     func getMiniAppView() -> UIView
+
+    /// Get the supported orientations for the mini app
+    func getSupportedOrientation() -> UIInterfaceOrientationMask
 }

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -318,7 +318,6 @@ class MockMiniAppCallbackProtocol: MiniAppCallbackDelegate {
     }
 
     func didOrientationChanged(orientation: UIInterfaceOrientationMask) {
-        
     }
 }
 

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -316,6 +316,10 @@ class MockMiniAppCallbackProtocol: MiniAppCallbackDelegate {
         self.messageId = messageId
         self.errorMessage = errorMessage
     }
+
+    func didOrientationChanged(orientation: UIInterfaceOrientationMask) {
+        
+    }
 }
 
 class MockNavigationView: UIView, MiniAppNavigationDelegate {

--- a/Tests/Unit/MiniAppJavascriptEnumerationTests.swift
+++ b/Tests/Unit/MiniAppJavascriptEnumerationTests.swift
@@ -57,7 +57,7 @@ class MiniAppJavascriptEnumerationTests: QuickSpec {
                 it("will return all UIInterfaceOrientationMask") {
                     let miniAppInterfaceOrientation = MiniAppInterfaceOrientation(rawValue: "rakuten.miniapp.screen.LOCK_RELEASE")
                     expect(miniAppInterfaceOrientation).toEventually(equal(MiniAppInterfaceOrientation.lockRelease))
-                    expect(miniAppInterfaceOrientation?.orientation).toEventually(equal(UIInterfaceOrientationMask.all))
+                    expect(miniAppInterfaceOrientation?.orientation).toEventually(equal([]))
                 }
             }
         }

--- a/Tests/Unit/MiniAppJavascriptEnumerationTests.swift
+++ b/Tests/Unit/MiniAppJavascriptEnumerationTests.swift
@@ -39,6 +39,27 @@ class MiniAppJavascriptEnumerationTests: QuickSpec {
                     expect(miniAppPermissionStatus?.boolValue).toEventually(equal(false))
                 }
             }
+            context("when MiniAppInterfaceOrientation is initialized with valid Portrait string ") {
+                it("will return portrait UIInterfaceOrientationMask") {
+                    let miniAppInterfaceOrientation = MiniAppInterfaceOrientation(rawValue: "rakuten.miniapp.screen.LOCK_PORTRAIT")
+                    expect(miniAppInterfaceOrientation).toEventually(equal(MiniAppInterfaceOrientation.lockPortrait))
+                    expect(miniAppInterfaceOrientation?.orientation).toEventually(equal(UIInterfaceOrientationMask.portrait))
+                }
+            }
+            context("when MiniAppInterfaceOrientation is initialized with valid Landscape string ") {
+                it("will return landscape UIInterfaceOrientationMask") {
+                    let miniAppInterfaceOrientation = MiniAppInterfaceOrientation(rawValue: "rakuten.miniapp.screen.LOCK_LANDSCAPE")
+                    expect(miniAppInterfaceOrientation).toEventually(equal(MiniAppInterfaceOrientation.lockLandscape))
+                    expect(miniAppInterfaceOrientation?.orientation).toEventually(equal(UIInterfaceOrientationMask.landscape))
+                }
+            }
+            context("when MiniAppInterfaceOrientation is initialized with valid LOCK_RELEASE string") {
+                it("will return all UIInterfaceOrientationMask") {
+                    let miniAppInterfaceOrientation = MiniAppInterfaceOrientation(rawValue: "rakuten.miniapp.screen.LOCK_RELEASE")
+                    expect(miniAppInterfaceOrientation).toEventually(equal(MiniAppInterfaceOrientation.lockRelease))
+                    expect(miniAppInterfaceOrientation?.orientation).toEventually(equal(UIInterfaceOrientationMask.all))
+                }
+            }
         }
     }
 }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -341,6 +341,36 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userDenied.rawValue), timeout: .seconds(10))
                 }
             }
+            context("when MiniAppScriptMessageHandler receives invalid orientation lock command") {
+                 it("will return error") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        miniAppId: "Test"
+                    )
+                    mockMessageInterface.messageContentAllowed = false
+                    let mockMessage = MockWKScriptMessage(
+                        name: "", body: "{\"action\":\"setScreenOrientation\",\"param\":{\"action\":null},\"id\":\"5.733550049709592\"}" as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue), timeout: .seconds(10))
+                 }
+            }
+            context("when MiniAppScriptMessageHandler receives no orientation lock command") {
+                 it("will return error") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        miniAppId: "Test"
+                    )
+                    mockMessageInterface.messageContentAllowed = false
+                    let mockMessage = MockWKScriptMessage(
+                        name: "", body: "{\"action\":\"setScreenOrientation\",\"param\":{\"action\":\"rakuten.miniapp.screen.LOCK_LANDSCAPE_RIGHT\"},\"id\":\"5.733550049709592\"}" as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue), timeout: .seconds(10))
+                 }
+            }
         }
     }
 }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -50,7 +50,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         miniAppId: "Test"
                     )
-                    let requestParam = RequestParameters(permission: "location", permissions: nil, locationOptions: nil, shareInfo: ShareInfoParameters(content: ""))
+                    let requestParam = RequestParameters(action: "", permission: "location", permissions: nil, locationOptions: nil, shareInfo: ShareInfoParameters(content: ""))
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "", id: "123", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
                     expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue))
@@ -63,7 +63,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         miniAppId: "Test"
                     )
-                    let requestParam = RequestParameters(permission: "location", permissions: nil, locationOptions: nil, shareInfo: ShareInfoParameters(content: ""))
+                    let requestParam = RequestParameters(action: "", permission: "location", permissions: nil, locationOptions: nil, shareInfo: ShareInfoParameters(content: ""))
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
                     expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue))

--- a/Tests/Unit/RealMiniAppViewTests.swift
+++ b/Tests/Unit/RealMiniAppViewTests.swift
@@ -30,7 +30,7 @@ class RealMiniAppViewTests: QuickSpec {
             context("when getSupportedOrientation is called and no supported orientation is set by the mini app") {
                 it("will return UIInterfaceOrientationMask.all") {
                     miniAppView.supportedMiniAppOrientation = []
-                    expect(miniAppView.getSupportedOrientation()).toEventually(equal(UIInterfaceOrientationMask.all))
+                    expect(miniAppView.getSupportedOrientation()).toEventually(equal(UIInterfaceOrientationMask.portrait))
                 }
             }
             context("when getSupportedOrientation is called and supported orientation is set by the mini app as portrait") {

--- a/Tests/Unit/RealMiniAppViewTests.swift
+++ b/Tests/Unit/RealMiniAppViewTests.swift
@@ -27,6 +27,18 @@ class RealMiniAppViewTests: QuickSpec {
                     expect(miniAppView.getMiniAppView()).toEventually(beAKindOf(UIView.self))
                 }
             }
+            context("when getSupportedOrientation is called and no supported orientation is set by the mini app") {
+                it("will return UIInterfaceOrientationMask.all") {
+                    miniAppView.supportedMiniAppOrientation = []
+                    expect(miniAppView.getSupportedOrientation()).toEventually(equal(UIInterfaceOrientationMask.all))
+                }
+            }
+            context("when getSupportedOrientation is called and supported orientation is set by the mini app as portrait") {
+                it("will return UIInterfaceOrientationMask.portrait") {
+                    miniAppView.supportedMiniAppOrientation = UIInterfaceOrientationMask.portrait
+                    expect(miniAppView.getSupportedOrientation()).toEventually(equal(UIInterfaceOrientationMask.portrait))
+                }
+            }
             context("when host app info is specified in plist") {
                 it("will add custom string in User agent") {
                     let miniAppView = RealMiniAppView(

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -72,6 +72,7 @@ Config.userDefaults?.set("MY_CUSTOM_ID", forKey: Config.Key.subscriptionKey.rawV
 * [Custom Permissions](#custom-permissions)
 * [List Downloaded Mini apps](#list-downloaded-mini-apps)
 * [Retrieve User Profile details](#user-profile-details)
+* [Orientation Lock](#orientation-lock)
 
 <div id="runtime-conf"></div>
 
@@ -339,6 +340,55 @@ extension ViewController: MiniAppMessageDelegate {
     }
 }
 ```
+
+<div id="orientation-lock"></div>
+
+### Orientation Lock
+---
+Mini-app can request the SDK to lock the orientation using the JS SDK interfaces and the locked orientation can be retrieved using the following interface,
+
+1. Overriding `supportedInterfaceOrientations` in your ViewController
+
+    ```swift
+    static var miniAppSupportedOrientation: UIInterfaceOrientationMask = []
+
+    extension DisplayController {
+        override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+            DisplayController.miniAppSupportedOrientation = self.miniAppDisplayDelegate?.getSupportedOrientation() ?? .all
+            return DisplayController.miniAppSupportedOrientation
+        }
+    }
+    ```
+    NOTE: `self.miniAppDisplayDelegate` is an instance of `MiniAppDisplayProtocol` which can be retrieved while [creating mini-app](#create-mini-app).
+
+    The above code will help you to override the orientation for a given Viewcontroller (in which the Mini app view is displayed)
+
+2. Overriding `navigationControllerSupportedInterfaceOrientations`
+
+    If you have used UINavigationController, then you need to add the following code to enable the orientation lock,
+
+    ```swift
+    extension DisplayController: UINavigationControllerDelegate {
+        public func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+            return navigationController.topViewController?.supportedInterfaceOrientations ?? .all
+        }
+    }
+    ```
+    NOTE: You should also set the Navigation Controller delegate to self. ```self.navigationController?.delegate = self```
+
+3. Overriding `supportedInterfaceOrientations` for AVPlayerViewController
+
+    Orientation lock will not work for videos that is played inside Mini-app. To enable Orientation lock for the videos, please add the following code,
+
+    `import AVKit`
+
+    ```swift
+    extension AVPlayerViewController {
+        override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+                return DisplayController.miniAppSupportedOrientation
+            }
+        }
+    ```
 
 <div id="change-log"></div>
 


### PR DESCRIPTION
# Description
* Enable Orientation lock from the Mini app. Mini app can lock the orientation using the JS interfaces and the list of Orientation locks supported is,
    * Portrait
    * Landscape
* Updated sample app plist to support all orientations
* Updated sample app to enable Orientation Lock

## Links
[MINI-1751](https://jira.rakuten-it.com/jira/browse/MINI-1751)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
