### PR TITLE
fix: Remove root file name when creating mini app from URL

### DIFF
--- a/MiniApp/Classes/Display/MiniAppWebView.swift
+++ b/MiniApp/Classes/Display/MiniAppWebView.swift
@@ -22,7 +22,7 @@ internal class MiniAppWebView: WKWebView {
     }
 
     convenience init(miniAppURL: URL) {
-        let urlRequest = URLRequest(url: miniAppURL.appendingPathComponent(Constants.rootFileName))
+        let urlRequest = URLRequest(url: miniAppURL)
         self.init(frame: .zero, configuration: MiniAppWebView.defaultConfig())
         commonInit(urlRequest: urlRequest)
     }


### PR DESCRIPTION
# Description
This was causing issues if you entered a complete path with index.html such as https://www.example.com/index.html. Also, the remote server should be able to handle directing to the correct root html file.

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
