### PR TITLE
Fix failing async unit tests

### DIFF
--- a/MiniApp/Classes/Display/RealMiniAppView.swift
+++ b/MiniApp/Classes/Display/RealMiniAppView.swift
@@ -187,6 +187,10 @@ internal class RealMiniAppView: UIView {
         }
         decisionHandler(.cancel)
     }
+
+    internal func presentAlert(alertController: UIAlertController) {
+        UIApplication.topViewController()?.present(alertController, animated: true, completion: nil)
+    }
 }
 
 extension RealMiniAppView: MiniAppDisplayProtocol {

--- a/MiniApp/Classes/Extensions/RealMiniAppView+WKUIDelegate.swift
+++ b/MiniApp/Classes/Extensions/RealMiniAppView+WKUIDelegate.swift
@@ -10,7 +10,7 @@ extension RealMiniAppView: WKUIDelegate {
             completionHandler()
         })
         currentDialogController = alertController
-        UIApplication.topViewController()?.present(alertController, animated: true, completion: nil)
+        presentAlert(alertController: alertController)
     }
 
     func webView(_ webView: WKWebView,
@@ -25,7 +25,7 @@ extension RealMiniAppView: WKUIDelegate {
             completionHandler(false)
         }))
         currentDialogController = alertController
-        UIApplication.topViewController()?.present(alertController, animated: true, completion: nil)
+        presentAlert(alertController: alertController)
     }
 
     func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String,
@@ -47,6 +47,6 @@ extension RealMiniAppView: WKUIDelegate {
             completionHandler(nil)
         }))
         currentDialogController = alertController
-        UIApplication.topViewController()?.present(alertController, animated: true, completion: nil)
+        presentAlert(alertController: alertController)
     }
 }

