### PR TITLE
ci: Move CI scripts into local script files

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,2 +1,8 @@
 podspec: MiniApp.podspec
 documentation: "*.md"
+xcodebuild_arguments: -scheme,Tests
+module: MiniApp
+source-directory: MiniApp
+podspec: MiniApp.podspec
+theme: fullwidth
+readme: USERGUIDE.md

--- a/DEV.md
+++ b/DEV.md
@@ -54,16 +54,10 @@ If you need to test your SDK fork into your host app before making a pull reques
 ---
 
 You may want to generate the SDK documentation locally so that you can ensure that the generated docs look correct. 
-We use [Jazzy](https://github.com/realm/jazzy) for this, so you can run the following commands:
+We use [Jazzy](https://github.com/realm/jazzy) for this, so you can run the following command:
 
-```ruby
-bundle exec jazzy \
-  --xcodebuild-arguments -scheme,Tests \
-  --module MiniApp \
-  --source-directory MiniApp \
-  --podspec MiniApp.podspec \
-  --theme fullwidth \
-  --readme USERGUIDE.md
+```
+bundle exec jazzy
 ```
 
 The generated docs will be output to a folder named `docs` in the root of this repo.

--- a/appcenter-post-clone.sh
+++ b/appcenter-post-clone.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-

--- a/scripts/deploy-to-app-center.sh
+++ b/scripts/deploy-to-app-center.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -ex
+
+# Publish the Simulator App build to App Center.
+# You must set the following environment variables:
+# APP_CENTER_TOKEN
+# APP_CENTER_APP_NAME
+# APP_CENTER_GROUP
+# APP_CENTER_BUILD_VERSION
+
+echo "Creating ZIP file for Simulator build."
+zip -r ./artifacts/miniapp.app.zip ./artifacts/MiniApp_Example.app/*
+
+echo "Instaling App Center CLI."
+npm install -g appcenter-cli
+
+echo "Deploying Simulator App build to $APP_CENTER_GROUP group on App Center."
+appcenter distribute release \
+--token $APP_CENTER_TOKEN \
+--app $APP_CENTER_APP_NAME \
+--group $APP_CENTER_GROUP \
+--build-version $APP_CENTER_BUILD_VERSION \
+--file ./artifacts/miniapp.app.zip \
+--quiet

--- a/scripts/release-cocoapods.sh
+++ b/scripts/release-cocoapods.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -ex
+
+# Publishes the SDKs podspec to public CocoPods repo
+
+echo "Runing pod spec lint."
+bundle exec pod spec lint --allow-warnings
+
+echo "Pushing podspec to CocoaPods public repo."
+bundle exec pod trunk push --allow-warnings

--- a/scripts/release-docs.sh
+++ b/scripts/release-docs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -ex
+
+# Publishes SDK documentation to Github Pages for a Git tag ($RELEASE_TAG)
+
+# You must set the environent variable $RELEASE_GIT_REMOTE
+# It should be inclue a github token in the format:
+# https://{GITHUB_TOKEN}@github.com/{ORG}/{REPO}.git
+
+git fetch $RELEASE_GIT_REMOTE gh-pages:gh-pages --force
+git checkout -f gh-pages
+
+echo "Copying new docs to gh-pages branch."
+git rm -r '*'
+git add docs
+git mv docs/* ./ -k
+
+echo "Pushing docs for $RELEASE_TAG to gh-pages branch."
+git commit -m "Publish documentation for $RELEASE_TAG [ci skip]"
+git push $RELEASE_GIT_REMOTE gh-pages

--- a/scripts/release-prod-branch.sh
+++ b/scripts/release-prod-branch.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ex
+
+# Pushes a release tag ($RELEASE_TAG) to the "prod" branch in order to trigger a prod build on App Center
+
+# You must set the environent variable $RELEASE_GIT_REMOTE
+# It should be inclue a github token in the format:
+# https://{GITHUB_TOKEN}@github.com/{ORG}/{REPO}.git
+
+git fetch $RELEASE_GIT_REMOTE $RELEASE_TAG:prod --force
+git push $RELEASE_GIT_REMOTE prod --force


### PR DESCRIPTION
# Description
This allows us to more easily move between different CI services.

Also moved the jazzy doc settings into the local config file so docs can be generated by just running 'bundle excec jazzy'

## Links
MINI-2437

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
