### PR TITLE
MINI-2194 Settings saved values were not displayed

### DIFF
--- a/Example/Controllers/SettingsTableViewController.swift
+++ b/Example/Controllers/SettingsTableViewController.swift
@@ -10,7 +10,7 @@ class SettingsTableViewController: UITableViewController {
     @IBOutlet weak var invalidSubscriptionKeyLabel: UILabel!
     weak var configUpdateDelegate: SettingsDelegate?
 
-    let predefinedKeys: [String] = ["RAS_APPLICATION_IDENTIFIER", "RAS_SUBSCRIPTION_KEY", ""]
+    let predefinedKeys: [String] = ["RAS_PROJECT_IDENTIFIER", "RAS_SUBSCRIPTION_KEY", ""]
 
     enum SectionHeader: Int {
         case RAS = 1
@@ -19,7 +19,7 @@ class SettingsTableViewController: UITableViewController {
     }
     enum TestMode: Int, CaseIterable {
         case HOSTED,
-        PREVIEW
+             PREVIEW
 
         func stringValue() -> String {
             switch self {
@@ -75,11 +75,11 @@ class SettingsTableViewController: UITableViewController {
                 let isPreview = selectedMode?.isPreviewMode() ?? true
 
                 fetchAppList(withConfig:
-                        createConfig(
-                            projectId: self.textFieldAppID.text!,
-                            subscriptionKey: self.textFieldSubKey.text!,
-                            loadPreviewVersions: isPreview
-                        )
+                                createConfig(
+                                    projectId: self.textFieldAppID.text!,
+                                    subscriptionKey: self.textFieldSubKey.text!,
+                                    loadPreviewVersions: isPreview
+                                )
                 )
             }
             displayInvalidValueErrorMessage(forKey: .projectId)
@@ -125,8 +125,8 @@ class SettingsTableViewController: UITableViewController {
         self.saveMode()
 
         self.displayAlert(title: NSLocalizedString("message_save_title", comment: ""),
-            message: NSLocalizedString("message_save_text", comment: ""),
-            autoDismiss: true) { _ in
+                          message: NSLocalizedString("message_save_text", comment: ""),
+                          autoDismiss: true) { _ in
             self.dismiss(animated: true, completion: nil)
             guard let miniAppList = responseData else {
                 self.configUpdateDelegate?.didSettingsUpdated(controller: self, updated: nil)
@@ -172,11 +172,10 @@ class SettingsTableViewController: UITableViewController {
     }
 
     func getTextFieldValue(key: Config.Key, placeholderText: String?) -> String? {
-        if predefinedKeys.contains(placeholderText ?? "") {
-            return Config.userDefaults?.string(forKey: key.rawValue) ?? ""
-        } else {
+        guard let value = Config.userDefaults?.string(forKey: key.rawValue) else {
             return placeholderText
         }
+        return value
     }
 
     func toggleSaveButton() {
@@ -212,12 +211,12 @@ class SettingsTableViewController: UITableViewController {
         switch forKey {
         case .projectId:
             displayAlert(title: NSLocalizedString("error_title", comment: ""),
-                message: NSLocalizedString("error_incorrect_appid_message", comment: ""),
-                autoDismiss: true)
+                         message: NSLocalizedString("error_incorrect_appid_message", comment: ""),
+                         autoDismiss: true)
         case .subscriptionKey:
             displayAlert(title: NSLocalizedString("error_title", comment: ""),
-                message: NSLocalizedString("error_incorrect_subscription_key_message", comment: ""),
-                autoDismiss: false)
+                         message: NSLocalizedString("error_incorrect_subscription_key_message", comment: ""),
+                         autoDismiss: false)
         default:
             break
         }
@@ -226,12 +225,12 @@ class SettingsTableViewController: UITableViewController {
         switch forKey {
         case .projectId:
             displayAlert(title: NSLocalizedString("error_title", comment: ""),
-                message: NSLocalizedString("error_empty_appid_key_message", comment: ""),
-                autoDismiss: true)
+                         message: NSLocalizedString("error_empty_appid_key_message", comment: ""),
+                         autoDismiss: true)
         case .subscriptionKey:
             displayAlert(title: NSLocalizedString("error_title", comment: ""),
-                message: NSLocalizedString("error_empty_subscription_key_message", comment: ""),
-                autoDismiss: false)
+                         message: NSLocalizedString("error_empty_subscription_key_message", comment: ""),
+                         autoDismiss: false)
         default:
             break
         }


### PR DESCRIPTION
# Description
When saving project id or subscription key, if you launched the settings screen again default value taken from config file were displayed instead of saved values.

## Links
MINI-2194

# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