--- a/Tests/Unit/RealMiniAppView+Mock.swift
+++ b/Tests/Unit/RealMiniAppView+Mock.swift
@@ -3,85 +3,25 @@ import WebKit
 
 class MockRealMiniAppView: RealMiniAppView {
     enum DialogButton {
-        case okButton, cancelButton, okWithText
+        case okButton, cancelButton
     }
 
-    var currentHandler: Any?
-    var dialogTitle, dialogMessage, dialogTextFieldText, okText, cancelText: String?
+    var alertController: UIAlertController?
+
+    override internal func presentAlert(alertController: UIAlertController) {
+        self.alertController = alertController
+    }
 
     func tapButton(_ button: DialogButton?) {
-        if let title = button == .cancelButton ? cancelText : okText {
+        if let title = button == .cancelButton ? "Cancel" : "OK" {
             tapAlertButton(title: title, actions: currentDialogController?.actions)
-        } else {
-            if button == .okWithText, let handler = currentHandler as? ((String?) -> Void) {
-                handler("dummText")
-            } else if let handler = currentHandler as? ((Bool?) -> Void) {
-                handler(button == .cancelButton ? false : true)
-            } else {
-                (currentHandler as? (() -> Void))?()
-            }
         }
-    }
-
-    override func webView(_ webView: WKWebView,
-                          runJavaScriptAlertPanelWithMessage message: String,
-                          initiatedByFrame frame: WKFrameInfo,
-                          completionHandler: @escaping () -> Void) {
-        super.webView(webView,
-                      runJavaScriptAlertPanelWithMessage: message,
-                      initiatedByFrame: frame,
-                      completionHandler: completionHandler)
-        populateVariables(dialogTitle: self.miniAppTitle,
-                          dialogMessage: message,
-                          okText: "Ok_title".localizedString())
-        self.currentHandler = completionHandler
-    }
-
-    override func webView(_ webView: WKWebView,
-                          runJavaScriptConfirmPanelWithMessage message: String,
-                          initiatedByFrame frame: WKFrameInfo,
-                          completionHandler: @escaping (Bool) -> Void) {
-        super.webView(webView,
-                      runJavaScriptConfirmPanelWithMessage: message,
-                      initiatedByFrame: frame,
-                      completionHandler: completionHandler)
-        populateVariables(dialogTitle: self.miniAppTitle,
-                          dialogMessage: message,
-                          okText: "Ok_title".localizedString(),
-                          cancelText: "Cancel_title".localizedString())
-        self.currentHandler = completionHandler
-    }
-
-    override func webView(_ webView: WKWebView,
-                          runJavaScriptTextInputPanelWithPrompt prompt: String,
-                          defaultText: String?,
-                          initiatedByFrame frame: WKFrameInfo,
-                          completionHandler: @escaping (String?) -> Void) {
-        super.webView(webView, runJavaScriptTextInputPanelWithPrompt: prompt, defaultText: defaultText, initiatedByFrame: frame, completionHandler: completionHandler)
-        populateVariables(dialogTitle: self.miniAppTitle,
-                          dialogMessage: prompt,
-                          okText: "Ok_title".localizedString(),
-                          cancelText: "Cancel_title".localizedString(),
-                          dialogTextFieldText: defaultText)
-        self.currentHandler = completionHandler
-    }
-
-    func populateVariables(dialogTitle: String? = nil,
-                           dialogMessage: String? = nil,
-                           okText: String? = nil,
-                           cancelText: String? = nil,
-                           dialogTextFieldText: String? = nil) {
-        self.dialogTitle = dialogTitle
-        self.dialogMessage = dialogMessage
-        self.dialogTextFieldText = dialogTextFieldText
-        self.okText = okText
-        self.cancelText = cancelText
     }
 
     func tapAlertButton(title: String, actions: [UIAlertAction]?) {
         typealias AlertHandler = @convention(block) (UIAlertAction) -> Void
 
-        guard let action = actions?.first(where: { $0.title == title }), let block = action.value(forKey: "handler") else { return }
+        guard let action = alertController?.actions.first(where: { $0.title == title }), let block = action.value(forKey: "handler") else { return }
         let handler = unsafeBitCast(block as AnyObject, to: AlertHandler.self)
         handler(action)
     }

--- a/Tests/Unit/RealMiniAppViewTests.swift
+++ b/Tests/Unit/RealMiniAppViewTests.swift
@@ -48,139 +48,121 @@ class RealMiniAppViewTests: QuickSpec {
             }
         }
         describe("WKUIDelegate") {
-            let mockMessageInterface = MockMessageInterface()
-            let miniAppView = MockRealMiniAppView(
-                miniAppId: "miniappid-testing",
-                versionId: "version-id",
-                projectId: "project-id",
-                miniAppTitle: "Mini app title",
-                hostAppMessageDelegate: mockMessageInterface)
-
+            func createMiniAppView() -> MockRealMiniAppView {
+                return MockRealMiniAppView(
+                    miniAppId: "miniappid-testing",
+                    versionId: "version-id",
+                    projectId: "project-id",
+                    miniAppTitle: "Mini app title",
+                    hostAppMessageDelegate: MockMessageInterface())
+            }
             context("when webview is loaded with alert javascript dialog") {
-                it("will show native alert with request message, ok with no crash") {
-                    let html = """
-                    <html>
-                    <body>
-                    <script>
-                    alert("mini-app-alert")
-                    </script>
-                    </body>
-                    </html>
-                    """
-                    miniAppView.webView.loadHTMLString(html, baseURL: nil)
-                    expect(miniAppView.okText).toEventually(equal("OK"), timeout: .seconds(30))
-                    expect(miniAppView.dialogMessage).toEventually(equal("mini-app-alert"), timeout: .seconds(30))
+                it("will show native alert with request message") {
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptAlertPanelWithMessage: "mini-app-alert",
+                                        initiatedByFrame: WKFrameInfo(), completionHandler: {})
+
+                    expect(miniAppView.alertController?.message).to(equal("mini-app-alert"))
+                    expect(miniAppView.alertController?.actions[0].title).to(equal("OK"))
                     miniAppView.tapButton(.okButton)
                 }
-            }
-        }
-        describe("WKUIDelegate") {
-            let mockMessageInterface = MockMessageInterface()
-            let miniAppView = MockRealMiniAppView(
-                miniAppId: "miniappid-testing",
-                versionId: "version-id",
-                projectId: "project-id",
-                miniAppTitle: "Mini app title",
-                hostAppMessageDelegate: mockMessageInterface)
-            context("when webview is loaded with confirm javascript dialog") {
-                it("will show native alert with request message, ok and cancel button, ok don't crash") {
-                    let html = """
-                    <html>
-                    <body>
-                    <script>
-                    confirm("mini-app-confirm")
-                    </script>
-                    </body>
-                    </html>
-                    """
-                    miniAppView.webView.loadHTMLString(html, baseURL: nil)
-                    expect(miniAppView.okText).toEventually(equal("OK"), timeout: .seconds(30))
-                    expect(miniAppView.cancelText).toEventually(equal("Cancel"), timeout: .seconds(30))
-                    expect(miniAppView.dialogMessage).toEventually(equal("mini-app-confirm"), timeout: .seconds(30))
+                it("will call completion handler when OK is tapped") {
+                    var okTapped = false
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptAlertPanelWithMessage: "mini-app-alert",
+                                        initiatedByFrame: WKFrameInfo(), completionHandler: { okTapped = true })
+
                     miniAppView.tapButton(.okButton)
+                    expect(okTapped).toEventually(beTrue())
                 }
             }
-        }
-        describe("WKUIDelegate") {
-            let mockMessageInterface = MockMessageInterface()
-            let miniAppView = MockRealMiniAppView(
-                miniAppId: "miniappid-testing",
-                versionId: "version-id",
-                projectId: "project-id",
-                miniAppTitle: "Mini app title",
-                hostAppMessageDelegate: mockMessageInterface)
             context("when webview is loaded with confirm javascript dialog") {
-                it("will show native alert with request message, ok and cancel button, cancel don't crash") {
-                    let html = """
-                    <html>
-                    <body>
-                    <script>
-                    confirm("mini-app-confirm")
-                    </script>
-                    </body>
-                    </html>
-                    """
-                    miniAppView.webView.loadHTMLString(html, baseURL: nil)
-                    expect(miniAppView.okText).toEventually(equal("OK"), timeout: .seconds(30))
-                    expect(miniAppView.cancelText).toEventually(equal("Cancel"), timeout: .seconds(30))
-                    expect(miniAppView.dialogMessage).toEventually(equal("mini-app-confirm"), timeout: .seconds(30))
+                it("will show native alert with request message, ok and cancel button") {
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptConfirmPanelWithMessage: "mini-app-confirm",
+                                        initiatedByFrame: WKFrameInfo(), completionHandler: {(_) in })
+
+                    expect(miniAppView.alertController?.message).to(equal("mini-app-confirm"))
+                    expect(miniAppView.alertController?.actions[0].title).to(equal("OK"))
+                    expect(miniAppView.alertController?.actions[1].title).to(equal("Cancel"))
+                }
+                it("will return true to completion handler when OK button is tapped") {
+                    var confirm = false
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptConfirmPanelWithMessage: "mini-app-confirm",
+                                        initiatedByFrame: WKFrameInfo(), completionHandler: {(status) in
+                                            confirm = status
+                                        })
+
+                    miniAppView.tapButton(.okButton)
+                    expect(confirm).toEventually(beTrue())
+                }
+                it("will show native alert with request message, ok and cancel button") {
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptConfirmPanelWithMessage: "mini-app-confirm",
+                                        initiatedByFrame: WKFrameInfo(), completionHandler: {(_) in })
+
+                    expect(miniAppView.alertController).toEventuallyNot(beNil(), timeout: .seconds(10))
+                    expect(miniAppView.alertController?.message).to(equal("mini-app-confirm"))
+                    expect(miniAppView.alertController?.actions[0].title).to(equal("OK"))
+                    expect(miniAppView.alertController?.actions[1].title).to(equal("Cancel"))
+                }
+                it("will return false to completion handler when Cancel button is tapped") {
+                    var confirm = true
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptConfirmPanelWithMessage: "mini-app-confirm",
+                                        initiatedByFrame: WKFrameInfo(), completionHandler: {(status) in
+                                            confirm = status
+                                        })
+
                     miniAppView.tapButton(.cancelButton)
+                    expect(confirm).toEventually(beFalse())
                 }
             }
