### PR TITLE
feat: Return custom Error type to clients

### DIFF
--- a/Example/Assets/en.lproj/Localizable.strings
+++ b/Example/Assets/en.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 "error_title" = "Error";
 "error_list_message" = "Couldn't retrieve Miniapp list, please try again later";
 "error_single_message" = "Couldn't retrieve Miniapp info, please try again later";
+"error_no_published_version" = "No published versions for the provided Mini App ID.";
+"error_miniapp_id_not_found" = "No Mini App found for the provided Mini App ID.";
 "error_incorrect_appid_message" = "Incorrect Host app ID, please try again";
 "error_empty_appid_key_message" = "Host app ID cannot be empty, enter valid ID and try again";
 "error_incorrect_subscription_key_message" = "Incorrect subscription key, please try again";

--- a/Example/Assets/ja.lproj/Localizable.strings
+++ b/Example/Assets/ja.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 "error_title" = "Error";
 "error_list_message" = "Couldn't retrieve Miniapp list, please try again later";
 "error_single_message" = "Couldn't retrieve Miniapp info, please try again later";
+"error_no_published_version" = "No published versions for the provided Mini App ID.";
+"error_no_miniapp_found" = "No Mini App found for the provided Mini App ID.";
 "error_incorrect_appid_message" = "Incorrect Host app ID, please try again";
 "error_empty_appid_key_message" = "Host app ID cannot be empty, enter valid ID and try again";
 "error_incorrect_subscription_key_message" = "Incorrect subscription key, please try again";

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -34,9 +34,18 @@ extension ViewController: MiniAppNavigationDelegate {
                     self.currentMiniAppInfo = responseData
                     self.fetchMiniApp(for: responseData)
                 case .failure(let error):
+                    var message: String
+                    switch error {
+                    case .noPublishedVersion:
+                        message = NSLocalizedString("error_no_published_version", comment: "")
+                    case .miniAppNotFound:
+                        message = NSLocalizedString("error_miniapp_id_not_found", comment: "")
+                    default:
+                        message = NSLocalizedString("error_single_message", comment: "")
+                    }
                     print(error.localizedDescription)
                     self.dismissProgressIndicator {
-                        self.fetchMiniAppUsingId(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_single_message", comment: ""))
+                        self.fetchMiniAppUsingId(title: NSLocalizedString("error_title", comment: ""), message: message)
                     }
                 }
             }

--- a/MiniApp.xcodeproj/project.pbxproj
+++ b/MiniApp.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		38F73B4523D554FE00F2C1CE /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F73B4423D554FE00F2C1CE /* Helpers.swift */; };
 		38F73B4723D55CCB00F2C1CE /* MiniAppInfoFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F73B4623D55CCB00F2C1CE /* MiniAppInfoFetcherTests.swift */; };
 		38FC4653244628F600BE33E0 /* MiniAppScriptMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FC4652244628F600BE33E0 /* MiniAppScriptMessageHandlerTests.swift */; };
+		D07452312567B72A00B6E842 /* MASDKErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07452302567B72A00B6E842 /* MASDKErrorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -153,6 +154,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7FB3A4D3F3350D35AED2F43D /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		A78AF8E4D879DF8FC03A7E9F /* MiniApp.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = MiniApp.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		D07452302567B72A00B6E842 /* MASDKErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MASDKErrorTests.swift; sourceTree = "<group>"; };
 		D85784C7998D04CE64578236 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -312,6 +314,7 @@
 				382B960224F6DAC500DA8B7D /* MiniAppTests.swift */,
 				3879499724FCFB0900DB099B /* MiniAppKeyChainTests.swift */,
 				38F07E0B2535CC3600E32B32 /* MiniAppExternalUrlLoaderTests.swift */,
+				D07452302567B72A00B6E842 /* MASDKErrorTests.swift */,
 			);
 			path = Unit;
 			sourceTree = "<group>";
