### PR TITLE
URL query param encoding refactor

### DIFF
--- a/MiniApp/Classes/Display/MiniAppWebView.swift
+++ b/MiniApp/Classes/Display/MiniAppWebView.swift
@@ -22,7 +22,8 @@ internal class MiniAppWebView: WKWebView {
     }
 
     convenience init(miniAppURL: URL, queryParams: String? = nil) {
-        let urlRequest = URLRequest(url: miniAppURL)
+        let urlWithQueryParam = miniAppURL.appendingPathComponent(MiniAppWebView.getQueryParams(queryParams: queryParams))
+        let urlRequest = URLRequest(url: urlWithQueryParam)
         self.init(frame: .zero, configuration: MiniAppWebView.defaultConfig())
         commonInit(urlRequest: urlRequest)
     }

--- a/MiniApp/Classes/Extensions/String+MiniApp.swift
+++ b/MiniApp/Classes/Extensions/String+MiniApp.swift
@@ -25,17 +25,18 @@ extension String {
     }
 
     func encodeURLParam() -> String? {
-        var characterSet = CharacterSet.urlAllowed
-        characterSet.insert(charactersIn: "#?")
-        return addingPercentEncoding(withAllowedCharacters: characterSet)
+        let skipEncodingChar = "?=&@"
+        let allowed = NSMutableCharacterSet.alphanumeric()
+        allowed.addCharacters(in: skipEncodingChar)
+        let encodedString = addingPercentEncoding(withAllowedCharacters: allowed as CharacterSet)
+        return encodedString?.replaceFirst(of: "%23", with: "#")
     }
-}
 
-extension CharacterSet {
-    static let urlAllowed = CharacterSet.urlFragmentAllowed
-        .union(.urlHostAllowed)
-        .union(.urlPasswordAllowed)
-        .union(.urlQueryAllowed)
-        .union(.urlUserAllowed)
-        .union(.alphanumerics)
+    func replaceFirst(of searchString: String, with replacementString: String) -> String {
+        if let range = self.range(of: searchString) {
+            return self.replacingCharacters(in: range, with: replacementString)
+        } else {
+            return self
+        }
+    }
 }

--- a/MiniApp/Classes/Extensions/String+MiniApp.swift
+++ b/MiniApp/Classes/Extensions/String+MiniApp.swift
@@ -25,10 +25,9 @@ extension String {
     }
 
     func encodeURLParam() -> String? {
-        let skipEncodingChar = "?=&@"
-        let allowed = NSMutableCharacterSet.alphanumeric()
-        allowed.addCharacters(in: skipEncodingChar)
-        let encodedString = addingPercentEncoding(withAllowedCharacters: allowed as CharacterSet)
+        var characterSet = CharacterSet.urlAllowed
+        characterSet.insert(charactersIn: "?=&@")
+        let encodedString = addingPercentEncoding(withAllowedCharacters: characterSet)
         return encodedString?.replaceFirst(of: "%23", with: "#")
     }
 
@@ -39,4 +38,14 @@ extension String {
             return self
         }
     }
+}
+
+extension CharacterSet {
+    static let urlAllowed = CharacterSet.urlFragmentAllowed
+        .union(.urlHostAllowed)
+        .union(.urlPasswordAllowed)
+        .union(.urlQueryAllowed)
+        .union(.urlUserAllowed)
+        .union(.urlPathAllowed)
+        .union(.alphanumerics)
 }


### PR DESCRIPTION
# Description
* Added fix to enable more than one `#` to be included in the query param
* Updated the code to use Query Param in load by URL init method as well.


# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