-        }
-        describe("WKUIDelegate") {
-                let mockMessageInterface = MockMessageInterface()
-                let miniAppView = MockRealMiniAppView(
-                    miniAppId: "miniappid-testing",
-                    versionId: "version-id",
-                    projectId: "project-id",
-                    miniAppTitle: "Mini app title",
-                    hostAppMessageDelegate: mockMessageInterface)
             context("when webview is loaded with prompt javascript dialog") {
-                it("will show native alert with request message and wanted text in textfield, ok will transmit text with no crash") {
-                    let html = """
-                    <html>
-                    <body>
-                    <script>
-                    prompt("Please enter your name:", "Rakuten Mini app");
-                    </script>
-                    </body>
-                    </html>
-                    """
-                    miniAppView.webView.loadHTMLString(html, baseURL: nil)
-                    expect(miniAppView.okText).toEventually(equal("OK"), timeout: .seconds(30))
-                    expect(miniAppView.cancelText).toEventually(equal("Cancel"), timeout: .seconds(30))
-                    expect(miniAppView.dialogMessage).toEventually(equal("Please enter your name:"), timeout: .seconds(30))
-                    expect(miniAppView.dialogTextFieldText).toEventually(equal("Rakuten Mini app"), timeout: .seconds(30))
-                    miniAppView.tapButton(.okButton)
+                it("will show native alert with request message and wanted text in textfield") {
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptTextInputPanelWithPrompt: "Please enter your name:",
+                                        defaultText: "Rakuten Mini app", initiatedByFrame: WKFrameInfo(), completionHandler: {(_) in })
+
+                    expect(miniAppView.alertController).toEventuallyNot(beNil(), timeout: .seconds(10))
+                    expect(miniAppView.alertController?.actions[0].title).to(equal("OK"))
+                    expect(miniAppView.alertController?.actions[1].title).to(equal("Cancel"))
+                    expect(miniAppView.alertController?.message).to(equal("Please enter your name:"))
+                    expect(miniAppView.alertController?.textFields?.first?.text).to(equal("Rakuten Mini app"))
                 }
-            }
-            describe("WKUIDelegate") {
-                let mockMessageInterface = MockMessageInterface()
-                let miniAppView = MockRealMiniAppView(
-                    miniAppId: "miniappid-testing",
-                    versionId: "version-id",
-                    projectId: "project-id",
-                    miniAppTitle: "Mini app title",
-                    hostAppMessageDelegate: mockMessageInterface)
-                context("when webview is loaded with prompt javascript dialog") {
-                    it("will show native alert with request message and wanted no in textfield, cancel won't crash") {
-                        let html = """
-                    <html>
-                    <body>
-                    <script>
-                    prompt("Please enter your name:", "");
-                    </script>
-                    </body>
-                    </html>
-                    """
-                        miniAppView.webView.loadHTMLString(html, baseURL: nil)
-                        expect(miniAppView.okText).toEventually(equal("OK"), timeout: .seconds(30))
-                        expect(miniAppView.cancelText).toEventually(equal("Cancel"), timeout: .seconds(30))
-                        expect(miniAppView.dialogMessage).toEventually(equal("Please enter your name:"), timeout: .seconds(30))
-                        expect(miniAppView.dialogTextFieldText).toEventually(equal(""), timeout: .seconds(30))
-                        miniAppView.tapButton(.cancelButton)
-                    }
+                it("will return text field value to completion hanlder when OK button is tapped") {
+                    var userInput: String?
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptTextInputPanelWithPrompt: "Please enter your name:",
+                                        defaultText: "Rakuten Mini app", initiatedByFrame: WKFrameInfo(), completionHandler: {(value) in
+                                            userInput = value
+                                        })
+
+                    miniAppView.tapButton(.okButton)
+                    expect(userInput).toEventually(equal("Rakuten Mini app"))
+                }
+                it("will show native alert with request message and wanted no in textfield") {
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptTextInputPanelWithPrompt: "Please enter your name:",
+                                        defaultText: "", initiatedByFrame: WKFrameInfo(), completionHandler: {(_) in })
+
+                    expect(miniAppView.alertController).toEventuallyNot(beNil(), timeout: .seconds(10))
+                    expect(miniAppView.alertController?.actions[0].title).to(equal("OK"))
+                    expect(miniAppView.alertController?.actions[1].title).to(equal("Cancel"))
+                    expect(miniAppView.alertController?.message).to(equal("Please enter your name:"))
+                    expect(miniAppView.alertController?.textFields?.first?.text).to(equal(""))
+                }
+                it("will return nil to completion handler when Cancel button is tapped") {
+                    var userInput: String? = "fake-text"
+                    let miniAppView = createMiniAppView()
+                    miniAppView.webView(miniAppView.webView, runJavaScriptTextInputPanelWithPrompt: "Please enter your name:",
+                                        defaultText: "", initiatedByFrame: WKFrameInfo(), completionHandler: {(value) in
+                                            userInput = value
+                                        })
+
+                    miniAppView.tapButton(.cancelButton)
+                    expect(userInput).toEventually(beNil())
                 }
             }
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ platform :ios do
       clean: true,
       output_directory: './artifacts/unit-tests',
       scheme: 'MiniApp_Tests',
-      device: 'iPhone X',
+      device: 'iPhone 11 Pro Max',
       code_coverage: true,
       output_types: 'json-compilation-database,html,junit',
       output_files: 'compile_commands.json,report.html,report.junit')


### PR DESCRIPTION
# Description
This fixes the intermittently failing unit tests for javascript dialogs. I have updated the tests so that they don't depend on the real UI. I think these tests still cover the same functionality as the old ones.

I'm still seeing a different test failing sometimes, but I'm not sure how to fix it:
`old_mini_app_folder_will_be_deleted__when_manifest_returns_list_of_valid_URLs__will_download_all_files_and_remove_previous_mini_app_path`

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
