### PR TITLE
feat: add an option to load mini app by url (MINI-1981)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,18 +2,20 @@ disabled_rules: # rule identifiers to exclude from running
   - nesting
 # parameterized rules are first parameterized as a warning level, then error level.
 line_length:
-  - 200 # warning
-  - 300 # error
+    warning: 200
+    error: 300
+    ignores_function_declarations: true
+    ignores_comments: true
+    ignores_urls: true
 function_body_length:
-  max_length:
-    warning: 30
-    error: 50
+    warning: 40
+    error: 60
 type_body_length:
-  - 300
-  - 400
+    warning: 300
+    error: 400
 cyclomatic_complexity:
-  - 20
-  - 20
+    warning: 20
+    error: 20
 # paths to ignore
 identifier_name:
   excluded:

--- a/Example/Controllers/DisplayController.swift
+++ b/Example/Controllers/DisplayController.swift
@@ -9,16 +9,17 @@ class DisplayController: UIViewController {
     weak var miniAppDisplayDelegate: MiniAppDisplayProtocol?
 
     override func viewDidAppear(_ animated: Bool) {
-        guard let controller = self.navigationController as? DisplayNavigationController, let info = controller.miniAppInfo, let miniAppDisplay = controller.miniAppDisplay else {
+        guard let controller = self.navigationController as? DisplayNavigationController,
+              let miniAppDisplay = controller.miniAppDisplay else {
             return
         }
 
-        self.title = info.displayName
-        self.miniAppDisplayDelegate = miniAppDisplay
-        let view = miniAppDisplay.getMiniAppView()
-        view.frame = self.view.bounds
-        self.navBarDelegate = miniAppDisplay as? MiniAppNavigationBarDelegate
-        self.view.addSubview(view)
+        title = controller.miniAppInfo?.displayName ?? "Mini app"
+        miniAppDisplayDelegate = miniAppDisplay
+        let miniAppView = miniAppDisplay.getMiniAppView()
+        miniAppView.frame = view.bounds
+        navBarDelegate = miniAppDisplay as? MiniAppNavigationBarDelegate
+        view.addSubview(miniAppView)
     }
 
     @IBAction func done(_ sender: UIBarButtonItem) {

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -61,6 +61,18 @@ extension ViewController: MiniAppNavigationDelegate {
         }, messageInterface: self)
     }
 
+    func loadMiniAppUsingURL(_ url: URL) {
+        let miniAppDisplay = MiniApp.shared(with: Config.getCurrent(), navigationSettings: Config.getNavConfig(delegate: self)).create(
+            url: url,
+            errorHandler: { error in
+                self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_miniapp_message", comment: ""), dismissController: true)
+                print("Errored: ", error.localizedDescription)
+            }, messageInterface: self)
+
+        currentMiniAppView = miniAppDisplay
+        performSegue(withIdentifier: "DisplayMiniApp", sender: nil)
+    }
+
     func fetchMiniAppUsingId(title: String? = nil, message: String? = nil) {
         self.displayTextFieldAlert(title: title, message: message) { (_, textField) in
             if let textField = textField, let miniAppID = textField.text, miniAppID.count > 0 {

--- a/Example/Controllers/Storyboards/Base.lproj/Main.storyboard
+++ b/Example/Controllers/Storyboards/Base.lproj/Main.storyboard
@@ -794,7 +794,7 @@
                                     <outlet property="delegate" destination="BQV-uy-8GQ" id="nc3-ar-qnG"/>
                                 </connections>
                             </tableView>
-                            <searchBar contentMode="redraw" barStyle="black" prompt="Search Mini App by name or load by ID" placeholder="Name or ID" translatesAutoresizingMaskIntoConstraints="NO" id="wM9-1o-Y4m">
+                            <searchBar contentMode="redraw" barStyle="black" prompt="Search Mini App by name or load by ID or URL" placeholder="Name, ID or URL" translatesAutoresizingMaskIntoConstraints="NO" id="wM9-1o-Y4m">
                                 <rect key="frame" x="0.0" y="44" width="375" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="pNm-44-330"/>

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -49,5 +49,18 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+      <key>NSExceptionDomains</key>
+      <dict>
+        <key>localhost</key>
+        <dict>
+          <key>NSIncludesSubdomains</key>
+          <false/>
+          <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+        </dict>
+      </dict>
+    </dict>
 </dict>
 </plist>

--- a/Example/Utils/String+MiniApp.swift
+++ b/Example/Utils/String+MiniApp.swift
@@ -3,6 +3,10 @@ import UIKit
 
 extension String {
 
+    var hasHTTPPrefix: Bool {
+        return lowercased().hasPrefix("http://") || lowercased().hasPrefix("https://")
+    }
+
     func isValidUUID() -> Bool {
         if UUID(uuidString: self) != nil {
             return true

--- a/MiniApp.xcodeproj/xcshareddata/xcschemes/MiniApp-Example.xcscheme
+++ b/MiniApp.xcodeproj/xcshareddata/xcschemes/MiniApp-Example.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">

--- a/MiniApp/Classes/Display/Displayer.swift
+++ b/MiniApp/Classes/Display/Displayer.swift
@@ -5,12 +5,29 @@ internal class Displayer {
         self.navConfig = config
     }
 
-    func getMiniAppView(miniAppId: String, versionId: String, miniAppTitle: String, hostAppMessageDelegate: MiniAppMessageDelegate) -> MiniAppDisplayProtocol {
+    func getMiniAppView(miniAppId: String,
+                        versionId: String,
+                        miniAppTitle: String,
+                        hostAppMessageDelegate: MiniAppMessageDelegate) -> MiniAppDisplayProtocol {
         return RealMiniAppView(
           miniAppId: miniAppId,
           versionId: versionId,
           miniAppTitle: miniAppTitle,
           hostAppMessageDelegate: hostAppMessageDelegate,
+          displayNavBar: navConfig?.navigationBarVisibility ?? .never,
+          navigationDelegate: navConfig?.navigationDelegate,
+          navigationView: navConfig?.navigationView)
+    }
+
+    func getMiniAppView(miniAppURL: URL,
+                        miniAppTitle: String,
+                        hostAppMessageDelegate: MiniAppMessageDelegate,
+                        initialLoadCallback: @escaping (Bool) -> Void) -> MiniAppDisplayProtocol {
+        return RealMiniAppView(
+          miniAppURL: miniAppURL,
+          miniAppTitle: miniAppTitle,
+          hostAppMessageDelegate: hostAppMessageDelegate,
+          initialLoadCallback: initialLoadCallback,
           displayNavBar: navConfig?.navigationBarVisibility ?? .never,
           navigationDelegate: navConfig?.navigationDelegate,
           navigationView: navConfig?.navigationView)

--- a/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
+++ b/MiniApp/Classes/Display/MiniAppExternalWebViewController.swift
@@ -3,15 +3,23 @@ import UIKit
 import WebKit
 
 class MiniAppExternalWebViewController: UIViewController {
-    struct ReturnObject: Codable {
-        var url: String?
-    }
 
-    var webView: WKWebView!
-    var currentURL: URL?
-    var miniAppExternalUrlLoader: MiniAppExternalUrlLoader?
+    private var webView: WKWebView!
+    private var currentURL: URL?
+    private var customMiniAppURL: URL?
+    private var miniAppExternalUrlLoader: MiniAppExternalUrlLoader?
 
-    public class func presentModally(url: URL, externalLinkResponseHandler: MiniAppNavigationResponseHandler?) {
+    ///
+    /// Presents a webview modally to handle external URLs.
+    ///
+    /// - Parameters:
+    ///   - url: A url to load in a webview
+    ///   - externalLinkResponseHandler: A closure that will provide triggered url to the Mini App view.
+    ///   - customMiniAppURL: The url that was used to load the Mini App.
+    ///
+    public class func presentModally(url: URL,
+                                     externalLinkResponseHandler: MiniAppNavigationResponseHandler?,
+                                     customMiniAppURL: URL? = nil) {
         let window: UIWindow?
         if #available(iOS 13, *) {
             window = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
@@ -20,12 +28,14 @@ class MiniAppExternalWebViewController: UIViewController {
         }
         let webctrl = MiniAppExternalWebViewController()
         webctrl.currentURL = url
+        webctrl.customMiniAppURL = customMiniAppURL
         let navigationController = MiniAppCloseNavigationController(rootViewController: webctrl)
         let closeButton = UIBarButtonItem(barButtonSystemItem: .done, target: navigationController, action: #selector(MiniAppCloseNavigationController.close))
         webctrl.navigationItem.rightBarButtonItem = closeButton
-        webctrl.miniAppExternalUrlLoader = MiniAppExternalUrlLoader(webViewController: webctrl, responseHandler: externalLinkResponseHandler)
+        webctrl.miniAppExternalUrlLoader = MiniAppExternalUrlLoader(webViewController: webctrl,
+                                                                    responseHandler: externalLinkResponseHandler,
+                                                                    customMiniAppURL: customMiniAppURL)
         window?.topController()?.present(navigationController, animated: true)
-
     }
 
     override func loadView() {

--- a/MiniApp/Classes/Display/MiniAppNavigationConfig.swift
+++ b/MiniApp/Classes/Display/MiniAppNavigationConfig.swift
@@ -36,6 +36,16 @@ public protocol MiniAppNavigationDelegate: class {
     ///   - url: the external URL triggered from the MiniApp
     ///   - responseHandler: a `MiniAppNavigationResponseHandler` used to provide an URL to the Mini App
     func miniAppNavigation(shouldOpen url: URL, with responseHandler: @escaping MiniAppNavigationResponseHandler)
+    /// This delegate method is called when an external URL is tapped into a url loaded Mini App
+    /// so you can display your own webview to load the url parameter, for example.
+    /// A `MiniAppNavigationResponseHandler` is also provided so you can give a proper
+    /// feedback to your MiniApp under the form of an URL when you want.
+    /// This should only be used for previewing a mini app from a local server.
+    /// - Parameters:
+    ///   - url: the external URL triggered from the MiniApp
+    ///   - responseHandler: a `MiniAppNavigationResponseHandler` used to provide an URL to the Mini App
+    ///   - customMiniAppURL: The url that was used to load the Mini App.
+    func miniAppNavigation(shouldOpen url: URL, with responseHandler: @escaping MiniAppNavigationResponseHandler, customMiniAppURL: URL)
     /// This delegate method is called when a navigation is performed inside the Mini App.
     /// - Parameters:
     ///   - actions: a list of `MiniAppNavigationAction` that can be used to navigate inside the Mini App
@@ -48,7 +58,16 @@ public protocol MiniAppNavigationDelegate: class {
 
 public extension MiniAppNavigationDelegate {
     func miniAppNavigation(shouldOpen url: URL, with responseHandler: @escaping MiniAppNavigationResponseHandler) {
-        MiniAppExternalWebViewController.presentModally(url: url, externalLinkResponseHandler: responseHandler)
+        MiniAppExternalWebViewController.presentModally(url: url,
+                                                        externalLinkResponseHandler: responseHandler,
+                                                        customMiniAppURL: nil)
+    }
+    func miniAppNavigation(shouldOpen url: URL,
+                           with responseHandler: @escaping MiniAppNavigationResponseHandler,
+                           customMiniAppURL: URL) {
+        MiniAppExternalWebViewController.presentModally(url: url,
+                                                        externalLinkResponseHandler: responseHandler,
+                                                        customMiniAppURL: customMiniAppURL)
     }
     func miniAppNavigation(canUse actions: [MiniAppNavigationAction]) {
     }

--- a/MiniApp/Classes/Display/MiniAppWebView.swift
+++ b/MiniApp/Classes/Display/MiniAppWebView.swift
@@ -2,21 +2,37 @@ import WebKit
 
 internal class MiniAppWebView: WKWebView {
 
-    convenience init(miniAppId: String, versionId: String) {
-        let environment = Environment()
-        let schemeName = Constants.miniAppSchemePrefix + miniAppId
-        let urlRequest = URLRequest(url: URL(string: schemeName + "://miniapp/" + Constants.rootFileName)!)
+    private static func defaultConfig() -> WKWebViewConfiguration {
         let config = WKWebViewConfiguration()
         config.preferences.javaScriptEnabled = true
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
-        config.setURLSchemeHandler(URLSchemeHandler(versionId: versionId), forURLScheme: schemeName)
         config.allowsInlineMediaPlayback = true
         config.mediaTypesRequiringUserActionForPlayback = []
         config.allowsPictureInPictureMediaPlayback = true
+        return config
+    }
+
+    convenience init(miniAppId: String, versionId: String) {
+        let schemeName = Constants.miniAppSchemePrefix + miniAppId
+        let urlRequest = URLRequest(url: URL(string: schemeName + "://miniapp/" + Constants.rootFileName)!)
+        let config = MiniAppWebView.defaultConfig()
+        config.setURLSchemeHandler(URLSchemeHandler(versionId: versionId), forURLScheme: schemeName)
         self.init(frame: .zero, configuration: config)
+        commonInit(urlRequest: urlRequest)
+    }
+
+    convenience init(miniAppURL: URL) {
+        let urlRequest = URLRequest(url: miniAppURL.appendingPathComponent(Constants.rootFileName))
+        self.init(frame: .zero, configuration: MiniAppWebView.defaultConfig())
+        commonInit(urlRequest: urlRequest)
+    }
+
+    private func commonInit(urlRequest: URLRequest) {
+        let environment = Environment()
         self.allowsBackForwardNavigationGestures = true
         contentMode = .scaleToFill
         load(urlRequest)
+
         if !environment.hostAppUserAgentInfo.isEmpty && environment.hostAppUserAgentInfo != "NONE" {
             evaluateJavaScript("navigator.userAgent") { [weak self] (result, error) in
                 if error != nil {

--- a/MiniApp/Classes/Extensions/MiniApp+String.swift
+++ b/MiniApp/Classes/Extensions/MiniApp+String.swift
@@ -1,4 +1,9 @@
 extension String {
+
+    var hasHTTPPrefix: Bool {
+        return lowercased().hasPrefix("http://") || lowercased().hasPrefix("https://")
+    }
+
     func deletingPrefix(_ prefix: String) -> String {
         guard self.hasPrefix(prefix) else { return self }
         return String(self.dropFirst(prefix.count))

--- a/MiniApp/Classes/Extensions/MiniApp+URL.swift
+++ b/MiniApp/Classes/Extensions/MiniApp+URL.swift
@@ -3,7 +3,10 @@ extension URL {
         (self.absoluteString as NSString).pathExtension.lowercased()
     }
 
-    func isMiniAppURL() -> Bool {
+    func isMiniAppURL(customMiniAppURL: URL? = nil) -> Bool {
+        if let miniAppURL = customMiniAppURL {
+            return host?.lowercased() == miniAppURL.host?.lowercased()
+        }
         return scheme?.starts(with: Constants.miniAppSchemePrefix) ?? false
     }
 }

--- a/MiniApp/Classes/MiniApp.swift
+++ b/MiniApp/Classes/MiniApp.swift
@@ -18,7 +18,7 @@ public class MiniApp: NSObject {
     /// Error information will be returned if any problem while fetching from the backed
     ///
     /// - Parameters:
-    ///     -   completionBlock: A block to be called when list of [MiniAppInfo] information is fetched. Completion blocks receives the following parameters
+    ///     -   completionHandler: A block to be called when list of [MiniAppInfo] information is fetched. Completion blocks receives the following parameters
     ///         -   [MiniAppInfo]: List of [MiniAppInfo] information.
     ///         -   Error: Error details if fetching is failed.
     public func list(completionHandler: @escaping (Result<[MiniAppInfo], Error>) -> Void) {
@@ -44,7 +44,7 @@ public class MiniApp: NSObject {
     /// - Parameters:
     ///   - appId: Mini AppId String value
     ///   - version: optional Mini App version String value. If omitted the modt recent one is picked
-    ///   - completionBlock: A block to be called on successful creation of [MiniAppView] or throws errors if any. Completion blocks receives the following parameters
+    ///   - completionHandler: A block to be called on successful creation of [MiniAppView] or throws errors if any. Completion blocks receives the following parameters
     ///         -   MiniAppDisplayProtocol: Protocol that helps the hosting application to communicate with the displayer module of the mini app. More like an interface for host app
     ///                         to interact with View component of mini app.
     ///         -   Error: Error details if Mini App View creating is failed
@@ -58,9 +58,7 @@ public class MiniApp: NSObject {
     ///   - appId: Mini AppId String value
     ///   - permissionList: List of MASDKCustomPermissionModel class that contains the MiniAppCustomPermissionType and MiniAppCustomPermissionGrantedStatus
     public func setCustomPermissions(forMiniApp appId: String, permissionList: [MASDKCustomPermissionModel]) {
-        if !appId.isEmpty {
-            return realMiniApp.storeCustomPermissions(forMiniApp: appId, permissionList: permissionList)
-        }
+        return realMiniApp.storeCustomPermissions(forMiniApp: appId, permissionList: permissionList)
     }
 
     /// Get the list of supported Custom permissions and its status for a given Mini app ID
@@ -79,19 +77,38 @@ public class MiniApp: NSObject {
         return realMiniApp.getDownloadedListWithCustomPermissions()
     }
 
-//    public func getCustomPermissionsManageList
-
     /// Creates a Mini App for the given mini app info object, Mini app will be downloaded and cached in local.
     /// This method should only be used in "Preview Mode".
     ///
     /// - Parameters:
     ///   - appInfo: Mini App info object
-    ///   - completionBlock: A block to be called on successful creation of [MiniAppView] or throws errors if any. Completion blocks receives the following parameters
+    ///   - completionHandler: A block to be called on successful creation of [MiniAppView] or throws errors if any. Completion blocks receives the following parameters
     ///         -   MiniAppDisplayProtocol: Protocol that helps the hosting application to communicate with the displayer module of the mini app. More like an interface for host app
     ///                         to interact with View component of mini app.
     ///         -   Error: Error details if Mini App View creating is failed
     ///   - messageInterface: Protocol implemented by the user that helps to communicate between Mini App and native application
     public func create(appInfo: MiniAppInfo, completionHandler: @escaping (Result<MiniAppDisplayProtocol, Error>) -> Void, messageInterface: MiniAppMessageDelegate) {
         return realMiniApp.createMiniApp(appInfo: appInfo, completionHandler: completionHandler, messageInterface: messageInterface)
+    }
+}
+
+// MARK: - Testing
+public extension MiniApp {
+    /// Creates a Mini App for the given url.
+    /// Mini app will NOT be downloaded and cached in local, its content will be read directly from provided url.
+    /// This should only be used for previewing a mini app from a local server.
+    ///
+    /// - Parameters:
+    ///   - url: a HTTP url containing Mini App content
+    ///   - errorHandler: A block to be called on unsuccessful initial load of Mini App's web content. The handler block receives the following parameter
+    ///         -   Error: Error details if Mini App's url content loading is failed, otherwise nil.
+    /// - Returns: MiniAppDisplayProtocol: Protocol that helps the hosting application to communicate with the displayer module of the mini app. More like an interface for host app
+    ///                         to interact with View component of mini app.
+    func create(url: URL,
+                errorHandler: @escaping (Error) -> Void,
+                messageInterface: MiniAppMessageDelegate) -> MiniAppDisplayProtocol {
+        return realMiniApp.createMiniApp(url: url,
+                                         errorHandler: errorHandler,
+                                         messageInterface: messageInterface)
     }
 }

--- a/MiniApp/Classes/MiniAppSdkConfig.swift
+++ b/MiniApp/Classes/MiniAppSdkConfig.swift
@@ -4,11 +4,11 @@ import Foundation
 public class MiniAppSdkConfig {
     @available(*, deprecated, renamed: "isPreviewMode")
     var isTestMode: Bool? {
-        set {
-            isPreviewMode = newValue
-        }
         get {
             isPreviewMode
+        }
+        set {
+            isPreviewMode = newValue
         }
     }
 

--- a/MiniApp/Classes/Protocols/MiniAppShareContentDelegate.swift
+++ b/MiniApp/Classes/Protocols/MiniAppShareContentDelegate.swift
@@ -10,7 +10,7 @@ public protocol MiniAppShareContentDelegate: class {
 public extension MiniAppShareContentDelegate {
     func shareContent(info: MiniAppShareContent, completionHandler: @escaping (Result<MASDKProtocolResponse, Error>) -> Void) {
         let activityController = UIActivityViewController(activityItems: [info.messageContent], applicationActivities: nil)
-        activityController.completionWithItemsHandler = { (activityType: UIActivity.ActivityType?, completed: Bool, returnedItems: [Any]?, error: Error?) in
+        activityController.completionWithItemsHandler = { (_, _, _, error: Error?) in
             if let err = error {
                 completionHandler(.failure(err))
             } else {

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -77,6 +77,19 @@ internal class RealMiniApp {
             } }
     }
 
+    func createMiniApp(url: URL,
+                       errorHandler: @escaping (Error) -> Void,
+                       messageInterface: MiniAppMessageDelegate? = nil) -> MiniAppDisplayProtocol {
+        return displayer.getMiniAppView(miniAppURL: url,
+                                        miniAppTitle: "Mini app",
+                                        hostAppMessageDelegate: messageInterface ?? self,
+                                        initialLoadCallback: { success in
+            if !success {
+                errorHandler(NSError.invalidURLError())
+            }
+        })
+    }
+
     /// Download Mini app for a given Mini app info object
     /// - Parameters:
     ///   - appInfo: Miniapp Info object

--- a/MiniApp/Classes/Storage/MiniAppKeyChain.swift
+++ b/MiniApp/Classes/Storage/MiniAppKeyChain.swift
@@ -19,6 +19,9 @@ import Foundation
     }
 
     func storeCustomPermissions(permissions: [MASDKCustomPermissionModel], forMiniApp keyId: String) {
+        guard !keyId.isEmpty else {
+            return
+        }
         var keysDic = keys()
         var cachedPermissions = self.getCustomPermissions(forMiniApp: keyId)
         _ = permissions.map { (permissionModel: MASDKCustomPermissionModel) -> MASDKCustomPermissionModel in

--- a/MiniApp/Classes/Utilities/MiniAppExternalUrlLoader.swift
+++ b/MiniApp/Classes/Utilities/MiniAppExternalUrlLoader.swift
@@ -3,6 +3,7 @@ import WebKit
 public class MiniAppExternalUrlLoader {
     public weak var currentWebViewController: UIViewController?
     public var currentResponseHandler: MiniAppNavigationResponseHandler?
+    public var customMiniAppURL: URL?
 
     /// This class supports the scenario that external loader redirects url that are only supported in mini app view,
     /// closes the external loader and emits that url to mini app view with the help of  a MiniAppNavigationResponseHandler.
@@ -11,10 +12,14 @@ public class MiniAppExternalUrlLoader {
     ///     -   webViewController: The UIViewController containing the external webview.
     ///         Provide it if you want the controller to auto-close when a Mini App url is triggered.
     ///     -   responseHandler: a MiniAppNavigationResponseHandler closure that will provide the Mini App view the url that has been triggered.
+    ///     -   customMiniAppURL: The url that was used to load the Mini App.
     ///         Provide this if you want to manage the result of the external navigation inside your Mini App
-    public init(webViewController: UIViewController? = nil, responseHandler: MiniAppNavigationResponseHandler? = nil) {
+    public init(webViewController: UIViewController? = nil,
+                responseHandler: MiniAppNavigationResponseHandler? = nil,
+                customMiniAppURL: URL? = nil) {
         currentWebViewController = webViewController
         currentResponseHandler = responseHandler
+        self.customMiniAppURL = customMiniAppURL
     }
 
     /// Use this method inside your WKNavigationDelegate to provide the appropriate WKNavigationActionPolicy to the decidePolicyForNavigationAction method,
@@ -22,7 +27,7 @@ public class MiniAppExternalUrlLoader {
     /// and provide a feedback to the Mini App via the MiniAppNavigationResponseHandler
     public func shouldOverrideURLLoading(_ url: URL?) -> WKNavigationActionPolicy {
         MiniAppLogger.d("shouldOverrideURLLoading(_ url: \(url?.absoluteString ?? "?"))")
-        if let urlWebview = url, urlWebview.isMiniAppURL() {
+        if let urlWebview = url, urlWebview.isMiniAppURL(customMiniAppURL: customMiniAppURL) {
             self.currentResponseHandler?(urlWebview)
             self.currentWebViewController?.dismiss(animated: true)
             return .cancel

--- a/Tests/Unit/DisplayerTests.swift
+++ b/Tests/Unit/DisplayerTests.swift
@@ -6,14 +6,38 @@ class DisplayerTests: QuickSpec {
 
     override func spec() {
         describe("get mini app view") {
+
+            var miniAppDisplayer: Displayer!
+            var mockMessageInterface: MockMessageInterface!
+
+            beforeEach {
+                miniAppDisplayer = Displayer()
+                mockMessageInterface = MockMessageInterface()
+            }
+
             context("when mini app id is passed") {
                 it("will return MiniAppView") {
-                    let miniAppDisplayer = Displayer()
-                    let mockMessageInterface = MockMessageInterface()
                     let miniAppView = miniAppDisplayer.getMiniAppView(miniAppId: "miniappid-testing",
                                                                       versionId: "version-id",
                                                                       miniAppTitle: "Mini app title",
                                                                       hostAppMessageDelegate: mockMessageInterface)
+                    expect(miniAppView).toEventually(beAnInstanceOf(RealMiniAppView.self), timeout: .seconds(10))
+                }
+            }
+
+            context("when mini app url is passed") {
+                it("will return MiniAppView for valid url") {
+                    let miniAppView = miniAppDisplayer.getMiniAppView(miniAppURL: URL(string: "http://miniapp")!,
+                                                                      miniAppTitle: "Mini app title",
+                                                                      hostAppMessageDelegate: mockMessageInterface,
+                                                                      initialLoadCallback: { _ in })
+                    expect(miniAppView).toEventually(beAnInstanceOf(RealMiniAppView.self), timeout: .seconds(10))
+                }
+                it("will return MiniAppView for invalid url") {
+                    let miniAppView = miniAppDisplayer.getMiniAppView(miniAppURL: URL(string: "file:/miniapp")!,
+                                                                      miniAppTitle: "Mini app title",
+                                                                      hostAppMessageDelegate: mockMessageInterface,
+                                                                      initialLoadCallback: { _ in })
                     expect(miniAppView).toEventually(beAnInstanceOf(RealMiniAppView.self), timeout: .seconds(10))
                 }
             }

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -402,6 +402,25 @@ class MockNavigationWebView: MiniAppWebView {
     }
 }
 
+class MockDisplayer: Displayer {
+    var mockedInitialLoadCallbackResponse = true
+
+    override func getMiniAppView(miniAppURL: URL,
+                                 miniAppTitle: String,
+                                 hostAppMessageDelegate: MiniAppMessageDelegate,
+                                 initialLoadCallback: @escaping (Bool) -> Void) -> MiniAppDisplayProtocol {
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
+            DispatchQueue.main.async {
+                initialLoadCallback(self.mockedInitialLoadCallbackResponse)
+            }
+        }
+        return super.getMiniAppView(miniAppURL: miniAppURL,
+                                    miniAppTitle: miniAppTitle,
+                                    hostAppMessageDelegate: hostAppMessageDelegate,
+                                    initialLoadCallback: { _ in })
+    }
+}
+
 /// Method to delete the Mini App directory which was created for Mock testing
 /// - Parameters:
 ///   - appId: Mini App ID

--- a/Tests/Unit/MiniApp+StringTests.swift
+++ b/Tests/Unit/MiniApp+StringTests.swift
@@ -11,8 +11,7 @@ class MiniAppStringTests: QuickSpec {
                     let okLocalizedTitle = "Ok_title".localizedString()
                     expect(okLocalizedTitle).toEventually(equal("OK"), timeout: .seconds(10))
                 }
-            }
-            context("when localized key is passed that is available in Pod bundle") {
+
                 it("will return valid localized string") {
                     let cancelLocalizedTitle = "Cancel_title".localizedString()
                     expect(cancelLocalizedTitle).toEventually(equal("Cancel"), timeout: .seconds(10))
@@ -23,11 +22,42 @@ class MiniAppStringTests: QuickSpec {
                     let okLocalizedTitle = "Ok_title".localizedString(path: "")
                     expect(okLocalizedTitle).toEventually(equal("Ok_title"), timeout: .seconds(10))
                 }
-            }
-            context("when localized key is passed with pod bundle path as empty") {
+
                 it("will return the key as string") {
                     let cancelLocalizedTitle = "Cancel_title".localizedString(path: "")
                     expect(cancelLocalizedTitle).toEventually(equal("Cancel_title"), timeout: .seconds(10))
+                }
+            }
+            context("when calling hasHTTPPrefix with a valid http string") {
+                it("will return true for http string") {
+                    expect("http://miniapp".hasHTTPPrefix).to(beTrue())
+                }
+                it("will return true for https string") {
+                    expect("https://miniapp".hasHTTPPrefix).to(beTrue())
+                }
+                it("will return true for http string (case insensitive)") {
+                    expect("hTTp://miniapp".hasHTTPPrefix).to(beTrue())
+                }
+                it("will return false for http string with white character at the beginning") {
+                    expect(" http://miniapp".hasHTTPPrefix).to(beFalse())
+                }
+            }
+            context("when calling hasHTTPPrefix with an invalid http string") {
+                it("will return false incomplete http url") {
+                    expect("http:/miniapp".hasHTTPPrefix).to(beFalse())
+                    expect("http//miniapp".hasHTTPPrefix).to(beFalse())
+                }
+                it("will return false for other url schemes") {
+                    expect("file://file".hasHTTPPrefix).to(beFalse())
+                }
+                it("will return false for empty string") {
+                    expect("".hasHTTPPrefix).to(beFalse())
+                }
+                it("will return false for string containing only white characters") {
+                    expect(" ".hasHTTPPrefix).to(beFalse())
+                }
+                it("will return false for non url string") {
+                    expect("a1".hasHTTPPrefix).to(beFalse())
                 }
             }
         }

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -3,6 +3,7 @@ import Nimble
 @testable import MiniApp
 
 // swiftlint:disable function_body_length
+// swiftlint:disable file_length
 // swiftlint:disable cyclomatic_complexity
 // swiftlint:disable type_body_length
 class RealMiniAppTests: QuickSpec {
@@ -374,6 +375,29 @@ class RealMiniAppTests: QuickSpec {
                         }
                     }, messageInterface: mockMessageInterface)
                     expect(testError?.code).toEventually(equal(0))
+                }
+            }
+            context("when createMiniApp is called with url parameter") {
+                var originalDisplayer: Displayer!
+                var mockedDisplayer: MockDisplayer!
+
+                beforeEach {
+                    originalDisplayer = realMiniApp.displayer
+                    mockedDisplayer = MockDisplayer()
+                    realMiniApp.displayer = mockedDisplayer
+                }
+                afterEach {
+                    realMiniApp.displayer = originalDisplayer
+                }
+
+                it("will return an error if initial load of the mini app has failed") {
+                    var testError: NSError?
+                    mockedDisplayer.mockedInitialLoadCallbackResponse = false
+                    _ = realMiniApp.createMiniApp(url: URL(string: "http://miniapp")!,
+                                              errorHandler: { error in
+                        testError = error as NSError
+                    }, messageInterface: mockMessageInterface)
+                    expect(testError).toEventually(equal(NSError.invalidURLError()), timeout: .seconds(2))
                 }
             }
         }

--- a/Tests/Unit/RealMiniAppViewTests.swift
+++ b/Tests/Unit/RealMiniAppViewTests.swift
@@ -14,9 +14,15 @@ class RealMiniAppViewTests: QuickSpec {
                                               miniAppTitle: "Mini app title",
                                               hostAppMessageDelegate: mockMessageInterface)
             context("when initialized with valid parameters") {
-                it("will return MiniAppView object") {
+                it("will return MiniAppView object for given app id") {
                     let miniAppView = RealMiniAppView(miniAppId: "miniappid-testing",
                                                       versionId: "version-id",
+                                                      miniAppTitle: "",
+                                                      hostAppMessageDelegate: mockMessageInterface)
+                    expect(miniAppView).toEventually(beAnInstanceOf(RealMiniAppView.self))
+                }
+                it("will return MiniAppView object for given app url") {
+                    let miniAppView = RealMiniAppView(miniAppURL: URL(string: "http://miniapp")!,
                                                       miniAppTitle: "",
                                                       hostAppMessageDelegate: mockMessageInterface)
                     expect(miniAppView).toEventually(beAnInstanceOf(RealMiniAppView.self))


### PR DESCRIPTION
# Description
Search bar in sample app now accepts localhost and https urls containing a mini app.
No data is persisted for such mini apps.

## Links
MINI-1981

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
