### PR TITLE
Refactor/remove rsdk utils

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        AppCenter.start(withAppSecret: Bundle.main.value(forKey: "AppCenterSecret") as? String, services: [Crashes.self])
+        AppCenter.start(withAppSecret: Bundle.main.value(for: "AppCenterSecret"), services: [Crashes.self])
         self.window?.tintColor = #colorLiteral(red: 0.7472071648, green: 0, blue: 0, alpha: 1)
         GADMobileAds.sharedInstance().start(completionHandler: nil)
         return true

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        AppCenter.start(withAppSecret: Bundle.main.value(for: "AppCenterSecret"), services: [Crashes.self])
+        AppCenter.start(withAppSecret: Bundle.main.value(forKey: "AppCenterSecret") as? String, services: [Crashes.self])
         self.window?.tintColor = #colorLiteral(red: 0.7472071648, green: 0, blue: 0, alpha: 1)
         GADMobileAds.sharedInstance().start(completionHandler: nil)
         return true

--- a/Example/Utils/Bundle+MiniApp.swift
+++ b/Example/Utils/Bundle+MiniApp.swift
@@ -1,0 +1,12 @@
+import Foundation
+import UIKit
+
+extension Bundle {
+    var valueNotFound: String {
+        return ""
+    }
+
+    func value(for key: String) -> String? {
+        return self.object(forInfoDictionaryKey: key) as? String
+    }
+}

--- a/MiniApp.podspec
+++ b/MiniApp.podspec
@@ -29,7 +29,6 @@ Pod::Spec.new do |s|
         "Localization" => ["MiniApp/*.lproj/*.strings"],
         "MiniApp" => ['MiniApp/Classes/core/**/*.{xcassets,js,pdf,xib}','js-miniapp/bridge.js']
     }
-    core.dependency 'RSDKUtils', '>= 1.1.0'
     core.dependency 'ZIPFoundation'
   end
 

--- a/MiniApp.xcodeproj/project.pbxproj
+++ b/MiniApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		38480100251DB4E00079D6EB /* CustomPermissionsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384800FE251DB4E00079D6EB /* CustomPermissionsListViewController.swift */; };
 		38480101251DB4E00079D6EB /* ManageCustomPermissionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384800FF251DB4E00079D6EB /* ManageCustomPermissionsViewController.swift */; };
 		3850AE722434E02D0046978C /* RealMiniAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3850AE712434E02D0046978C /* RealMiniAppTests.swift */; };
+		3857ED7E25DEE0690083F3E1 /* Bundle+MiniApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3857ED7D25DEE0690083F3E1 /* Bundle+MiniApp.swift */; };
 		385C25CA23F2E8BA00D61206 /* DisplayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385C25C923F2E8BA00D61206 /* DisplayerTests.swift */; };
 		385C25D023F3991C00D61206 /* RealMiniAppViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385C25CF23F3991C00D61206 /* RealMiniAppViewTests.swift */; };
 		3862EFA823EA5752004D518C /* MiniApp+URLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3862EFA723EA5752004D518C /* MiniApp+URLRequestTests.swift */; };
@@ -114,6 +115,7 @@
 		384800FE251DB4E00079D6EB /* CustomPermissionsListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomPermissionsListViewController.swift; sourceTree = "<group>"; };
 		384800FF251DB4E00079D6EB /* ManageCustomPermissionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageCustomPermissionsViewController.swift; sourceTree = "<group>"; };
 		3850AE712434E02D0046978C /* RealMiniAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealMiniAppTests.swift; sourceTree = "<group>"; };
+		3857ED7D25DEE0690083F3E1 /* Bundle+MiniApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+MiniApp.swift"; sourceTree = "<group>"; };
 		385C25C923F2E8BA00D61206 /* DisplayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayerTests.swift; sourceTree = "<group>"; };
 		385C25CF23F3991C00D61206 /* RealMiniAppViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealMiniAppViewTests.swift; sourceTree = "<group>"; };
 		3862EFA723EA5752004D518C /* MiniApp+URLRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MiniApp+URLRequestTests.swift"; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				38920AD2251D9C57004C5DDD /* UIViewController+MiniApp.swift */,
 				38920AD3251D9C57004C5DDD /* MiniApp+UIImage.swift */,
 				38CEFA5025C0A3CA00EE250A /* UIView+MiniApp.swift */,
