### PR TITLE
Updated sample app to use RASProjectId

### DIFF
--- a/Example/Controllers/FirstLaunchViewController.swift
+++ b/Example/Controllers/FirstLaunchViewController.swift
@@ -18,7 +18,7 @@ class FirstLaunchViewController: UIViewController {
     }
 
     func checkSettingsOK() -> Bool {
-        return Config.userDefaults?.string(forKey: Config.Key.applicationIdentifier.rawValue) != nil && Config.userDefaults?.string(forKey: Config.Key.subscriptionKey.rawValue) != nil
+        return Config.userDefaults?.string(forKey: Config.Key.projectId.rawValue) != nil && Config.userDefaults?.string(forKey: Config.Key.subscriptionKey.rawValue) != nil
     }
 
     func animateViews() {

--- a/Example/Controllers/SettingsTableViewController.swift
+++ b/Example/Controllers/SettingsTableViewController.swift
@@ -58,7 +58,7 @@ class SettingsTableViewController: UITableViewController {
     func resetFields() {
         self.invalidHostAppIdLabel.isHidden = true
         self.invalidSubscriptionKeyLabel.isHidden = true
-        configure(field: self.textFieldAppID, for: .applicationIdentifier)
+        configure(field: self.textFieldAppID, for: .projectId)
         configure(field: self.textFieldSubKey, for: .subscriptionKey)
         configureMode()
     }
@@ -69,7 +69,7 @@ class SettingsTableViewController: UITableViewController {
     }
 
     @IBAction func actionSaveConfig() {
-        if isValueEntered(text: self.textFieldAppID.text, key: .applicationIdentifier) && isValueEntered(text: self.textFieldSubKey.text, key: .subscriptionKey) {
+        if isValueEntered(text: self.textFieldAppID.text, key: .projectId) && isValueEntered(text: self.textFieldSubKey.text, key: .subscriptionKey) {
             if self.textFieldAppID.text!.isValidUUID() {
                 let selectedMode = TestMode(rawValue: self.endPointSegmentedControl.selectedSegmentIndex)
                 let isTest = selectedMode?.isTestMode() ?? false
@@ -82,7 +82,7 @@ class SettingsTableViewController: UITableViewController {
                         )
                 )
             }
-            displayInvalidValueErrorMessage(forKey: .applicationIdentifier)
+            displayInvalidValueErrorMessage(forKey: .projectId)
         }
     }
 
@@ -120,7 +120,7 @@ class SettingsTableViewController: UITableViewController {
     }
 
     func saveCustomConfiguration(responseData: [MiniAppInfo]?) {
-        self.save(field: self.textFieldAppID, for: .applicationIdentifier)
+        self.save(field: self.textFieldAppID, for: .projectId)
         self.save(field: self.textFieldSubKey, for: .subscriptionKey)
         self.saveMode()
 
@@ -210,7 +210,7 @@ class SettingsTableViewController: UITableViewController {
 
     func displayInvalidValueErrorMessage(forKey: Config.Key) {
         switch forKey {
-        case .applicationIdentifier:
+        case .projectId:
             displayAlert(title: NSLocalizedString("error_title", comment: ""),
                 message: NSLocalizedString("error_incorrect_appid_message", comment: ""),
                 autoDismiss: true)
@@ -224,7 +224,7 @@ class SettingsTableViewController: UITableViewController {
     }
     func displayNoValueFoundErrorMessage(forKey: Config.Key) {
         switch forKey {
-        case .applicationIdentifier:
+        case .projectId:
             displayAlert(title: NSLocalizedString("error_title", comment: ""),
                 message: NSLocalizedString("error_empty_appid_key_message", comment: ""),
                 autoDismiss: true)

--- a/Example/Controllers/Storyboards/Base.lproj/Main.storyboard
+++ b/Example/Controllers/Storyboards/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hzK-gd-cH8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hzK-gd-cH8">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -235,7 +235,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Profile" highlightedImage="Profile" translatesAutoresizingMaskIntoConstraints="NO" id="5qa-hz-rgq">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profile" highlightedImage="Profile" translatesAutoresizingMaskIntoConstraints="NO" id="5qa-hz-rgq">
                                                     <rect key="frame" x="10" y="15" width="32" height="32"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="tintColor" systemColor="systemGrayColor"/>
@@ -1126,6 +1126,7 @@
         <image name="arrow_left" width="24" height="24"/>
         <image name="arrow_right" width="24" height="24"/>
         <image name="curved-arrow" width="170.66667175292969" height="170.66667175292969"/>
+        <image name="profile" width="44" height="44"/>
         <systemColor name="darkTextColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -24,7 +24,7 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Demo app helps you find more information near you</string>
-	<key>RASApplicationIdentifier</key>
+	<key>RASProjectId</key>
 	<string>$(RAS_APPLICATION_IDENTIFIER)</string>
 	<key>RASProjectSubscriptionKey</key>
 	<string>$(RAS_PROJECT_SUBSCRIPTION_KEY)</string>

--- a/MiniApp/Classes/Environment.swift
+++ b/MiniApp/Classes/Environment.swift
@@ -18,7 +18,7 @@ internal class Environment {
     let bundle: EnvironmentProtocol
 
     var customUrl: String?
-    @available(*, deprecated, message: "use customProjectId instead")
+    @available(*, deprecated, renamed: "customProjectId")
     var customAppId: String?
     var customProjectId: String?
     var customAppVersion: String?
@@ -39,7 +39,7 @@ internal class Environment {
         self.customIsTestMode = config.isTestMode
     }
 
-    @available(*, deprecated, message: "use projectId instead")
+    @available(*, deprecated, renamed: "projectId")
     var appId: String {
         return value(for: customAppId, fallback: .applicationIdentifier)
     }

--- a/MiniApp/Classes/MiniAppSdkConfig.swift
+++ b/MiniApp/Classes/MiniAppSdkConfig.swift
@@ -11,7 +11,7 @@ public class MiniAppSdkConfig {
             }
         }
     }
-    @available(*, deprecated, message: "use rasProjectId instead")
+    @available(*, deprecated, renamed: "rasProjectId")
     var rasAppId: String? {
         didSet {
             if rasAppId?.count ?? 0 == 0 {

--- a/Tests/Unit/MiniAppClientTests.swift
+++ b/Tests/Unit/MiniAppClientTests.swift
@@ -264,7 +264,6 @@ class MiniAppClientTests: QuickSpec {
                 it("it uses plist configuration as environment") {
                     let miniAppClient = MiniAppClient()
 
-                    expect(miniAppClient.environment.appId).to(equal(bundle.value(for: applicationIdentifierKey)))
                     expect(miniAppClient.environment.projectId).to(equal(bundle.value(for: projectId)))
                     expect(miniAppClient.environment.appVersion).to(equal(bundle.value(for: versionKey)))
                     expect(miniAppClient.environment.subscriptionKey).to(equal(bundle.value(for: subscriptionKey)))
@@ -327,7 +326,6 @@ class MiniAppClientTests: QuickSpec {
                     let miniAppClient = MiniAppClient(baseUrl: testURL, rasProjectId: testID)
                     miniAppClient.updateEnvironment(with: nil)
 
-                    expect(miniAppClient.environment.appId).to(equal(bundle.value(for: applicationIdentifierKey)))
                     expect(miniAppClient.environment.projectId).to(equal(bundle.value(for: projectId)))
                     expect(miniAppClient.environment.appVersion).to(equal(bundle.value(for: versionKey)))
                     expect(miniAppClient.environment.subscriptionKey).to(equal(bundle.value(for: subscriptionKey)))

--- a/Tests/Unit/MiniAppClientTests.swift
+++ b/Tests/Unit/MiniAppClientTests.swift
@@ -248,7 +248,7 @@ class MiniAppClientTests: QuickSpec {
         }
         describe("override configuration at runtime") {
             let applicationIdentifierKey = "RASApplicationIdentifier"
-            let projectId = "RASApplicationIdentifier"
+            let projectId = "RASProjectId"
             let versionKey = "CFBundleShortVersionString"
             let subscriptionKey = "RASProjectSubscriptionKey"
             let endpointKey = "RMAAPIEndpoint"


### PR DESCRIPTION
# Description
* Updated sample app to use `RASProjectId` instead of `RASApplicationIdentifier`
* Updated `renamed` param for `@available` attribute

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