@@ -576,6 +579,7 @@
 				3871A8E124C54AD600BEC6CF /* MiniApp+StringTests.swift in Sources */,
 				38252B9923DFFBAB008A4E93 /* ListingAPITests.swift in Sources */,
 				189A69D12566479800DCE2B1 /* RealMiniAppTests+Permissions.swift in Sources */,
+				D07452312567B72A00B6E842 /* MASDKErrorTests.swift in Sources */,
 				3879499824FCFB0900DB099B /* MiniAppKeyChainTests.swift in Sources */,
 				38F73B4523D554FE00F2C1CE /* Helpers.swift in Sources */,
 				385C25CA23F2E8BA00D61206 /* DisplayerTests.swift in Sources */,

--- a/MiniApp/Classes/Extensions/MiniApp+NSError.swift
+++ b/MiniApp/Classes/Extensions/MiniApp+NSError.swift
@@ -1,11 +1,16 @@
 extension NSError {
 
     class func serverError(code: Int, message: String) -> NSError {
-        return NSError(
-            domain: "APIClient",
-            code: code,
-            userInfo: [NSLocalizedDescriptionKey: message]
-        )
+        switch code {
+        case 404:
+            return miniAppNotFound(message: message)
+        default:
+            return NSError(
+                domain: MiniAppSDKServerErrorDomain,
+                code: code,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
     }
 
     class func unknownServerError(httpResponse: HTTPURLResponse?) -> NSError {
@@ -17,33 +22,57 @@ extension NSError {
 
     class func invalidURLError() -> NSError {
         return NSError(
-            domain: "APIClient",
-            code: 0,
-            userInfo: [NSLocalizedDescriptionKey: "Invalid URL error"]
+            domain: MiniAppSDKErrorDomain,
+            code: MiniAppSDKErrorCode.invalidURLError.rawValue
         )
     }
 
     class func invalidAppId() -> NSError {
         return NSError(
-            domain: "APIClient",
-            code: 0,
-            userInfo: [NSLocalizedDescriptionKey: "Invalid AppID error"]
+            domain: MiniAppSDKErrorDomain,
+            code: MiniAppSDKErrorCode.invalidAppId.rawValue
         )
     }
 
     class func invalidResponseData() -> NSError {
         return NSError(
-            domain: "APIClient",
-            code: 0,
-            userInfo: [NSLocalizedDescriptionKey: "Invalid response received"]
+            domain: MiniAppSDKErrorDomain,
+            code: MiniAppSDKErrorCode.invalidResponseData.rawValue
         )
     }
 
     class func downloadingFailed() -> NSError {
         return NSError(
-            domain: "Downloader",
-            code: 0,
-            userInfo: [NSLocalizedDescriptionKey: "Downloading failed"]
+            domain: MiniAppSDKErrorDomain,
+            code: MiniAppSDKErrorCode.downloadingFailed.rawValue
         )
     }
+
+    class func noPublishedVersion() -> NSError {
+        return NSError(
+            domain: MiniAppSDKErrorDomain,
+            code: MiniAppSDKErrorCode.noPublishedVersion.rawValue
+        )
+    }
+
+    class func miniAppNotFound(message: String) -> NSError {
+        return NSError(
+            domain: MiniAppSDKErrorDomain,
+            code: MiniAppSDKErrorCode.miniAppNotFound.rawValue,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}
+
+// swiftlint:disable identifier_name
+var MiniAppSDKErrorDomain = "MiniAppSDKErrorDomain"
+var MiniAppSDKServerErrorDomain = "MiniAppSDKServerErrorDomain"
+
+enum MiniAppSDKErrorCode: Int {
+    case invalidURLError = 1,
+         invalidAppId,
+         invalidResponseData,
+         downloadingFailed,
+         noPublishedVersion,
+         miniAppNotFound
 }

--- a/MiniApp/Classes/MASDKError.swift
+++ b/MiniApp/Classes/MASDKError.swift
@@ -8,26 +8,26 @@ public enum MASDKError: Error {
     ///     - code: HTTP status code from the server
     ///     - message: error message returned by the server
     case serverError(code: Int, message: String)
-    
+
     /// The URL was invalid the SDK tried to connect to the server.
     /// Probably you provided an invalid URL value to the Base URL setting.
     case invalidURLError
-    
+
     /// The provided mini app ID was invalid. For example, the value cannot be an empty string.
     case invalidAppId
-    
+
     /// The server provided an invalid response body.
     case invalidResponseData
-    
+
     /// The mini app failed to download.
     case downloadingFailed
-    
+
     /// There are no published versions for the provided mini app ID.
     case noPublishedVersion
-    
+
     /// The provided mini app ID was not found on the server.
     case miniAppNotFound
-    
+
     /// An unexpected error occured.
     ///
     /// - Parameters:

--- a/MiniApp/Classes/MASDKError.swift
+++ b/MiniApp/Classes/MASDKError.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Mini App SDK Error which is passed from the main MiniApp APIs.
+public enum MASDKError: Error {
+    /// The server returned an error.
+    ///
+    /// - Parameters:
+    ///     - code: HTTP status code from the server
+    ///     - message: error message returned by the server
+    case serverError(code: Int, message: String)
+    
+    /// The URL was invalid the SDK tried to connect to the server.
+    /// Probably you provided an invalid URL value to the Base URL setting.
+    case invalidURLError
+    
+    /// The provided mini app ID was invalid. For example, the value cannot be an empty string.
+    case invalidAppId
+    
+    /// The server provided an invalid response body.
+    case invalidResponseData
+    
+    /// The mini app failed to download.
+    case downloadingFailed
+    
+    /// There are no published versions for the provided mini app ID.
+    case noPublishedVersion
+    
+    /// The provided mini app ID was not found on the server.
+    case miniAppNotFound
+    
+    /// An unexpected error occured.
+    ///
+    /// - Parameters:
+    ///     - domain: The domain from the original NSError.
+    ///     - message: The code from the original NSError.
+    ///     - description: The description from the original NSError
+    case unknownError(domain: String, code: Int, description: String)
+}
+
+extension MASDKError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .serverError(let code, let message):
+            return String(format: NSLocalizedString("error_server", comment: ""), code, message)
+        case .invalidURLError:
+            return NSLocalizedString("error_invalid_url", comment: "")
+        case .invalidAppId:
+            return NSLocalizedString("error_invalid_app_id", comment: "")
+        case .invalidResponseData:
+            return NSLocalizedString("error_invalid_response", comment: "")
+        case .downloadingFailed:
+            return NSLocalizedString("error_download_failed", comment: "")
+        case .noPublishedVersion:
+            return NSLocalizedString("error_no_published_version", comment: "")
+        case .miniAppNotFound:
+            return NSLocalizedString("error_miniapp_id_not_found", comment: "")
+        case .unknownError(let domain, let code, let description):
+            return String(format: NSLocalizedString("error_unknown", comment: ""), domain, code, description)
+        }
+    }
+}
+
+extension MASDKError {
+    static func fromError(error: Error) -> MASDKError {
+        let error = error as NSError
+        if error.domain == MiniAppSDKServerErrorDomain {
+            return MASDKError.serverError(code: error.code, message: error.userInfo.description)
+        }
+        if error.domain == MiniAppSDKErrorDomain {
+            switch MiniAppSDKErrorCode(rawValue: error.code) {
+            case .invalidURLError:
+                return MASDKError.invalidURLError
+            case .invalidAppId:
+                return MASDKError.invalidAppId
+            case .invalidResponseData:
+                return MASDKError.invalidResponseData
+            case .downloadingFailed:
+                return MASDKError.downloadingFailed
+            case .noPublishedVersion:
+                return MASDKError.noPublishedVersion
+            case .miniAppNotFound:
+                return MASDKError.miniAppNotFound
+            default:
+                break
+            }
+        }
+        return MASDKError.unknownError(domain: error.domain, code: error.code, description: error.localizedDescription)
+    }
+}

--- a/MiniApp/Classes/MiniAppInfoFetcher.swift
+++ b/MiniApp/Classes/MiniAppInfoFetcher.swift
@@ -31,6 +31,8 @@ internal class MiniAppInfoFetcher {
                     }
                     if let miniApp = miniAppInfo {
                         return completionHandler(.success(miniApp))
+                    } else {
+                        return completionHandler(.failure(NSError.noPublishedVersion()))
                     }
                 }
                 return completionHandler(.failure(NSError.invalidResponseData()))

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -31,12 +31,12 @@ internal class RealMiniApp {
         self.displayer.navConfig = navigationSettings
     }
 
-    func listMiniApp(completionHandler: @escaping (Result<[MiniAppInfo], Error>) -> Void) {
-        return miniAppInfoFetcher.fetchList(apiClient: self.miniAppClient, completionHandler: completionHandler)
+    func listMiniApp(completionHandler: @escaping (Result<[MiniAppInfo], MASDKError>) -> Void) {
+        return miniAppInfoFetcher.fetchList(apiClient: self.miniAppClient, completionHandler: self.createCompletionHandler(completionHandler: completionHandler))
     }
 
-    func getMiniApp(miniAppId: String, miniAppVersion: String? = nil, completionHandler: @escaping (Result<MiniAppInfo, Error>) -> Void) {
-        return miniAppInfoFetcher.getInfo(miniAppId: miniAppId, miniAppVersion: miniAppVersion, apiClient: self.miniAppClient, completionHandler: completionHandler)
+    func getMiniApp(miniAppId: String, miniAppVersion: String? = nil, completionHandler: @escaping (Result<MiniAppInfo, MASDKError>) -> Void) {
+        return miniAppInfoFetcher.getInfo(miniAppId: miniAppId, miniAppVersion: miniAppVersion, apiClient: self.miniAppClient, completionHandler: self.createCompletionHandler(completionHandler: completionHandler))
     }
 
     /// For a given Miniapp info object, this method will check whether the version id is the latest one with the platform.
@@ -63,16 +63,16 @@ internal class RealMiniApp {
             } }
     }
 
-    func createMiniApp(appId: String, version: String? = nil, completionHandler: @escaping (Result<MiniAppDisplayProtocol, Error>) -> Void, messageInterface: MiniAppMessageDelegate? = nil) {
+    func createMiniApp(appId: String, version: String? = nil, completionHandler: @escaping (Result<MiniAppDisplayProtocol, MASDKError>) -> Void, messageInterface: MiniAppMessageDelegate? = nil) {
         getMiniApp(miniAppId: appId, miniAppVersion: version) { (result) in
             switch result {
             case .success(let responseData):
                 self.miniAppStatus.saveMiniAppInfo(appInfo: responseData, key: responseData.id)
-                self.downloadMiniApp(appInfo: responseData, completionHandler: completionHandler, messageInterface: messageInterface)
+                self.downloadMiniApp(appInfo: responseData, completionHandler: self.createCompletionHandler(completionHandler: completionHandler), messageInterface: messageInterface)
             case .failure(let error):
                 self.handleMiniAppDownloadError(appId: appId,
                                  error: error,
-                                 completionHandler: completionHandler,
+                                 completionHandler: self.createCompletionHandler(completionHandler: completionHandler),
                                  messageInterface: messageInterface)
             } }
     }
@@ -155,6 +155,17 @@ internal class RealMiniApp {
 
     func getDownloadedListWithCustomPermissions() -> MASDKDownloadedListPermissionsPair {
         return self.miniAppStatus.getMiniAppsListWithCustomPermissionsInfo() ?? []
+    }
+
+    func createCompletionHandler<T>(completionHandler: @escaping (Result<T, MASDKError>) -> Void) -> (Result<T, Error>) -> Void {
+        return { (result) in
+            switch result {
+            case .success(let responseData):
+                completionHandler(.success(responseData))
+            case .failure(let error):
+                completionHandler(.failure(.fromError(error: error)))
+            }
+        }
     }
 }
 

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -36,7 +36,8 @@ internal class RealMiniApp {
     }
 
     func getMiniApp(miniAppId: String, miniAppVersion: String? = nil, completionHandler: @escaping (Result<MiniAppInfo, MASDKError>) -> Void) {
-        return miniAppInfoFetcher.getInfo(miniAppId: miniAppId, miniAppVersion: miniAppVersion, apiClient: self.miniAppClient, completionHandler: self.createCompletionHandler(completionHandler: completionHandler))
+        return miniAppInfoFetcher.getInfo(miniAppId: miniAppId, miniAppVersion: miniAppVersion, apiClient: self.miniAppClient,
+                                          completionHandler: self.createCompletionHandler(completionHandler: completionHandler))
     }
 
     /// For a given Miniapp info object, this method will check whether the version id is the latest one with the platform.

--- a/MiniApp/en.lproj/Localizable.strings
+++ b/MiniApp/en.lproj/Localizable.strings
@@ -13,6 +13,16 @@
 "error_invalid_miniapp_id" = "Invalid Miniapp ID";
 "error_no_miniapp_found" = "No Miniapp found, please contact your administrator";
 
+/* MASDKError messages */
+"error_server" = "Server returned an error. %@: %@";
+"error_invalid_url" = "URL is invalid.";
+"error_invalid_app_id" = "Provided Mini App ID is invalid.";
+"error_invalid_response" = "Invalid response received from server.";
+"error_download_failed" = "Failed to download the mini app.";
+"error_no_published_version" = "Server returned no published versions for the provided Mini App ID.";
+"error_miniapp_id_not_found" = "Server could not find the provided Mini App ID.";
+"error_unknown" = "Unknown error occured in %@ domain with error code %@: %@";
+
 "input_miniapp_title" = "Please enter Miniapp ID";
 "input_valid_miniapp_title" = "Please enter valid Miniapp ID and try again";
 

--- a/Tests/Unit/MASDKErrorTests.swift
+++ b/Tests/Unit/MASDKErrorTests.swift
@@ -1,0 +1,67 @@
+import Quick
+import Nimble
+@testable import MiniApp
+
+class MASDKErrorTests: QuickSpec {
+    override func spec() {
+        describe("MASDKError tests") {
+            context("when converting an NSError") {
+                it("will convert server error") {
+                    let originalError = NSError.serverError(code: 400, message: "test")
+                    let newError = MASDKError.serverError(code: 400, message: "test")
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+
+                it("will convert invalid URL error") {
+                    let originalError = NSError.invalidURLError()
+                    let newError = MASDKError.invalidURLError
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+
+                it("will convert invalid App ID error") {
+                    let originalError = NSError.invalidAppId()
+                    let newError = MASDKError.invalidAppId
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+
+                it("will convert invalid response data error") {
+                    let originalError = NSError.invalidResponseData()
+                    let newError = MASDKError.invalidResponseData
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+
+                it("will convert invalid downloading failed error") {
+                    let originalError = NSError.downloadingFailed()
+                    let newError = MASDKError.downloadingFailed
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+
+                it("will convert invalid no published version error") {
+                    let originalError = NSError.noPublishedVersion()
+                    let newError = MASDKError.noPublishedVersion
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+
+                it("will convert invalid no mini app not found error") {
+                    let originalError = NSError.miniAppNotFound(message: "")
+                    let newError = MASDKError.miniAppNotFound
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+
+                it("will convert return unknown error") {
+                    let originalError = NSError(domain: "test_domain", code: 1, userInfo: [self.description: "test_description"])
+                    let newError = MASDKError.unknownError(domain: "test_domain", code: 1, description: "test_description")
+
+                    expect(MASDKError.fromError(error: originalError).localizedDescription).to(equal(newError.localizedDescription))
+                }
+            }
+        }
+    }
+}

--- a/Tests/Unit/ManifestDownloaderTests.swift
+++ b/Tests/Unit/ManifestDownloaderTests.swift
@@ -54,7 +54,7 @@ class ManifestDownloaderTests: QuickSpec {
                             testError = error as NSError
                         }
                     })
-                    expect(testError?.code).toEventually(equal(0))
+                    expect(testError?.code).toEventually(equal(MiniAppSDKErrorCode.invalidResponseData.rawValue))
                 }
             }
             context("when request from server returns error") {

--- a/Tests/Unit/MiniApp+NSErrorTests.swift
+++ b/Tests/Unit/MiniApp+NSErrorTests.swift
@@ -21,13 +21,13 @@ class MiniAppNSErrorTests: QuickSpec {
                 }
             }
             context("throws unknown error") {
-                let urlResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 404, httpVersion: "1", headerFields: nil)
+                let urlResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 400, httpVersion: "1", headerFields: nil)
                 let error = NSError.unknownServerError(httpResponse: urlResponse)
                 it("will return server with NSError type") {
                     expect(error).toEventually(beAnInstanceOf(NSError.self), timeout: .seconds(2))
                 }
                 it("will return unknown error with code") {
-                    expect(error.code).toEventually(equal(404), timeout: .seconds(2))
+                    expect(error.code).toEventually(equal(400), timeout: .seconds(2))
                 }
                 it("will return unknown error with message") {
                     expect(error.localizedDescription).toEventually(equal("Unknown server error occurred"), timeout: .seconds(2))
@@ -43,10 +43,7 @@ class MiniAppNSErrorTests: QuickSpec {
                     expect(error).toEventually(beAnInstanceOf(NSError.self), timeout: .seconds(2))
                 }
                 it("will return invalid URL error with code") {
-                    expect(error.code).toEventually(equal(0), timeout: .seconds(2))
-                }
-                it("will return invalid URL error with message") {
-                    expect(error.localizedDescription).toEventually(equal("Invalid URL error"), timeout: .seconds(2))
+                    expect(error.code).toEventually(equal(MiniAppSDKErrorCode.invalidURLError.rawValue), timeout: .seconds(2))
                 }
             }
             context("throws invalid response received error") {
@@ -55,10 +52,7 @@ class MiniAppNSErrorTests: QuickSpec {
                     expect(error).toEventually(beAnInstanceOf(NSError.self), timeout: .seconds(2))
                 }
                 it("will return invalid response received error with code") {
-                    expect(error.code).toEventually(equal(0), timeout: .seconds(2))
-                }
-                it("will return invalid response received error with message") {
-                    expect(error.localizedDescription).toEventually(equal("Invalid response received"), timeout: .seconds(2))
+                    expect(error.code).toEventually(equal(MiniAppSDKErrorCode.invalidResponseData.rawValue), timeout: .seconds(2))
                 }
             }
             context("throws downloading mini app failed error") {
@@ -67,10 +61,7 @@ class MiniAppNSErrorTests: QuickSpec {
                     expect(error).toEventually(beAnInstanceOf(NSError.self), timeout: .seconds(2))
                 }
                 it("will return server error with code") {
-                    expect(error.code).toEventually(equal(0), timeout: .seconds(2))
-                }
-                it("will return server error with message") {
-                    expect(error.localizedDescription).toEventually(equal("Downloading failed"), timeout: .seconds(2))
+                    expect(error.code).toEventually(equal(MiniAppSDKErrorCode.downloadingFailed.rawValue), timeout: .seconds(2))
                 }
             }
         }

--- a/Tests/Unit/MiniAppClientTests.swift
+++ b/Tests/Unit/MiniAppClientTests.swift
@@ -93,7 +93,7 @@ class MiniAppClientTests: QuickSpec {
             context("when network response contains valid error json") {
                 var testError: NSError?
                 it("will pass an error to completion handler with expected code") {
-                    self.executeSession(data: ["code": 404, "message": "error message"], statusCode: 404) { (result) in
+                    self.executeSession(data: ["code": 400, "message": "error message"], statusCode: 400) { (result) in
                         switch result {
                         case .success:
                             break
@@ -101,10 +101,10 @@ class MiniAppClientTests: QuickSpec {
                             testError = error as NSError
                         }
                     }
-                    expect(testError?.code).toEventually(equal(404), timeout: .seconds(2))
+                    expect(testError?.code).toEventually(equal(400), timeout: .seconds(2))
                 }
                 it("will pass an error to completion handler with expected message") {
-                    self.executeSession(data: ["code": 404, "message": "error message description"], statusCode: 404) { (result) in
+                    self.executeSession(data: ["code": 400, "message": "error message description"], statusCode: 400) { (result) in
                         switch result {
                         case .success:
                             break
@@ -216,7 +216,7 @@ class MiniAppClientTests: QuickSpec {
                 }
                 it("returns valid error response") {
                     var testError: NSError?
-                    let mockSession = MockSession(data: ["code": 404, "message": "error message"], statusCode: 404)
+                    let mockSession = MockSession(data: ["code": 400, "message": "error message"], statusCode: 400)
                     let miniAppClient = MiniAppClient()
                     miniAppClient.session = mockSession
                     miniAppClient.getAppManifest(appId: "abc", versionId: "ver") { (result) in
@@ -227,7 +227,7 @@ class MiniAppClientTests: QuickSpec {
                             testError = error as NSError
                         }
                     }
-                    expect(testError?.code).toEventually(equal(404), timeout: .seconds(2))
+                    expect(testError?.code).toEventually(equal(400), timeout: .seconds(2))
                 }
                 it("returns invalid error response") {
                     var testError: NSError?

--- a/Tests/Unit/MiniAppInfoFetcherTests.swift
+++ b/Tests/Unit/MiniAppInfoFetcherTests.swift
@@ -78,7 +78,7 @@ class MiniAppInfoFetcherTests: QuickSpec {
                             testError = error as NSError
                         }
                     })
-                    expect(testError?.code).toEventually(equal(0))
+                    expect(testError?.code).toEventually(equal(MiniAppSDKErrorCode.invalidResponseData.rawValue))
                 }
             }
             context("when request from server returns error") {
@@ -158,7 +158,7 @@ class MiniAppInfoFetcherTests: QuickSpec {
                             testError = error as NSError
                         }
                     })
-                    expect(testError?.code).toEventually(equal(0))
+                    expect(testError?.code).toEventually(equal(MiniAppSDKErrorCode.invalidResponseData.rawValue))
                 }
             }
             context("when request from server returns error") {
@@ -171,7 +171,7 @@ class MiniAppInfoFetcherTests: QuickSpec {
                         userInfo: nil
                     )
                     let miniAppInfoFetcher = MiniAppInfoFetcher()
-                    miniAppInfoFetcher.fetchList(apiClient: mockAPIClient, completionHandler: { (result) in
+                    miniAppInfoFetcher.getInfo(miniAppId: "123", apiClient: mockAPIClient, completionHandler: { (result) in
                         switch result {
                         case .success:
                             break
@@ -180,6 +180,26 @@ class MiniAppInfoFetcherTests: QuickSpec {
                         }
                     })
                     expect(testError?.code).toEventually(equal(123))
+                }
+            }
+            context("when request from server returns no versions") {
+                it("will pass no published versions error to completion handler") {
+                    let mockAPIClient = MockAPIClient()
+                    mockAPIClient.data = "[]".data(using: .utf8)
+                    var testError: NSError?
+                    let miniAppInfoFetcher = MiniAppInfoFetcher()
+
+                    miniAppInfoFetcher.getInfo(miniAppId: "123", apiClient: mockAPIClient, completionHandler: { (result) in
+                        switch result {
+                        case .success:
+                            break
+                        case .failure(let error):
+                            testError = error as NSError
+                        }
+                    })
+
+                    expect(testError?.domain).toEventually(equal(MiniAppSDKErrorDomain))
+                    expect(testError?.code).toEventually(equal(MiniAppSDKErrorCode.noPublishedVersion.rawValue))
                 }
             }
         }

--- a/Tests/Unit/MiniAppTests.swift
+++ b/Tests/Unit/MiniAppTests.swift
@@ -24,29 +24,16 @@ class MiniAppTests: QuickSpec {
                 }
             }
             context("when info method is called with empty mini app id") {
-                it("will return nil") {
-                    var testError: NSError?
+                it("will return an error") {
+                    var testError: MASDKError?
                     MiniApp.shared().info(miniAppId: "") { (result) in
                         switch result {
                         case .success: break
                         case .failure(let error):
-                            testError = error as NSError
+                            testError = error
                         }
                     }
-                    expect(testError?.localizedDescription).toEventually(equal("Invalid AppID error"), timeout: .seconds(2))
-                }
-            }
-            context("when info method is called with valid mini app id") {
-                it("will return nil") {
-                    var testError: NSError?
-                    MiniApp.shared().info(miniAppId: "1234") { (result) in
-                        switch result {
-                        case .success: break
-                        case .failure(let error):
-                            testError = error as NSError
-                        }
-                    }
-                    expect(testError?.code).toEventually(equal(400) || equal(404), timeout: .seconds(10))
+                    expect(testError?.localizedDescription).toEventually(equal(MASDKError.invalidAppId.localizedDescription), timeout: .seconds(2))
                 }
             }
             context("when no mini apps downloaded and listDownloadedWithCustomPermissions method is called") {

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -52,18 +52,18 @@ class RealMiniAppTests: QuickSpec {
                 }
             }
             context("when getMiniApp is called with invalid app id") {
-                it("will return valid MiniAppInfo") {
-                    var testError: NSError?
+                it("will return an Error") {
+                    var testError: MASDKError?
                     mockAPIClient.data = nil
                     realMiniApp.getMiniApp(miniAppId: "123", completionHandler: { (result) in
                             switch result {
                             case .success:
                                 break
                             case .failure(let error):
-                                testError = error as NSError
+                                testError = error
                         }
                     })
-                    expect(testError?.code).toEventually(equal(0))
+                    expect(testError).toEventuallyNot(beNil())
                 }
             }
             context("when listMiniApp is called") {
@@ -310,16 +310,16 @@ class RealMiniAppTests: QuickSpec {
                     mockMiniAppInfoFetcher.error = NSError(domain: "URLErrorDomain", code: -1009, userInfo: nil)
                     mockAPIClient.data = responseString.data(using: .utf8)
                     mockAPIClient.manifestData = manifestResponse.data(using: .utf8)
-                    var testError: NSError?
+                    var testError: MASDKError?
                     realMiniApp.createMiniApp(appId: mockMiniAppInfo.id, completionHandler: { (result) in
                         switch result {
                         case .success:
                             break
                         case .failure(let error):
-                            testError = error as NSError
+                            testError = error
                         }
                     }, messageInterface: mockMessageInterface)
-                    expect(testError?.code).toEventually(equal(-1009), timeout: .seconds(10))
+                    expect(testError).toEventuallyNot(beNil())
                     mockMiniAppInfoFetcher.error = nil
                 }
             }
@@ -374,7 +374,7 @@ class RealMiniAppTests: QuickSpec {
                                 testError = error as NSError
                         }
                     }, messageInterface: mockMessageInterface)
-                    expect(testError?.code).toEventually(equal(0))
+                    expect(testError?.code).toEventually(equal(MiniAppSDKErrorCode.invalidURLError.rawValue))
                 }
             }
             context("when createMiniApp is called with url parameter") {


### PR DESCRIPTION
# Description
The basic idea is that we wanted to allow the Host App to handle the error cases for 'no published version' and 'mini app not found'. But I found that the current implementation for returning Errors doesn't really allow them to easily do that - they would have to convert the error to `NSError` and check the error domain and error code.

I wanted to make it so the Host App can easily handle errors in the Swift style by using switch/case, so I've changed the `MiniApp` functions to return a new error type `MASDKError`. The `NSError` will be converted to `MASDKError` before being returned to the Host App.

One problem with this is that it would be a breaking change for Host Apps if they've explicitly defined their completion handler to use an `Error`. So the method I found to get around this is to add deprecated methods which use `where T: Error`. This will mean that the functions using `MASDKError` will be used by default if the Host App has not defined an explicit type, but the deprecated functions can still be used if the Host App is explicitly using `Error`.

## Links
MINI-1972

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
