### PR TITLE
Rename protocol `requestPermission` to `requestDevicePermission`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Feature** Added analytics for Mini App usage tracking
 - **Feature** Updated `getUserName` and `getProfilePhoto` interfaces to be asynchronous. Old methods are deprecated
 - **Feature** Updated `MiniApp().shared.create` interface to accept another optional query string parameter.
+- **Deprecated:** `requestPermission(permissionType:completionHandler:)` in `MiniAppMessageDelegate` protocol is deprecated. You should use `requestDevicePermission(permissionType:completionHandler:))` instead
 
 **Sample App**
 

--- a/Example/Controllers/Extensions/ViewController+MiniAppMessageProtocol.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniAppMessageProtocol.swift
@@ -4,7 +4,7 @@ import CoreLocation
 extension ViewController: MiniAppMessageDelegate, CLLocationManagerDelegate {
     typealias PermissionCompletionHandler = (((Result<MASDKPermissionResponse, MASDKPermissionError>)) -> Void)
 
-    func requestPermission(permissionType: MiniAppPermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
+    func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
         switch permissionType {
         case .location:
             let locStatus = CLLocationManager.authorizationStatus()

--- a/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -21,8 +21,10 @@ enum MiniAppSupportedSchemes: String {
     case about // used to reveal internal state and built-in functions (e.g.: alert dialog)
 }
 
+@available(*, deprecated, message: "enum renamed to MiniAppDevicePermissionType")
+public typealias MiniAppPermissionType = MiniAppDevicePermissionType
 /// List of Device Permissions supported by the SDK that can be requested by a Mini app
-public enum MiniAppPermissionType: String {
+public enum MiniAppDevicePermissionType: String {
     /// Device Location permission type. Host app is expected to implement the logic only for requesting the location permission.
     case location
 }

--- a/MiniApp/Classes/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -52,7 +52,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         case .getUniqueId:
             sendUniqueId(messageId: callbackId)
         case .requestPermission:
-            requestPermission(requestParam: requestParam, callbackId: callbackId)
+            requestDevicePermission(requestParam: requestParam, callbackId: callbackId)
         case .getCurrentPosition:
             locationManager = LocationManager(enableHighAccuracy: requestParam?.locationOptions?.enableHighAccuracy ?? false)
             getCurrentPosition(callbackId: callbackId)
@@ -81,12 +81,12 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         executeJavaScriptCallback(responseStatus: .onSuccess, messageId: messageId, response: uniqueId)
     }
 
-    func requestPermission(requestParam: RequestParameters?, callbackId: String) {
+    func requestDevicePermission(requestParam: RequestParameters?, callbackId: String) {
         guard let requestParamValue = requestParam?.permission else {
             executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.invalidPermissionType))
             return
         }
-        guard let requestPermissionType = MiniAppPermissionType(rawValue: requestParamValue) else {
+        guard let requestPermissionType = MiniAppDevicePermissionType(rawValue: requestParamValue) else {
             executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.invalidPermissionType))
             return
         }
@@ -97,8 +97,8 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         }
     }
 
-    func getPermissionResult(requestPermissionType: MiniAppPermissionType, callbackId: String) {
-        hostAppMessageDelegate?.requestPermission(permissionType: requestPermissionType) { (result) in
+    func getPermissionResult(requestPermissionType: MiniAppDevicePermissionType, callbackId: String) {
+        hostAppMessageDelegate?.requestDevicePermission(permissionType: requestPermissionType) { (result) in
             switch result {
             case .success(let responseMessage):
                 self.executeJavaScriptCallback(responseStatus: .onSuccess, messageId: callbackId, response: responseMessage.rawValue)

--- a/MiniApp/Classes/Protocols/MiniAppMessageDelegate.swift
+++ b/MiniApp/Classes/Protocols/MiniAppMessageDelegate.swift
@@ -62,6 +62,10 @@ public extension MiniAppMessageDelegate {
     func requestPermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
         requestDevicePermission(permissionType: permissionType, completionHandler: completionHandler)
     }
+
+    func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
+        completionHandler(.failure(.failedToConformToProtocol))
+    }
 }
 
 public enum MASDKProtocolResponse: String {

--- a/MiniApp/Classes/Protocols/MiniAppMessageDelegate.swift
+++ b/MiniApp/Classes/Protocols/MiniAppMessageDelegate.swift
@@ -60,11 +60,11 @@ public extension MiniAppMessageDelegate {
     }
 
     func requestPermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
-        requestDevicePermission(permissionType: permissionType, completionHandler: completionHandler)
+        completionHandler(.failure(.failedToConformToProtocol))
     }
 
     func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
-        completionHandler(.failure(.failedToConformToProtocol))
+        self.requestPermission(permissionType: permissionType, completionHandler: completionHandler)
     }
 }
 

--- a/MiniApp/Classes/Protocols/MiniAppMessageDelegate.swift
+++ b/MiniApp/Classes/Protocols/MiniAppMessageDelegate.swift
@@ -12,6 +12,13 @@ public protocol MiniAppMessageDelegate: MiniAppUserInfoDelegate, MiniAppShareCon
 
     /// Interface that should be implemented in the host app that handles the code to request any permission and the
     /// result (allowed/denied) should be returned.
+    func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void)
+
+    /// Interface that should be implemented in the host app that handles the code to request any permission and the
+    /// result (allowed/denied) should be returned.
+    @available(*, deprecated,
+        message: "Since version 2.8.0, this method is deprecated",
+        renamed: "requestDevicePermission(permissionType:completionHandler:)")
     func requestPermission(permissionType: MiniAppPermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void)
 
     /// Optional Interface that can be implemented in the host app to handle the Custom Permissions.
