### PR TITLE
build: Use fixed version of Fastlane and XCov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem "cocoapods", "~>1.9"
-gem "xcov"
+gem "xcov", "1.7.3"
 gem "danger"
-gem "danger-xcov"
+gem "danger-xcov", "0.5.0"
 gem "jazzy"
 gem "xcode-install"
-gem "fastlane"
+gem "fastlane", "2.171.0"

--- a/Tests/Unit/RealMiniAppViewTests.swift
+++ b/Tests/Unit/RealMiniAppViewTests.swift
@@ -64,7 +64,6 @@ class RealMiniAppViewTests: QuickSpec {
 
                     expect(miniAppView.alertController?.message).to(equal("mini-app-alert"))
                     expect(miniAppView.alertController?.actions[0].title).to(equal("OK"))
-                    miniAppView.tapButton(.okButton)
                 }
                 it("will call completion handler when OK is tapped") {
                     var okTapped = false


### PR DESCRIPTION
# Description
The latest version of Fastlane (v2.172.0) is incompatible with the current version of Xcov and is causing CI builds to fail. See issue here: https://github.com/fastlane-community/xcov/issues/189

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
