### PR TITLE
build: Append build type to demo app version

### DIFF
--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>$(MARKETING_VERSION)$(RMA_DEMO_APP_BUILD_TYPE)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 use_frameworks!
 
 sdk_name = "MiniApp"
-secrets = ["RMA_API_ENDPOINT", "RAS_PROJECT_SUBSCRIPTION_KEY", "RAS_PROJECT_IDENTIFIER"]
+secrets = ["RMA_API_ENDPOINT", "RAS_PROJECT_SUBSCRIPTION_KEY", "RAS_PROJECT_IDENTIFIER", "RMA_DEMO_APP_BUILD_TYPE"]
 
 platform :ios, '11.0'
 target sdk_name + '_Example' do

--- a/configure-secrets.sh
+++ b/configure-secrets.sh
@@ -68,12 +68,13 @@ do
     >&2 echo "➜ ${BOLD}$var_name${NOCOLOR} ${stars// /*} ${RED}ERROR!${NOCOLOR} Missing environment variable ${BOLD}$var_name${NOCOLOR}."
     success=false
   else
-      echo "➜ ${BOLD}$var_name${NOCOLOR} ${stars// /*} ${GREEN}OK${NOCOLOR}"
+    secureDoubleSlashForXCConfig $value
+    # Set secrets from environment variables
+    cmd='echo "${var_name} = ${SECURE_DOUBLE_SLASH_FOR_XCCONFIG_RESULT:=${var_name}}"'
+    eval ${cmd} >> $SECRETS_FILE
+
+    echo "➜ ${BOLD}$var_name${NOCOLOR} ${stars// /*} ${GREEN}OK${NOCOLOR}"
   fi
-  secureDoubleSlashForXCConfig $value
-  # Set secrets from environment variables
-  cmd='echo "${var_name} = ${SECURE_DOUBLE_SLASH_FOR_XCCONFIG_RESULT:=${var_name}}"'
-  eval ${cmd} >> $SECRETS_FILE
 done
 
 if [ $success = false ] ; then


### PR DESCRIPTION
# Description
This will be used by CI when creating staging or release candidate builds so that we can see the build type in the version name. i.e. X.X.X-STG or X.X.X-RC

Also modified the configure-secrets script so that it won't output missing environment variables to the secrets file. This is needed becuase normal production builds should not have anything appended to the version name. i.e. production builds should be just X.X.X

## Links
MINI-2245

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