+				3857ED7D25DEE0690083F3E1 /* Bundle+MiniApp.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -602,6 +605,7 @@
 				38920AF6251D9C57004C5DDD /* Array+MiniApp.swift in Sources */,
 				38920AF7251D9C57004C5DDD /* Config.swift in Sources */,
 				38920B06251D9C57004C5DDD /* UserSettingsTableViewController.swift in Sources */,
+				3857ED7E25DEE0690083F3E1 /* Bundle+MiniApp.swift in Sources */,
 				38920AF2251D9C57004C5DDD /* ImageCache.swift in Sources */,
 				38920B03251D9C57004C5DDD /* ViewController.swift in Sources */,
 				38920B0A251D9C57004C5DDD /* ViewController+MiniAppMessageProtocol.swift in Sources */,

--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -17,7 +17,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     var miniAppTitle: String
     var userAlreadyRespondedRequestList = [MASDKCustomPermissionModel]()
     var cachedUnknownCustomPermissionRequest = [MiniAppCustomPermissionsListResponse]()
-    var miniAppKeyStore = MiniAppKeyChain()
+    var miniAppKeyStore = MiniAppPermissionsStorage()
 
     init(delegate: MiniAppCallbackDelegate, hostAppMessageDelegate: MiniAppMessageDelegate, adsDisplayer: MiniAppAdDisplayer?, miniAppId: String, miniAppTitle: String) {
         self.delegate = delegate

--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -5,7 +5,7 @@ internal class RealMiniApp {
     var manifestDownloader: ManifestDownloader
     var displayer: Displayer
     var miniAppStatus: MiniAppStatus
-    var miniAppKeyStore: MiniAppKeyChain
+    var miniAppPermissionStorage: MiniAppPermissionsStorage
     let offlineErrorCodeList: [Int] = [NSURLErrorNotConnectedToInternet, NSURLErrorTimedOut]
 
     convenience init() {
@@ -21,7 +21,7 @@ internal class RealMiniApp {
                                            isPreviewMode: settings?.isPreviewMode)
         self.manifestDownloader = ManifestDownloader()
         self.miniAppStatus = MiniAppStatus()
-        self.miniAppKeyStore = MiniAppKeyChain()
+        self.miniAppPermissionStorage = MiniAppPermissionsStorage()
         self.miniAppDownloader = MiniAppDownloader(apiClient: self.miniAppClient, manifestDownloader: self.manifestDownloader, status: self.miniAppStatus)
         self.displayer = Displayer(navigationSettings)
     }
@@ -173,11 +173,11 @@ internal class RealMiniApp {
     }
 
     func retrieveCustomPermissions(forMiniApp id: String) -> [MASDKCustomPermissionModel] {
-        miniAppKeyStore.getCustomPermissions(forMiniApp: id)
+        miniAppPermissionStorage.getCustomPermissions(forMiniApp: id)
     }
 
     func storeCustomPermissions(forMiniApp id: String, permissionList: [MASDKCustomPermissionModel]) {
-        miniAppKeyStore.storeCustomPermissions(permissions: permissionList, forMiniApp: id)
+        miniAppPermissionStorage.storeCustomPermissions(permissions: permissionList, forMiniApp: id)
     }
 
     func getDownloadedListWithCustomPermissions() -> MASDKDownloadedListPermissionsPair {

--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -184,8 +184,7 @@ internal class RealMiniApp {
         miniAppStatus.getMiniAppsListWithCustomPermissionsInfo() ?? []
     }
 
-    func createCompletionHandler<T>(completionHandler: @escaping (Result<T, MASDKError>) -> Void) -> (Result<T, Error>) -> Void {
-        { (result) in
+    func createCompletionHandler<T>(completionHandler: @escaping (Result<T, MASDKError>) -> Void) -> (Result<T, Error>) -> Void { { (result) in
             switch result {
             case .success(let responseData):
                 completionHandler(.success(responseData))

--- a/MiniApp/Classes/core/Storage/MiniAppCacheVerifier.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppCacheVerifier.swift
@@ -1,19 +1,18 @@
 import CommonCrypto
-import RSDKUtils
 
 internal class MiniAppCacheVerifier {
-    let keystore = KeyStore()
+    let keystore = MiniAppKeyChain(serviceName: .cacheVerifier)
 
     private func generateKeyId(for appId: String, version: String) -> String {
         "\(appId) | \(version)"
     }
 
     func verify(appId: String, version: String) -> Bool {
-        if keystore.key(for: appId) != nil {
+        if keystore.getCacheInfo(for: appId) != nil {
             return false // v2.5 legacy cleaning
         }
         let cachedFilesHash = calculateHash(appId: appId, version: version)
-        let storedHash = keystore.key(for: generateKeyId(for: appId, version: version)) ?? ""
+        let storedHash = keystore.getCacheInfo(for: generateKeyId(for: appId, version: version)) ?? ""
         return cachedFilesHash == storedHash
     }
 
@@ -21,7 +20,7 @@ internal class MiniAppCacheVerifier {
         keystore.removeKey(for: appId) // v2.5 legacy cleaning
         let appKey = generateKeyId(for: appId, version: version)
         keystore.removeKey(for: appKey)
-        keystore.addKey(key: calculateHash(appId: appId, version: version), for: appKey)
+        keystore.setCacheInfo(key: calculateHash(appId: appId, version: version), for: appKey)
     }
 
     private func calculateHash(appId: String, version: String) -> String {

--- a/MiniApp/Classes/core/Storage/MiniAppCacheVerifier.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppCacheVerifier.swift
@@ -1,26 +1,26 @@
 import CommonCrypto
 
 internal class MiniAppCacheVerifier {
-    let keystore = MiniAppVerificationStorage()
+    let miniAppVerificationStore = MiniAppVerificationStorage()
 
     private func generateKeyId(for appId: String, version: String) -> String {
         "\(appId) | \(version)"
     }
 
     func verify(appId: String, version: String) -> Bool {
-        if keystore.getCacheInfo(for: appId) != nil {
+        if miniAppVerificationStore.getCacheVerificationInfo(for: appId) != nil {
             return false // v2.5 legacy cleaning
         }
         let cachedFilesHash = calculateHash(appId: appId, version: version)
-        let storedHash = keystore.getCacheInfo(for: generateKeyId(for: appId, version: version)) ?? ""
+        let storedHash = miniAppVerificationStore.getCacheVerificationInfo(for: generateKeyId(for: appId, version: version)) ?? ""
         return cachedFilesHash == storedHash
     }
 
     func storeHash(for appId: String, version: String) {
-        keystore.removeCacheInfo(for: appId) // v2.5 legacy cleaning
+        miniAppVerificationStore.removeCacheInfo(for: appId) // v2.5 legacy cleaning
         let appKey = generateKeyId(for: appId, version: version)
-        keystore.removeCacheInfo(for: appKey)
-        keystore.setCacheInfo(key: calculateHash(appId: appId, version: version), for: appKey)
+        miniAppVerificationStore.removeCacheInfo(for: appKey)
+        miniAppVerificationStore.setCacheVerificationInfo(key: calculateHash(appId: appId, version: version), for: appKey)
     }
 
     private func calculateHash(appId: String, version: String) -> String {

--- a/MiniApp/Classes/core/Storage/MiniAppCacheVerifier.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppCacheVerifier.swift
@@ -1,7 +1,7 @@
 import CommonCrypto
 
 internal class MiniAppCacheVerifier {
-    let keystore = MiniAppKeyChain(serviceName: .cacheVerifier)
+    let keystore = MiniAppVerificationStorage()
 
     private func generateKeyId(for appId: String, version: String) -> String {
         "\(appId) | \(version)"
@@ -17,9 +17,9 @@ internal class MiniAppCacheVerifier {
     }
 
     func storeHash(for appId: String, version: String) {
-        keystore.removeKey(for: appId) // v2.5 legacy cleaning
+        keystore.removeCacheInfo(for: appId) // v2.5 legacy cleaning
         let appKey = generateKeyId(for: appId, version: version)
-        keystore.removeKey(for: appKey)
+        keystore.removeCacheInfo(for: appKey)
         keystore.setCacheInfo(key: calculateHash(appId: appId, version: version), for: appKey)
     }
 

--- a/MiniApp/Classes/core/Storage/MiniAppKeyChain.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppKeyChain.swift
@@ -4,150 +4,24 @@ import Foundation
     let service: String
     var account: String
 
-    typealias CacheVerifierKeysDictionary = [String: String]
-    typealias KeysDictionary = [String: [MASDKCustomPermissionModel]]
-
     init(service: String = Bundle.main.bundleIdentifier!, serviceName: ServiceName = .customPermission) {
         self.service = service
         self.account = "\(service).\(serviceName)"
     }
 
-    // MARK: - Custom permission methods
-    func getCustomPermissions(forMiniApp keyId: String) -> [MASDKCustomPermissionModel] {
-        guard let allKeys = retrieveAllPermissions(), let permissionList = allKeys[keyId] as [MASDKCustomPermissionModel]? else {
-            return getDefaultSupportedPermissions()
-        }
-        return permissionList
-    }
-
-    func storeCustomPermissions(permissions: [MASDKCustomPermissionModel], forMiniApp keyId: String) {
-        guard !keyId.isEmpty else {
-            return
-        }
-        var keysDic = retrieveAllPermissions()
-        var cachedPermissions = self.getCustomPermissions(forMiniApp: keyId)
-        _ = permissions.map { (permissionModel: MASDKCustomPermissionModel) -> MASDKCustomPermissionModel in
-            if let index = cachedPermissions.firstIndex(of: permissionModel) {
-                cachedPermissions[index] = permissionModel
-                cachedPermissions[index].permissionDescription = ""
-            }
-            return permissionModel
-        }
-
-        if keysDic != nil {
-            keysDic?[keyId] = cachedPermissions
-        } else {
-            keysDic = [keyId: cachedPermissions]
-        }
-
-        if let keys = keysDic {
-            writePermissionInfo(keys: keys)
-        }
-    }
-
-    /// Returns all key and values that is stored in Keychain,
-    /// - Returns: List of KeysDictionary
-    func getAllStoredCustomPermissionsList() -> KeysDictionary? {
-        retrieveAllPermissions()
-    }
-
-    /// Remove Key from the KeyChain
-    /// - Parameter keyId: Mini app ID
-    internal func removeKey(for keyId: String) {
-        var keysDic = retrieveAllPermissions()
-
-        keysDic?[keyId] = nil
-
-        if let keys = keysDic {
-            writePermissionInfo(keys: keys)
-        }
-    }
-
-    internal func getDefaultSupportedPermissions() -> [MASDKCustomPermissionModel] {
-        var supportedPermissionList = [MASDKCustomPermissionModel]()
-        MiniAppCustomPermissionType.allCases.forEach {
-            supportedPermissionList.append(MASDKCustomPermissionModel(
-                permissionName: MiniAppCustomPermissionType(
-                    rawValue: $0.rawValue)!,
-                isPermissionGranted: .denied,
-                permissionRequestDescription: ""
-            ))
-        }
-        return supportedPermissionList
-    }
-
-    private func writePermissionInfo(keys: KeysDictionary) {
+    internal func setInfoInKeyChain<T: Encodable>(keys: [String: T]) {
         guard let data = try? JSONEncoder().encode(keys) else {
             return
         }
-        setValueInKeyChain(data: data)
+        write(data: data)
     }
 
-    private func retrieveAllPermissions() -> KeysDictionary? {
-        guard let storedData = getAllKeysFromKeychain() else {
-            return nil
-        }
-
-        guard let keys = ResponseDecoder.decode(decodeType: KeysDictionary.self, data: storedData) else {
-            return nil
-        }
-
-        return keys
-    }
-
-    // MARK: - Cache Verifier Methods
-    internal func setCacheInfo(key: String, for keyId: String) {
-        var keysDic = getAllCacheKeys()
-        guard keysDic?[keyId] == nil else {
-            return // key exists
-        }
-
-        if keysDic != nil {
-            keysDic?[keyId] = key
-        } else {
-            keysDic = [keyId: key]
-        }
-
-        if let keys = keysDic {
-            writeCacheInfo(keys: keys)
-        }
-    }
-
-    internal func getCacheInfo(for keyId: String) -> String? {
-        return getAllCacheKeys()?[keyId]
-    }
-
-    private func getAllCacheKeys() -> CacheVerifierKeysDictionary? {
-        guard let storedData = getAllKeysFromKeychain() else {
-            return nil
-        }
-
-        guard let keys = try? JSONSerialization.jsonObject(with: storedData, options: []) as? CacheVerifierKeysDictionary else {
-            return nil
-        }
-
-        return keys
-    }
-
-    private func writeCacheInfo(keys: CacheVerifierKeysDictionary) {
-        guard let data = try? JSONEncoder().encode(keys) else {
-            return
-        }
-        setValueInKeyChain(data: data)
-    }
-
-    internal func removeCacheInfo(for keyId: String) {
-        var keysDic = getAllCacheKeys()
-
-        keysDic?[keyId] = nil
-
-        if let keys = keysDic {
-            writeCacheInfo(keys: keys)
-        }
+    internal func getAllKeys() -> Data? {
+        return retrieve()
     }
 
     // MARK: - Methods used to set & get values from Keychain
-    private func setValueInKeyChain(data: Data) {
+    private func write(data: Data) {
         let queryFind: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -177,7 +51,7 @@ import Foundation
         }
     }
 
-    private func getAllKeysFromKeychain() -> Data? {
+    private func retrieve() -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,

--- a/MiniApp/Classes/core/Storage/MiniAppPermissionsStorage.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppPermissionsStorage.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+internal class MiniAppPermissionsStorage {
+
+    typealias KeysDictionary = [String: [MASDKCustomPermissionModel]]
+    let keychainStore = MiniAppKeyChain(serviceName: .customPermission)
+
+    func getCustomPermissions(forMiniApp keyId: String) -> [MASDKCustomPermissionModel] {
+        guard let allKeys = retrieveAllPermissions(), let permissionList = allKeys[keyId] as [MASDKCustomPermissionModel]? else {
+            return getDefaultSupportedPermissions()
+        }
+        return permissionList
+    }
+
+    func storeCustomPermissions(permissions: [MASDKCustomPermissionModel], forMiniApp keyId: String) {
+        guard !keyId.isEmpty else {
+            return
+        }
+        var keysDic = retrieveAllPermissions()
+        var cachedPermissions = self.getCustomPermissions(forMiniApp: keyId)
+        _ = permissions.map { (permissionModel: MASDKCustomPermissionModel) -> MASDKCustomPermissionModel in
+            if let index = cachedPermissions.firstIndex(of: permissionModel) {
+                cachedPermissions[index] = permissionModel
+                cachedPermissions[index].permissionDescription = ""
+            }
+            return permissionModel
+        }
+
+        if keysDic != nil {
+            keysDic?[keyId] = cachedPermissions
+        } else {
+            keysDic = [keyId: cachedPermissions]
+        }
+
+        if let keys = keysDic {
+            keychainStore.setInfoInKeyChain(keys: keys)
+        }
+    }
+
+    /// Returns all key and values that is stored in Keychain,
+    /// - Returns: List of KeysDictionary
+    func getAllStoredCustomPermissionsList() -> KeysDictionary? {
+        retrieveAllPermissions()
+    }
+
+    /// Remove Key from the KeyChain
+    /// - Parameter keyId: Mini app ID
+    internal func removeKey(for keyId: String) {
+        var keysDic = retrieveAllPermissions()
+
+        keysDic?[keyId] = nil
+
+        if let keys = keysDic {
+            keychainStore.setInfoInKeyChain(keys: keys)
+        }
+    }
+
+    internal func getDefaultSupportedPermissions() -> [MASDKCustomPermissionModel] {
+        var supportedPermissionList = [MASDKCustomPermissionModel]()
+        MiniAppCustomPermissionType.allCases.forEach {
+            supportedPermissionList.append(MASDKCustomPermissionModel(
+                permissionName: MiniAppCustomPermissionType(
+                    rawValue: $0.rawValue)!,
+                isPermissionGranted: .denied,
+                permissionRequestDescription: ""
+            ))
+        }
+        return supportedPermissionList
+    }
+
+    private func retrieveAllPermissions() -> KeysDictionary? {
+        guard let storedData = keychainStore.getAllKeys() else {
+            return nil
+        }
+
+        guard let keys = ResponseDecoder.decode(decodeType: KeysDictionary.self, data: storedData) else {
+            return nil
+        }
+
+        return keys
+    }
+}

--- a/MiniApp/Classes/core/Storage/MiniAppStatus.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppStatus.swift
@@ -1,12 +1,12 @@
 class MiniAppStatus {
     private let defaults: UserDefaults?
     private let miniAppInfoDefaults: UserDefaults?
-    private let miniAppKeyStore: MiniAppKeyChain
+    private let miniAppKeyStore: MiniAppPermissionsStorage
 
     init() {
         self.defaults = UserDefaults(suiteName: "com.rakuten.tech.mobile.miniapp")
         self.miniAppInfoDefaults = UserDefaults(suiteName: "com.rakuten.tech.mobile.miniapp.MiniAppDemo.MiniAppInfo")
-        self.miniAppKeyStore = MiniAppKeyChain()
+        self.miniAppKeyStore = MiniAppPermissionsStorage()
     }
 
     func setDownloadStatus(_ value: Bool, appId: String, versionId: String) {

--- a/MiniApp/Classes/core/Storage/MiniAppVerificationStorage.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppVerificationStorage.swift
@@ -1,0 +1,52 @@
+import Foundation
+import CommonCrypto
+
+internal class MiniAppVerificationStorage {
+
+    typealias CacheVerifierKeysDictionary = [String: String]
+    let keychainStore = MiniAppKeyChain(serviceName: .cacheVerifier)
+
+    func setCacheInfo(key: String, for keyId: String) {
+        var keysDic = getAllCacheKeys()
+        guard keysDic?[keyId] == nil else {
+            return // key exists
+        }
+
+        if keysDic != nil {
+            keysDic?[keyId] = key
+        } else {
+            keysDic = [keyId: key]
+        }
+
+        if let keys = keysDic {
+            keychainStore.setInfoInKeyChain(keys: keys)
+        }
+    }
+
+    func getCacheInfo(for keyId: String) -> String? {
+        return getAllCacheKeys()?[keyId]
+    }
+
+    private func getAllCacheKeys() -> CacheVerifierKeysDictionary? {
+        guard let storedData = keychainStore.getAllKeys() else {
+            return nil
+        }
+
+        guard let keys = try? JSONSerialization.jsonObject(with: storedData, options: []) as? CacheVerifierKeysDictionary else {
+            return nil
+        }
+
+        return keys
+    }
+
+    func removeCacheInfo(for keyId: String) {
+        var keysDic = getAllCacheKeys()
+
+        keysDic?[keyId] = nil
+
+        if let keys = keysDic {
+            keychainStore.setInfoInKeyChain(keys: keys)
+        }
+    }
+
+}

--- a/MiniApp/Classes/core/Storage/MiniAppVerificationStorage.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppVerificationStorage.swift
@@ -6,7 +6,7 @@ internal class MiniAppVerificationStorage {
     typealias CacheVerifierKeysDictionary = [String: String]
     let keychainStore = MiniAppKeyChain(serviceName: .cacheVerifier)
 
-    func setCacheInfo(key: String, for keyId: String) {
+    func setCacheVerificationInfo(key: String, for keyId: String) {
         var keysDic = getAllCacheKeys()
         guard keysDic?[keyId] == nil else {
             return // key exists
@@ -23,7 +23,7 @@ internal class MiniAppVerificationStorage {
         }
     }
 
-    func getCacheInfo(for keyId: String) -> String? {
+    func getCacheVerificationInfo(for keyId: String) -> String? {
         return getAllCacheKeys()?[keyId]
     }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,6 @@ PODS:
     - Google-Mobile-Ads-SDK (~> 7.0)
     - MiniApp/Core
   - MiniApp/Core (2.8.0):
-    - RSDKUtils (>= 1.1.0)
     - ZIPFoundation
   - nanopb (2.30907.0):
     - nanopb/decode (= 2.30907.0)
@@ -43,7 +42,6 @@ PODS:
   - Nimble (9.0.0)
   - PromisesObjC (1.2.12)
   - Quick (3.1.2)
-  - RSDKUtils (1.1.0)
   - ZIPFoundation (0.9.11)
 
 DEPENDENCIES:
@@ -64,7 +62,6 @@ SPEC REPOS:
     - Nimble
     - PromisesObjC
     - Quick
-    - RSDKUtils
     - ZIPFoundation
 
 EXTERNAL SOURCES:
@@ -77,14 +74,13 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: c542a2feaac9ab98fd074e8f1a02c3585bbfbd47
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
   GoogleUtilities: 31c5b01f978a70c6cff2afc6272b3f1921614b43
-  MiniApp: 381328d81ee5ce0bf6989b2e3f0d5244063d9b7e
+  MiniApp: 1655d50cc391f183271204fae351ec5595239363
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
-  RSDKUtils: 9940b99fa0494181b8ee2cfa2ac742bb0958b984
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 42131d08d32bc489cf839bd96c0eeedeea2faf51
+PODFILE CHECKSUM: 5ebd48f8a691819563d81a11f591885bd461f08a
 
 COCOAPODS: 1.10.1

--- a/Tests/Unit/MiniAppKeyChainTests.swift
+++ b/Tests/Unit/MiniAppKeyChainTests.swift
@@ -8,7 +8,7 @@ class MiniAppKeyChainTests: QuickSpec {
         describe("Mini App Key chain tests") {
             context("when storeCustomPermissions method is called with valid params") {
                 it("will store the value in Keychain") {
-                    let miniAppKeyStore = MiniAppKeyChain()
+                    let miniAppKeyStore = MiniAppPermissionsStorage()
                     let customPermissions = miniAppKeyStore.getDefaultSupportedPermissions()
                     _ = customPermissions.map { return $0.isPermissionGranted = .allowed }
                     miniAppKeyStore.storeCustomPermissions(permissions: customPermissions, forMiniApp: mockMiniAppInfo.id)

--- a/Tests/Unit/MiniAppStatusTests.swift
+++ b/Tests/Unit/MiniAppStatusTests.swift
@@ -61,7 +61,7 @@ class MiniAppStatusTests: QuickSpec {
             }
             context("when mini app custom permissions info is saved and retrieved") {
                 it("will return the miniapp info for a valid mini app id") {
-                    let miniAppKeyStore = MiniAppKeyChain()
+                    let miniAppKeyStore = MiniAppPermissionsStorage()
                     let userNamePermission = MASDKCustomPermissionModel(
                         permissionName: MiniAppCustomPermissionType(rawValue: MiniAppCustomPermissionType.userName.rawValue)!)
                     let profilePhotoPermission = MASDKCustomPermissionModel(
@@ -84,7 +84,7 @@ class MiniAppStatusTests: QuickSpec {
             }
             context("when checkStoredPermissionList is called with downloaded mini apps list") {
                 it("will return list of custom permissions if it is stored already") {
-                    let miniAppKeyStore = MiniAppKeyChain()
+                    let miniAppKeyStore = MiniAppPermissionsStorage()
                     let miniAppStatus = MiniAppStatus()
                     miniAppKeyStore.storeCustomPermissions(permissions: miniAppKeyStore.getDefaultSupportedPermissions(), forMiniApp: mockMiniAppInfo.id)
                     let miniAppCustomPermissionList = miniAppStatus.checkStoredPermissionList(downloadedMiniAppsList: [mockMiniAppInfo])


### PR DESCRIPTION
# Description
* Added more interfaces to the existing MiniAppKeyChain class that helps the MiniAppCacheVerifier to use the same.
* Removed the RSDK Pods as MiniAppKeyChain is a replacement.


# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