@@ -50,6 +57,10 @@ public extension MiniAppMessageDelegate {
         permissions: [MASDKCustomPermissionModel], completionHandler: @escaping (
             Result<[MASDKCustomPermissionModel], MASDKCustomPermissionError>) -> Void) {
         self.requestCustomPermissions(permissions: permissions, miniAppTitle: "Mini App", completionHandler: completionHandler)
+    }
+
+    func requestPermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
+        requestDevicePermission(permissionType: permissionType, completionHandler: completionHandler)
     }
 }
 

--- a/MiniApp/Classes/RealMiniApp.swift
+++ b/MiniApp/Classes/RealMiniApp.swift
@@ -200,7 +200,7 @@ extension RealMiniApp: MiniAppMessageDelegate {
         completionHandler(.failure(.failedToConformToProtocol))
     }
 
-    func requestPermission(permissionType: MiniAppPermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
+    func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
         completionHandler(.failure(.failedToConformToProtocol))
     }
 

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -239,9 +239,9 @@ class MockMessageInterfaceExtension: MiniAppMessageDelegate {
         let mockMessageInterface = MockMessageInterface()
         return mockMessageInterface.getUniqueId()
     }
-    func requestPermission(permissionType: MiniAppPermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
+    func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
         let mockMessageInterface = MockMessageInterface()
-        return mockMessageInterface.requestPermission(permissionType: permissionType, completionHandler: completionHandler)
+        return mockMessageInterface.requestDevicePermission(permissionType: permissionType, completionHandler: completionHandler)
     }
 }
 class MockMessageInterface: MiniAppMessageDelegate {
@@ -276,7 +276,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
         }
     }
 
-    func requestPermission(permissionType: MiniAppPermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
+    func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
         if locationAllowed {
             completionHandler(.success(.allowed))
         } else {

--- a/Tests/Unit/RealMiniAppTests+Permissions.swift
+++ b/Tests/Unit/RealMiniAppTests+Permissions.swift
@@ -10,7 +10,7 @@ class RealMiniAppPermissionTests: QuickSpec {
             context("when RealMiniApp class has no message interface method object and when requestPermission is called") {
                 it("will return error") {
                     var testError: MASDKPermissionError?
-                    realMiniApp.requestPermission(permissionType: MiniAppPermissionType.init(rawValue: "location")!) { (result) in
+                    realMiniApp.requestDevicePermission(permissionType: MiniAppDevicePermissionType.init(rawValue: "location")!) { (result) in
                         switch result {
                         case .success:
                             break

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -119,7 +119,7 @@ Mini App SDK provides default implementation for few interfaces in `MiniAppMessa
 | Method                       | Default  |
 | :----                        | :----:   |
 | getUniqueId                  | 🚫       |
-| requestPermission            | 🚫       |
+| requestDevicePermission      | 🚫       |
 | requestCustomPermissions     | ✅       |
 | shareContent                 | ✅       |
 | getUserName                  | 🚫       |
@@ -153,7 +153,7 @@ extension ViewController: MiniAppMessageDelegate {
 
 ```swift
 extension ViewController: MiniAppMessageDelegate {
-    func requestPermission(permissionType: MiniAppPermissionType, completionHandler: @escaping (Result<String, Error>) -> Void) {
+    func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<String, Error>) -> Void) {
         switch permissionType {
         case .location:
             let locStatus = CLLocationManager.authorizationStatus()


### PR DESCRIPTION
# Description

- Rename `MiniAppScriptMessageHandler.requestPermission` to `requestDevicePermission`
- Rename `MiniAppPermissionType` to `MiniAppDevicePermissionType` 

## Links
[MINI-2119](https://jira.rakuten-it.com/jira/browse/MINI-2119)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
