### PR TITLE
ci: Update to fastlane 2.174.0 and xcov 1.7.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem "cocoapods", "~>1.9"
-gem "xcov", "1.7.3"
-gem "danger"
+gem "xcov", "1.7.5"
+gem "danger", "8.2.2"
 gem "danger-xcov", "0.5.0"
-gem "jazzy"
-gem "xcode-install"
-gem "fastlane", "2.171.0"
+gem "jazzy", "0.13.6"
+gem "xcode-install", "2.6.8"
+gem "fastlane", "2.174.0"


### PR DESCRIPTION
# Description
The previous incompatibility issue with fastlane/xcov (see https://github.com/rakutentech/ios-miniapp/pull/209) has been resolved so we can update these dependencies now.

Also set Danger, Jazzy, and xcode-install to fixed versions

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
