### PR TITLE
Feat/required optional permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **SDK**
 
-- **Core:** incremented minimum support version for iOS from 11.0 to 13.0 
+- **Core:** Incremented minimum support version for iOS from 11.0 to 13.0 
 - **Removed:** Removed all deprecated and variables methods from v2:
   - `MiniApp` :
     - `list(completionHandler:)` now takes a `(Result<[MiniAppInfo], MASDKError>) -> Void` in place of a `(Result<[MiniAppInfo], Error>) -> Void`
@@ -26,6 +26,7 @@
 - **Feature:** Added ads for Mini Apps host
 - **Feature:** Added Google mobile ads integration in a `MiniApps/Admob` pod subspec
 - **Feature:** Added new interface `getMiniAppManifest(miniAppId:miniAppVersion:)` to retrieve the meta-data of a MiniApp
+- **Feature:** Added new interface `getDownloadedManifest(miniAppId:)` to retrieve the cached meta-data of a MiniApp
 
 **Sample App**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **Feature:** Added Google mobile ads integration in a `MiniApps/Admob` pod subspec
 - **Feature:** Added new interface `getMiniAppManifest(miniAppId:miniAppVersion:)` to retrieve the meta-data of a MiniApp
 - **Feature:** Added new interface `getDownloadedManifest(miniAppId:)` to retrieve the cached meta-data of a MiniApp
+- **Removed:** RSDKUtils dependency removed
 
 **Sample App**
 

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -66,7 +66,11 @@ extension ViewController: MiniAppNavigationDelegate {
                     self.performSegue(withIdentifier: "DisplayMiniApp", sender: nil)
                 }
             case .failure(let error):
-                self.checkSDKErrorAndDisplay(error: error)
+                self.displayAlert(title: NSLocalizedString("error_title", comment: ""),
+                                  message: NSLocalizedString("error_miniapp_download_message", comment: "") + ".\n\(error.localizedDescription)",
+                                  dismissController: true) { _ in
+                    self.fetchAppList(inBackground: true)
+                }
                 print("Errored: ", error.localizedDescription)
             }
         }, messageInterface: self, adsDisplayer: adsDisplayer)
@@ -92,19 +96,6 @@ extension ViewController: MiniAppNavigationDelegate {
             } else {
                 self.fetchMiniAppUsingId(title: NSLocalizedString("error_invalid_miniapp_id", comment: ""), message: NSLocalizedString("input_valid_miniapp_title", comment: ""))
             }
-        }
-    }
-
-    func checkSDKErrorAndDisplay(error: MASDKError) {
-        var errorMessage: String = ""
-        switch error {
-        case .metaDataFailure:
-            errorMessage = NSLocalizedString("error_miniapp_download_message", comment: "") + ".\n\(error.localizedDescription)"
-        default:
-            errorMessage = NSLocalizedString("error_miniapp_download_message", comment: "")
-        }
-        self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: errorMessage, dismissController: true) { _ in
-            self.fetchAppList(inBackground: true)
         }
     }
 }

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -66,9 +66,7 @@ extension ViewController: MiniAppNavigationDelegate {
                     self.performSegue(withIdentifier: "DisplayMiniApp", sender: nil)
                 }
             case .failure(let error):
-                self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: NSLocalizedString("error_miniapp_download_message", comment: ""), dismissController: true) { _ in
-                    self.fetchAppList(inBackground: true)
-                }
+                self.checkSDKErrorAndDisplay(error: error)
                 print("Errored: ", error.localizedDescription)
             }
         }, messageInterface: self, adsDisplayer: adsDisplayer)
@@ -94,6 +92,19 @@ extension ViewController: MiniAppNavigationDelegate {
             } else {
                 self.fetchMiniAppUsingId(title: NSLocalizedString("error_invalid_miniapp_id", comment: ""), message: NSLocalizedString("input_valid_miniapp_title", comment: ""))
             }
+        }
+    }
+
+    func checkSDKErrorAndDisplay(error: MASDKError) {
+        var errorMessage: String = ""
+        switch error {
+        case .metaDataFailure:
+            errorMessage = NSLocalizedString("error_miniapp_download_message", comment: "") + ". \nPlease make sure user agreed to all required permissions from Meta-data"
+        default:
+            errorMessage = NSLocalizedString("error_miniapp_download_message", comment: "")
+        }
+        self.displayAlert(title: NSLocalizedString("error_title", comment: ""), message: errorMessage, dismissController: true) { _ in
+            self.fetchAppList(inBackground: true)
         }
     }
 }

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -99,7 +99,7 @@ extension ViewController: MiniAppNavigationDelegate {
         var errorMessage: String = ""
         switch error {
         case .metaDataFailure:
-            errorMessage = NSLocalizedString("error_miniapp_download_message", comment: "") + ". \nPlease make sure user agreed to all required permissions from Meta-data"
+            errorMessage = NSLocalizedString("error_miniapp_download_message", comment: "") + ".\n\(error.localizedDescription)"
         default:
             errorMessage = NSLocalizedString("error_miniapp_download_message", comment: "")
         }

--- a/MiniApp/Classes/core/Extensions/NSError+MiniApp.swift
+++ b/MiniApp/Classes/core/Extensions/NSError+MiniApp.swift
@@ -96,6 +96,7 @@ extension NSError {
 // swiftlint:disable identifier_name
 var MiniAppSDKErrorDomain = "MiniAppSDKErrorDomain"
 var MiniAppSDKServerErrorDomain = "MiniAppSDKServerErrorDomain"
+var MASDKErrorDomain = "MiniApp.MASDKError"
 
 enum MiniAppSDKErrorCode: Int {
     case invalidURLError = 1,

--- a/MiniApp/Classes/core/Extensions/NSError+MiniApp.swift
+++ b/MiniApp/Classes/core/Extensions/NSError+MiniApp.swift
@@ -105,5 +105,6 @@ enum MiniAppSDKErrorCode: Int {
          noPublishedVersion,
          adNotLoaded,
          adNotDisplayed,
-         miniAppNotFound
+         miniAppNotFound,
+         metaDataFailure
 }

--- a/MiniApp/Classes/core/MASDKError.swift
+++ b/MiniApp/Classes/core/MASDKError.swift
@@ -31,7 +31,10 @@ public enum MASDKError: Error {
     /// The provided mini app ID was not found on the server.
     case miniAppNotFound
 
-    /// An unexpected error occured.
+    /// All required custom permissions is not allowed by the user
+    case metaDataFailure
+
+    /// An unexpected error occurred.
     ///
     /// - Parameters:
     ///     - domain: The domain from the original NSError.
@@ -59,6 +62,8 @@ extension MASDKError: LocalizedError {
             return NSLocalizedString("error_no_published_version", comment: "")
         case .miniAppNotFound:
             return NSLocalizedString("error_miniapp_id_not_found", comment: "")
+        case .metaDataFailure:
+            return NSLocalizedString("error_miniapp_meta_data_required_permissions_failure", comment: "")
         case .unknownError(let domain, let code, let description):
             return String(format: NSLocalizedString("error_unknown", comment: ""), domain, code, description)
         }
@@ -85,6 +90,8 @@ extension MASDKError {
                 return MASDKError.noPublishedVersion
             case .miniAppNotFound:
                 return MASDKError.miniAppNotFound
+            case .metaDataFailure:
+                return MASDKError.metaDataFailure
             default:
                 break
             }

--- a/MiniApp/Classes/core/MASDKError.swift
+++ b/MiniApp/Classes/core/MASDKError.swift
@@ -49,21 +49,21 @@ extension MASDKError: LocalizedError {
         case .serverError(let code, let message):
             return String(format: NSLocalizedString("error_server", comment: ""), code, message)
         case .invalidURLError:
-            return NSLocalizedString("error_invalid_url", comment: "")
+            return "error_invalid_url".localizedString()
         case .invalidAppId:
-            return NSLocalizedString("error_invalid_app_id", comment: "")
+            return "error_invalid_app_id".localizedString()
         case .invalidVersionId:
-            return NSLocalizedString("error_invalid_version_id", comment: "")
+            return "error_invalid_version_id".localizedString()
         case .invalidResponseData:
-            return NSLocalizedString("error_invalid_response", comment: "")
+            return "error_invalid_response".localizedString()
         case .downloadingFailed:
-            return NSLocalizedString("error_download_failed", comment: "")
+            return "error_invalid_response".localizedString()
         case .noPublishedVersion:
-            return NSLocalizedString("error_no_published_version", comment: "")
+            return "error_no_published_version".localizedString()
         case .miniAppNotFound:
-            return NSLocalizedString("error_miniapp_id_not_found", comment: "")
+            return "error_miniapp_id_not_found".localizedString()
         case .metaDataFailure:
-            return NSLocalizedString("error_miniapp_meta_data_required_permissions_failure", comment: "")
+            return "error_miniapp_meta_data_required_permissions_failure".localizedString()
         case .unknownError(let domain, let code, let description):
             return String(format: NSLocalizedString("error_unknown", comment: ""), domain, code, description)
         }

--- a/MiniApp/Classes/core/MASDKError.swift
+++ b/MiniApp/Classes/core/MASDKError.swift
@@ -90,6 +90,12 @@ extension MASDKError {
                 return MASDKError.noPublishedVersion
             case .miniAppNotFound:
                 return MASDKError.miniAppNotFound
+            default:
+                break
+            }
+        }
+        if error.domain == MASDKErrorDomain {
+            switch MiniAppSDKErrorCode(rawValue: error.code) {
             case .metaDataFailure:
                 return MASDKError.metaDataFailure
             default:

--- a/MiniApp/Classes/core/MiniApp.swift
+++ b/MiniApp/Classes/core/MiniApp.swift
@@ -107,6 +107,14 @@ public class MiniApp: NSObject {
     public func getMiniAppManifest(miniAppId: String, miniAppVersion: String, completionHandler: @escaping (Result<MiniAppManifest, MASDKError>) -> Void) {
         return realMiniApp.retrieveMiniAppMetaData(appId: miniAppId, version: miniAppVersion, completionHandler: completionHandler)
     }
+
+    /// Method to return the cached meta-data information of a mini-app from the Keychain
+    /// - Parameters:
+    ///   - miniAppId:  Mini AppId String value
+    /// - Returns: MiniAppManifest object info from the cache
+    public func getDownloadedManifest(miniAppId: String) -> MiniAppManifest? {
+        return realMiniApp.getCachedManifestData(appId: miniAppId)
+    }
 }
 
 // MARK: - Testing

--- a/MiniApp/Classes/core/MiniApp.swift
+++ b/MiniApp/Classes/core/MiniApp.swift
@@ -108,10 +108,10 @@ public class MiniApp: NSObject {
         return realMiniApp.retrieveMiniAppMetaData(appId: miniAppId, version: miniAppVersion, completionHandler: completionHandler)
     }
 
-    /// Method to return the cached meta-data information of a mini-app from the Keychain
+    /// Method to return the cached meta-data information of a mini-app
     /// - Parameters:
     ///   - miniAppId:  Mini AppId String value
-    /// - Returns: MiniAppManifest object info from the cache
+    /// - Returns: MiniAppManifest object info from the cache, Returns nil, if the mini-app is not downloaded already.
     public func getDownloadedManifest(miniAppId: String) -> MiniAppManifest? {
         return realMiniApp.getCachedManifestData(appId: miniAppId)
     }

--- a/MiniApp/Classes/core/MiniAppInfoFetcher.swift
+++ b/MiniApp/Classes/core/MiniAppInfoFetcher.swift
@@ -42,20 +42,20 @@ internal class MiniAppInfoFetcher {
         }
     }
 
-    func getMiniAppMetaInfo(miniAppId: String, miniAppVersion: String, apiClient: MiniAppClient, completionHandler: @escaping (Result<MiniAppManifest, Error>) -> Void) {
+    func getMiniAppMetaInfo(miniAppId: String, miniAppVersion: String, apiClient: MiniAppClient, completionHandler: @escaping (Result<MiniAppManifest, MASDKError>) -> Void) {
 
         apiClient.getMiniAppMetaData(appId: miniAppId, versionId: miniAppVersion) { (result) in
             switch result {
             case .success(let responseData):
                 guard let decodeResponse = ResponseDecoder.decode(decodeType: MetaDataResponse.self,
                     data: responseData.data) else {
-                    return completionHandler(.failure(NSError.invalidResponseData()))
+                    return completionHandler(.failure(.invalidResponseData))
                 }
                 return completionHandler(.success(
                                             self.prepareMiniAppManifest(
                                                 metaDataResponse: decodeResponse.bundleManifest)))
             case .failure(let error):
-                return completionHandler(.failure(error))
+                return completionHandler(.failure(.fromError(error: error)))
             }
         }
     }

--- a/MiniApp/Classes/core/Models/MiniAppManifest.swift
+++ b/MiniApp/Classes/core/Models/MiniAppManifest.swift
@@ -55,3 +55,13 @@ public struct MiniAppManifest: Codable {
         self.customMetaData = customMetaData
     }
 }
+
+internal struct CachedMetaData: Codable {
+    let version: String
+    let miniAppManifest: MiniAppManifest?
+
+    init(version: String, miniAppManifest: MiniAppManifest) {
+        self.version = version
+        self.miniAppManifest = miniAppManifest
+    }
+}

--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -246,7 +246,7 @@ internal class RealMiniApp {
                 self.miniAppManifest = metaData
                 completionHandler(.success(metaData))
             case .failure(let error):
-                completionHandler(.failure(.fromError(error: error)))
+                completionHandler(.failure(error))
             }
         }
     }
@@ -273,7 +273,7 @@ internal class RealMiniApp {
                                                requiredPermissions: requiredPermissions,
                                                completionHandler: completionHandler)
             case .failure(let error):
-                completionHandler(.failure(.fromError(error: error)))
+                completionHandler(.failure(error))
             }
         }
     }

--- a/MiniApp/Classes/core/Storage/MAManifestStorage.swift
+++ b/MiniApp/Classes/core/Storage/MAManifestStorage.swift
@@ -3,10 +3,10 @@ import CommonCrypto
 
 internal class MAManifestStorage {
 
-    typealias KeysDictionary = [String: MiniAppManifest]
+    typealias KeysDictionary = [String: CachedMetaData]
     let keychainStore = MiniAppKeyChain(serviceName: .customPermission)
 
-    func saveManifestInfo(forMiniApp appId: String, manifest: MiniAppManifest) {
+    func saveManifestInfo(forMiniApp appId: String, manifest: CachedMetaData) {
         guard !appId.isEmpty else {
             return
         }
@@ -22,11 +22,11 @@ internal class MAManifestStorage {
         }
     }
 
-    func getManifestInfo(forMiniApp appId: String) -> MiniAppManifest? {
+    func getManifestInfo(forMiniApp appId: String) -> CachedMetaData? {
         guard !appId.isEmpty else {
             return nil
         }
-        guard let allKeys = retrieveAllManifestInfo(), let manifestInfo = allKeys[appId] as MiniAppManifest? else {
+        guard let allKeys = retrieveAllManifestInfo(), let manifestInfo = allKeys[appId] as CachedMetaData? else {
             return nil
         }
         return manifestInfo

--- a/MiniApp/Classes/core/Storage/MAManifestStorage.swift
+++ b/MiniApp/Classes/core/Storage/MAManifestStorage.swift
@@ -4,7 +4,7 @@ import CommonCrypto
 internal class MAManifestStorage {
 
     typealias KeysDictionary = [String: CachedMetaData]
-    let keychainStore = MiniAppKeyChain(serviceName: .customPermission)
+    let keychainStore = MiniAppKeyChain(serviceName: .miniAppManifest)
 
     func saveManifestInfo(forMiniApp appId: String, manifest: CachedMetaData) {
         guard !appId.isEmpty else {

--- a/MiniApp/Classes/core/Storage/MAManifestStorage.swift
+++ b/MiniApp/Classes/core/Storage/MAManifestStorage.swift
@@ -1,0 +1,59 @@
+import Foundation
+import CommonCrypto
+
+internal class MAManifestStorage {
+
+    typealias KeysDictionary = [String: MiniAppManifest]
+    let keychainStore = MiniAppKeyChain(serviceName: .customPermission)
+
+    func saveManifestInfo(forMiniApp appId: String, manifest: MiniAppManifest) {
+        guard !appId.isEmpty else {
+            return
+        }
+        var keysDic = retrieveAllManifestInfo()
+        if keysDic != nil {
+            keysDic?[appId] = manifest
+        } else {
+            keysDic = [appId: manifest]
+        }
+
+        if let keys = keysDic {
+            keychainStore.setInfoInKeyChain(keys: keys)
+        }
+    }
+
+    func getManifestInfo(forMiniApp appId: String) -> MiniAppManifest? {
+        guard !appId.isEmpty else {
+            return nil
+        }
+        guard let allKeys = retrieveAllManifestInfo(), let manifestInfo = allKeys[appId] as MiniAppManifest? else {
+            return nil
+        }
+        return manifestInfo
+    }
+
+    /// Remove Key from the KeyChain
+    /// - Parameter keyId: Mini app ID
+    internal func removeKey(forMiniApp appId: String) {
+        var keysDic = retrieveAllManifestInfo()
+
+        keysDic?[appId] = nil
+
+        if let keys = keysDic {
+            keychainStore.setInfoInKeyChain(keys: keys)
+        }
+    }
+
+    private func retrieveAllManifestInfo() -> KeysDictionary? {
+        guard let storedData = keychainStore.getAllKeys() else {
+            return nil
+        }
+
+        guard let keys = ResponseDecoder.decode(decodeType: KeysDictionary.self, data: storedData) else {
+            return nil
+        }
+
+        return keys
+    }
+
+}

--- a/MiniApp/Classes/core/Storage/MiniAppKeyChain.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppKeyChain.swift
@@ -72,5 +72,6 @@ import Foundation
 
 internal enum ServiceName: String {
     case customPermission = "rakuten.tech.permission.keys"
+    case miniAppManifest = "rakuten.tech.manifest.keys"
     case cacheVerifier = "rakuten.tech.keys"
 }

--- a/MiniApp/Classes/core/Storage/MiniAppPermissionsStorage.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppPermissionsStorage.swift
@@ -7,7 +7,7 @@ internal class MiniAppPermissionsStorage {
 
     func getCustomPermissions(forMiniApp keyId: String) -> [MASDKCustomPermissionModel] {
         guard let allKeys = retrieveAllPermissions(), let permissionList = allKeys[keyId] as [MASDKCustomPermissionModel]? else {
-            return getDefaultSupportedPermissions()
+            return []
         }
         return permissionList
     }
@@ -21,11 +21,12 @@ internal class MiniAppPermissionsStorage {
         _ = permissions.map { (permissionModel: MASDKCustomPermissionModel) -> MASDKCustomPermissionModel in
             if let index = cachedPermissions.firstIndex(of: permissionModel) {
                 cachedPermissions[index] = permissionModel
-                cachedPermissions[index].permissionDescription = ""
+            } else {
+                cachedPermissions.append(permissionModel)
             }
+            permissionModel.permissionDescription = ""
             return permissionModel
         }
-
         if keysDic != nil {
             keysDic?[keyId] = cachedPermissions
         } else {
@@ -53,19 +54,6 @@ internal class MiniAppPermissionsStorage {
         if let keys = keysDic {
             keychainStore.setInfoInKeyChain(keys: keys)
         }
-    }
-
-    internal func getDefaultSupportedPermissions() -> [MASDKCustomPermissionModel] {
-        var supportedPermissionList = [MASDKCustomPermissionModel]()
-        MiniAppCustomPermissionType.allCases.forEach {
-            supportedPermissionList.append(MASDKCustomPermissionModel(
-                permissionName: MiniAppCustomPermissionType(
-                    rawValue: $0.rawValue)!,
-                isPermissionGranted: .denied,
-                permissionRequestDescription: ""
-            ))
-        }
-        return supportedPermissionList
     }
 
     private func retrieveAllPermissions() -> KeysDictionary? {

--- a/MiniApp/Classes/core/Storage/MiniAppStatus.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppStatus.swift
@@ -78,7 +78,7 @@ class MiniAppStatus {
             if let permMod = finalList[miniAppInfo.id] {
                 returnList.append((miniAppInfo, permMod))
             } else {
-                returnList.append((miniAppInfo, self.miniAppKeyStore.getDefaultSupportedPermissions()))
+                returnList.append((miniAppInfo, []))
             }
         }
         return returnList

--- a/MiniApp/en.lproj/Localizable.strings
+++ b/MiniApp/en.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "error_download_failed" = "Failed to download the mini app.";
 "error_no_published_version" = "Server returned no published versions for the provided Mini App ID.";
 "error_miniapp_id_not_found" = "Server could not find the provided Mini App ID.";
-"error_miniapp_meta_data_required_permissions_failure" = "Please make sure you agreed to all required permissions for this Mini-app.";
+"error_miniapp_meta_data_required_permissions_failure" = "Mini App has not been granted all of the required permissions.";
 "error_unknown" = "Unknown error occurred in %@ domain with error code %@: %@";
 
 "input_miniapp_title" = "Please enter Miniapp ID";

--- a/MiniApp/en.lproj/Localizable.strings
+++ b/MiniApp/en.lproj/Localizable.strings
@@ -22,7 +22,8 @@
 "error_download_failed" = "Failed to download the mini app.";
 "error_no_published_version" = "Server returned no published versions for the provided Mini App ID.";
 "error_miniapp_id_not_found" = "Server could not find the provided Mini App ID.";
-"error_unknown" = "Unknown error occured in %@ domain with error code %@: %@";
+"error_miniapp_meta_data_required_permissions_failure" = "All required permissions must be agreed by the user";
+"error_unknown" = "Unknown error occurred in %@ domain with error code %@: %@";
 
 "input_miniapp_title" = "Please enter Miniapp ID";
 "input_valid_miniapp_title" = "Please enter valid Miniapp ID and try again";

--- a/MiniApp/en.lproj/Localizable.strings
+++ b/MiniApp/en.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "error_download_failed" = "Failed to download the mini app.";
 "error_no_published_version" = "Server returned no published versions for the provided Mini App ID.";
 "error_miniapp_id_not_found" = "Server could not find the provided Mini App ID.";
-"error_miniapp_meta_data_required_permissions_failure" = "All required permissions must be agreed by the user";
+"error_miniapp_meta_data_required_permissions_failure" = "Please make sure you agreed to all required permissions for this Mini-app.";
 "error_unknown" = "Unknown error occurred in %@ domain with error code %@: %@";
 
 "input_miniapp_title" = "Please enter Miniapp ID";

--- a/Tests/Unit/MiniAppKeyChainTests.swift
+++ b/Tests/Unit/MiniAppKeyChainTests.swift
@@ -9,7 +9,7 @@ class MiniAppKeyChainTests: QuickSpec {
             context("when storeCustomPermissions method is called with valid params") {
                 it("will store the value in Keychain") {
                     let miniAppKeyStore = MiniAppPermissionsStorage()
-                    let customPermissions = miniAppKeyStore.getDefaultSupportedPermissions()
+                    let customPermissions = getDefaultSupportedPermissions()
                     _ = customPermissions.map { return $0.isPermissionGranted = .allowed }
                     miniAppKeyStore.storeCustomPermissions(permissions: customPermissions, forMiniApp: mockMiniAppInfo.id)
                     let retrievedPermission = miniAppKeyStore.getCustomPermissions(forMiniApp: mockMiniAppInfo.id)

--- a/Tests/Unit/MiniAppStatusTests.swift
+++ b/Tests/Unit/MiniAppStatusTests.swift
@@ -70,15 +70,20 @@ class MiniAppStatusTests: QuickSpec {
                     permissionName: MiniAppCustomPermissionType(rawValue: MiniAppCustomPermissionType.contactsList.rawValue)!, isPermissionGranted: MiniAppCustomPermissionGrantedStatus.denied)
                     miniAppKeyStore.storeCustomPermissions(permissions: [userNamePermission, profilePhotoPermission, contactListPermission], forMiniApp: "123")
                     var miniAppCustomPermissionList = miniAppKeyStore.getCustomPermissions(forMiniApp: "123")
-                    expect(miniAppCustomPermissionList[0].permissionName.rawValue).to(equal("rakuten.miniapp.user.USER_NAME"))
-                    expect(miniAppCustomPermissionList[0].isPermissionGranted.rawValue).to(equal("ALLOWED"))
-                    expect(miniAppCustomPermissionList[1].permissionName.rawValue).to(equal("rakuten.miniapp.user.PROFILE_PHOTO"))
-                    expect(miniAppCustomPermissionList[1].isPermissionGranted.rawValue).to(equal("DENIED"))
-                    expect(miniAppCustomPermissionList[2].isPermissionGranted.rawValue).to(equal("DENIED"))
-                    profilePhotoPermission.isPermissionGranted = .allowed
-                    miniAppKeyStore.storeCustomPermissions(permissions: [profilePhotoPermission], forMiniApp: "123")
-                    miniAppCustomPermissionList = miniAppKeyStore.getCustomPermissions(forMiniApp: "123")
-                    expect(miniAppCustomPermissionList[1].isPermissionGranted.rawValue).to(equal("ALLOWED"))
+                    if miniAppCustomPermissionList.count >= 3 {
+                        expect(miniAppCustomPermissionList[0].permissionName.rawValue).to(equal("rakuten.miniapp.user.USER_NAME"))
+                        expect(miniAppCustomPermissionList[0].isPermissionGranted.rawValue).to(equal("ALLOWED"))
+                        expect(miniAppCustomPermissionList[1].permissionName.rawValue).to(equal("rakuten.miniapp.user.PROFILE_PHOTO"))
+                        expect(miniAppCustomPermissionList[1].isPermissionGranted.rawValue).to(equal("DENIED"))
+                        expect(miniAppCustomPermissionList[2].isPermissionGranted.rawValue).to(equal("DENIED"))
+                        profilePhotoPermission.isPermissionGranted = .allowed
+                        miniAppKeyStore.storeCustomPermissions(permissions: [profilePhotoPermission], forMiniApp: "123")
+                        miniAppCustomPermissionList = miniAppKeyStore.getCustomPermissions(forMiniApp: "123")
+                        expect(miniAppCustomPermissionList[0].isPermissionGranted.rawValue).to(equal("ALLOWED"))
+                    } else {
+                        fail("Failed to store and retrieve custom permissions in KeyChain")
+                    }
+
                     UserDefaults().removePersistentDomain(forName: "com.rakuten.tech.mobile.miniapp.MiniAppDemo.MiniAppInfo")
                 }
             }
@@ -86,7 +91,7 @@ class MiniAppStatusTests: QuickSpec {
                 it("will return list of custom permissions if it is stored already") {
                     let miniAppKeyStore = MiniAppPermissionsStorage()
                     let miniAppStatus = MiniAppStatus()
-                    miniAppKeyStore.storeCustomPermissions(permissions: miniAppKeyStore.getDefaultSupportedPermissions(), forMiniApp: mockMiniAppInfo.id)
+                    miniAppKeyStore.storeCustomPermissions(permissions: getDefaultSupportedPermissions(), forMiniApp: mockMiniAppInfo.id)
                     let miniAppCustomPermissionList = miniAppStatus.checkStoredPermissionList(downloadedMiniAppsList: [mockMiniAppInfo])
                     expect(miniAppCustomPermissionList.keys).to(contain(mockMiniAppInfo.id))
                     let miniAppInfo = MiniAppInfo(id: "123", displayName: "Test", icon: URL(string: "https://www.example.com/icon.png")!, version: mockMiniAppInfo.version)

--- a/Tests/Unit/MiniAppTests.swift
+++ b/Tests/Unit/MiniAppTests.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 @testable import MiniApp
 
-// swiftlint:disable function_body_length
 class MiniAppTests: QuickSpec {
 
     override func spec() {
@@ -11,17 +10,6 @@ class MiniAppTests: QuickSpec {
                 it("will return nil") {
                     let miniAppCustomPermissions = MiniApp.shared().getCustomPermissions(forMiniApp: "")
                     expect(miniAppCustomPermissions).to(equal([]))
-                }
-            }
-            context("when getPermissions is called with valid mini app id that has stored permissions") {
-                it("will return list of custom permissions") {
-                    let userNamePermission = MASDKCustomPermissionModel(permissionName: MiniAppCustomPermissionType(rawValue: MiniAppCustomPermissionType.contactsList.rawValue)!)
-                    let profilePhotoPermission = MASDKCustomPermissionModel(
-                        permissionName: MiniAppCustomPermissionType(rawValue: MiniAppCustomPermissionType.profilePhoto.rawValue)!,
-                        isPermissionGranted: MiniAppCustomPermissionGrantedStatus.denied)
-                    MiniApp.shared().setCustomPermissions(forMiniApp: "123", permissionList: [userNamePermission, profilePhotoPermission])
-                    let miniAppCustomPermissions = MiniApp.shared().getCustomPermissions(forMiniApp: "123")
-                    expect(miniAppCustomPermissions.count).to(equal(MiniAppCustomPermissionType.allCases.count))
                 }
             }
             context("when info method is called with empty mini app id") {

--- a/Tests/Unit/RealMiniAppTests+Permissions.swift
+++ b/Tests/Unit/RealMiniAppTests+Permissions.swift
@@ -52,7 +52,6 @@ class RealMiniAppPermissionTests: QuickSpec {
             }
             context("when we store permission") {
                 it("will store them persistently") {
-                    realMiniApp.miniAppManifest = mockMiniAppManifest
                     realMiniApp.storeCustomPermissions(
                         forMiniApp: "test",
                         permissionList: [MASDKCustomPermissionModel(permissionName: .userName, isPermissionGranted: .allowed, permissionRequestDescription: "permissionDesc")])

--- a/Tests/Unit/RealMiniAppTests+Permissions.swift
+++ b/Tests/Unit/RealMiniAppTests+Permissions.swift
@@ -52,6 +52,7 @@ class RealMiniAppPermissionTests: QuickSpec {
             }
             context("when we store permission") {
                 it("will store them persistently") {
+                    realMiniApp.miniAppManifest = mockMiniAppManifest
                     realMiniApp.storeCustomPermissions(
                         forMiniApp: "test",
                         permissionList: [MASDKCustomPermissionModel(permissionName: .userName, isPermissionGranted: .allowed, permissionRequestDescription: "permissionDesc")])

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -25,6 +25,11 @@ class RealMiniAppTests: QuickSpec {
             realMiniApp.miniAppDownloader = downloader
             let mockMessageInterface = MockMessageInterface()
 
+            beforeEach {
+                mockAPIClient.metaData = mockMetaDataString.data(using: .utf8)
+                updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
+                updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .profilePhoto, status: .allowed)
+            }
             context("when getMiniApp is called with valid app id") {
                 it("will return valid MiniAppInfo") {
                     var decodedResponse: MiniAppInfo?

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -145,7 +145,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will return valid Mini App View instance with a default hostAppMessageDelegate and getUniqueId() will return an error message") {
                     let responseString = """
                     [{
-                        "id": "123",
+                        "id": "app-id-test",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -159,8 +159,13 @@ class RealMiniAppTests: QuickSpec {
                         "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .profilePhoto, status: .allowed)
+
                     mockAPIClient.data = responseString.data(using: .utf8)
+                    mockAPIClient.metaData = mockMetaDataString.data(using: .utf8)
                     mockAPIClient.manifestData = manifestResponse.data(using: .utf8)
+
                     waitUntil { done in
                         realMiniApp.createMiniApp(appId: mockMiniAppInfo.id, completionHandler: { (result) in
                             switch result {
@@ -185,7 +190,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will return valid Mini App View instance with a default hostAppMessageDelegate and getUniqueId() will return an error message") {
                     let responseString = """
                     [{
-                        "id": "123",
+                        "id": "app-id-test",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -199,8 +204,11 @@ class RealMiniAppTests: QuickSpec {
                         "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .profilePhoto, status: .allowed)
                     mockAPIClient.data = responseString.data(using: .utf8)
                     mockAPIClient.manifestData = manifestResponse.data(using: .utf8)
+                    mockAPIClient.metaData = mockMetaDataString.data(using: .utf8)
                     waitUntil { done in
                         realMiniApp.createMiniApp(appInfo: mockMiniAppInfo, completionHandler: { (result) in
                             switch result {
@@ -225,7 +233,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will download mini app with the mini app info that is passed on") {
                     let responseString = """
                     [{
-                        "id": "123",
+                        "id": "app-id-test",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -259,7 +267,7 @@ class RealMiniAppTests: QuickSpec {
 
                     let responseString = """
                     [{
-                        "id": "123",
+                        "id": "app-id-test",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -292,7 +300,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will return error") {
                     let responseString = """
                     [{
-                        "id": "123",
+                        "id": "app-id-test",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -328,7 +336,7 @@ class RealMiniAppTests: QuickSpec {
 
                     let responseString = """
                     [{
-                        "id": "123",
+                        "id": "app-id-test",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -150,7 +150,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will return valid Mini App View instance with a default hostAppMessageDelegate and getUniqueId() will return an error message") {
                     let responseString = """
                     [{
-                        "id": "app-id-test",
+                        "id": "\(mockMiniAppInfo.id)",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -195,7 +195,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will return valid Mini App View instance with a default hostAppMessageDelegate and getUniqueId() will return an error message") {
                     let responseString = """
                     [{
-                        "id": "app-id-test",
+                        "id": "\(mockMiniAppInfo.id)",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -238,7 +238,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will download mini app with the mini app info that is passed on") {
                     let responseString = """
                     [{
-                        "id": "app-id-test",
+                        "id": "\(mockMiniAppInfo.id)",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -272,7 +272,7 @@ class RealMiniAppTests: QuickSpec {
 
                     let responseString = """
                     [{
-                        "id": "app-id-test",
+                        "id": "\(mockMiniAppInfo.id)",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -305,7 +305,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will return error") {
                     let responseString = """
                     [{
-                        "id": "app-id-test",
+                        "id": "\(mockMiniAppInfo.id)",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {
@@ -341,7 +341,7 @@ class RealMiniAppTests: QuickSpec {
 
                     let responseString = """
                     [{
-                        "id": "app-id-test",
+                        "id": "\(mockMiniAppInfo.id)",
                         "displayName": "Test",
                         "icon": "https://test.com",
                         "version": {

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1,14 +1,14 @@
 # MiniApp
 
 This open-source library allows you to integrate Mini App ecosystem into your iOS applications.
-Mini App SDK also facilitates communication between a mini app and the host app via a message bridge.
+Mini App SDK also facilitates communication between a Mini App and the host app via a message bridge.
 
 ## Features
 
 - Load MiniApp list
 - Load MiniApp metadata
 - Create a MiniApp view
-- Facilitate communication between host app and mini app
+- Facilitate communication between host app and Mini App
 
 And much more features which you can find them in [Usage](#usage).
 
@@ -74,8 +74,9 @@ Config.userDefaults?.set("MY_CUSTOM_ID", forKey: Config.Key.subscriptionKey.rawV
     * [Retrieve User Profile details](#retrieve-user-profile-details)
 * [Load the Mini App list](#load-miniapp-list)
 * [Get a MiniAppInfo](#get-mini-appinfo)
-* [Getting a MiniApp meta-data](#get-mini-meta-data)
-* [How to use MiniApp meta-data](#how-to-use-meta-data)
+* [Mini App meta-data](#mini-meta-data)
+    * [Getting a MiniApp meta-data](#get-mini-meta-data)
+    * [How to use MiniApp meta-data](#how-to-use-meta-data)
 * [List Downloaded Mini apps](#list-downloaded-mini-apps)
 * [Advanced Features](#advanced-features)
     * [Overriding configuration on runtime](#runtime-conf)
@@ -83,7 +84,7 @@ Config.userDefaults?.set("MY_CUSTOM_ID", forKey: Config.Key.subscriptionKey.rawV
     * [Opening external links](#Opening-external-links)
     * [Orientation Lock](#orientation-lock)
     * [Catching analytics events](#analytics-events)
-    * [Passing Query parameters while creating Mini-app](#query-param-mini-app)
+    * [Passing Query parameters while creating Mini App](#query-param-mini-app)
 
 <a id="create-mini-app"></a>
 
@@ -91,15 +92,15 @@ Config.userDefaults?.set("MY_CUSTOM_ID", forKey: Config.Key.subscriptionKey.rawV
 ---
 **API Docs:** `MiniApp.create(appId:completionHandler:messageInterface:)`, `MiniAppDisplayDelegate`
 
-`MiniApp.create` is used to create a `View` for displaying a specific mini app. You must provide the mini app ID which you wish to create (you can get the mini-app ID by [Loading the Mini App List](#load-miniapp-list) first). Calling `MiniApp.create` will do the following:
+`MiniApp.create` is used to create a `View` for displaying a specific Mini App. You must provide the Mini App ID which you wish to create (you can get the Mini App ID by [Loading the Mini App List](#load-miniapp-list) first). Calling `MiniApp.create` will do the following:
 
-- Checks with the platform what is the latest and published version of the mini app.
-- Check if the latest version of the mini app has been already downloaded 
-    - If yes, return the already downloaded mini app view.
+- Checks with the platform what is the latest and published version of the Mini App.
+- Check if the latest version of the Mini App has been already downloaded 
+    - If yes, return the already downloaded Mini App view.
     - If not, download the latest version and then return the view
-- If the device is disconnected from the internet and if the device already has a version of the mini app downloaded, then the already downloaded version will be returned immediately.
+- If the device is disconnected from the internet and if the device already has a version of the Mini App downloaded, then the already downloaded version will be returned immediately.
 
-After calling `MiniApp.create`, you will obtain an instance of `MiniAppDisplayDelegate` which is the delegate of the Display module. You can call `MiniAppDisplayDelegate.getMiniAppView` to obtain a `View` for displaying the mini app.
+After calling `MiniApp.create`, you will obtain an instance of `MiniAppDisplayDelegate` which is the delegate of the Display module. You can call `MiniAppDisplayDelegate.getMiniAppView` to obtain a `View` for displaying the Mini App.
 
 The following is a simplified example:
 
@@ -210,7 +211,7 @@ let miniAppPermissionsList = MiniApp.shared().getCustomPermissions(forMiniApp: m
 
 <a id="store-custom-permission"></a>
 ##### Store the Mini App Custom Permissions
-Custom permissions for a mini app is cached by the SDK and you can use the following interface to store and retrieve it when you need.
+Custom permissions for a Mini App is cached by the SDK and you can use the following interface to store and retrieve it when you need.
 
 ```swift
  MiniApp.shared().setCustomPermissions(forMiniApp: String, permissionList: [MASDKCustomPermissionModel])
@@ -435,9 +436,13 @@ MiniApp.shared(with: Config.getCurrent()).info(miniAppId: miniAppID) { (result) 
 }
 ```
 
+<a id="mini-meta-data"></a>
+
+### Mini App meta-data
+
 <a id="get-mini-meta-data"></a>
 
-### Getting a `MiniApp meta-data` :
+#### Getting a `MiniApp meta-data` :
 ---
 
 MiniApp developers can define the `required` & `optional` permissions in the `manifest.json` file like below. Also, they can add any custom variables/items inside `customMetaData`.
@@ -488,16 +493,16 @@ MiniApp.shared().getMiniAppManifest(miniAppId: miniAppId, miniAppVersion: miniAp
 
 <a id="get-mini-meta-data"></a>
 
-### How to use `MiniApp meta-data` :
+#### How to use `MiniApp meta-data` :
 ---
 
-SDK internally checks if the User has responded to the list of required/optional permissions that is enforced by the mini-app. So host app SHOULD make sure that the user is prompted with necessary custom permissions and get the response back from the user.
+SDK internally checks if the User has responded to the list of required/optional permissions that are enforced by the Mini App. So host app SHOULD make sure that the user is prompted with necessary custom permissions and get the response back from the user.
 
-Before calling the MiniApp.create, host app should make sure the following things are done,
+Before calling the `MiniApp.create`, host app should make sure the following things are done:
 
-* Retrieve the meta-data for the mini-app using [getMiniAppManifest](#get-mini-meta-data)
+* Retrieve the meta-data for the Mini App using [getMiniAppManifest](#get-mini-meta-data)
 * Display/Prompt the list of required & optional permissions to the user and the user response should be stored using [MiniApp.setCustomPermissions](#store-custom-permission)
-* Call [MiniApp.create](#create-mini-app) to start downloading the mini-app
+* Call [MiniApp.create](#create-mini-app) to start downloading the Mini App
 
 <a id="list-downloaded-mini-apps"></a>
 
@@ -605,9 +610,9 @@ extension ExternalWebViewController: WKNavigationDelegate {
 #### Orientation Lock
 
 
-You can choose to give orientation lock control to mini apps. However, this requires you to add some code to your `AppDelegate` which could have an affect on your entire App. If you do not wish to do this, please see the section *"Allow only full screen videos to change orientation".*
+You can choose to give orientation lock control to Mini Apps. However, this requires you to add some code to your `AppDelegate` which could have an affect on your entire App. If you do not wish to do this, please see the section *"Allow only full screen videos to change orientation".*
 
-##### Allow mini apps to lock the view to any orientation
+##### Allow Mini Apps to lock the view to any orientation
     
 ```swift
 func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
@@ -624,7 +629,7 @@ func application(_ application: UIApplication, supportedInterfaceOrientationsFor
 
 ##### Allow full screen videos to change orientation
 
-You can add the following if you want to enable videos to change orientation. Note that if you do not wish to add code to `AppDelegate` as in the above example, you can still allow videos inside the mini app to use landscape mode even when your App is locked to portrait mode and vice versa.
+You can add the following if you want to enable videos to change orientation. Note that if you do not wish to add code to `AppDelegate` as in the above example, you can still allow videos inside the Mini App to use landscape mode even when your App is locked to portrait mode and vice versa.
 
 ```swift
 import AVKit
@@ -679,9 +684,9 @@ Here is an example of data contained in payload:
 
 <a id="query-param-mini-app"></a>
 
-### Passing Query parameters while creating Mini-app
+### Passing Query parameters while creating Mini App
 
-While creating a mini app, you can pass the optional query parameter as well. This query parameter will be appended to the mini-app's URL.
+While creating a Mini App, you can pass the optional query parameter as well. This query parameter will be appended to the Mini App's URL.
 
 For eg.,
 
@@ -699,7 +704,7 @@ MiniApp.shared().create(appId: String, queryParams: "param1=value1&param2=value2
 
 ```
 
-And the mini-app will be loaded like the following scheme,
+And the Mini App will be loaded like the following scheme,
 
 ```mscheme.rakuten//miniapp/index.html?param1=value1&param2=value2```
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -491,7 +491,7 @@ MiniApp.shared().getMiniAppManifest(miniAppId: miniAppId, miniAppVersion: miniAp
 }
 ```
 
-<a id="get-mini-meta-data"></a>
+<a id="how-to-use-meta-data"></a>
 
 #### How to use `MiniApp meta-data` :
 ---

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -75,6 +75,7 @@ Config.userDefaults?.set("MY_CUSTOM_ID", forKey: Config.Key.subscriptionKey.rawV
 * [Load the Mini App list](#load-miniapp-list)
 * [Get a MiniAppInfo](#get-mini-appinfo)
 * [Getting a MiniApp meta-data](#get-mini-meta-data)
+* [How to use MiniApp meta-data](#how-to-use-meta-data)
 * [List Downloaded Mini apps](#list-downloaded-mini-apps)
 * [Advanced Features](#advanced-features)
     * [Overriding configuration on runtime](#runtime-conf)
@@ -207,6 +208,7 @@ Custom permissions and its status can be retrieved using the following interface
 let miniAppPermissionsList = MiniApp.shared().getCustomPermissions(forMiniApp: miniAppId)
 ```
 
+<a id="store-custom-permission"></a>
 ##### Store the Mini App Custom Permissions
 Custom permissions for a mini app is cached by the SDK and you can use the following interface to store and retrieve it when you need.
 
@@ -483,6 +485,19 @@ MiniApp.shared().getMiniAppManifest(miniAppId: miniAppId, miniAppVersion: miniAp
 	...
 }
 ```
+
+<a id="get-mini-meta-data"></a>
+
+### How to use `MiniApp meta-data` :
+---
+
+SDK internally checks if the User has responded to the list of required/optional permissions that is enforced by the mini-app. So host app SHOULD make sure that the user is prompted with necessary custom permissions and get the response back from the user.
+
+Before calling the MiniApp.create, host app should make sure the following things are done,
+
+* Retrieve the meta-data for the mini-app using [getMiniAppManifest](#get-mini-meta-data)
+* Display/Prompt the list of required & optional permissions to the user and the user response should be stored using [MiniApp.setCustomPermissions](#store-custom-permission)
+* Call [MiniApp.create](#create-mini-app) to start downloading the mini-app
 
 <a id="list-downloaded-mini-apps"></a>
 


### PR DESCRIPTION
# Description
* Added new interface `getDownloadedManifest` to return the cached MiniAppManifest
* Added new key to store MiniAppManifest
* Updated SDK to verify if the User has agreed to all required permissions before launching the mini-app
* Update MiniApp.setCustomPermissions to set only the list of custom permissions that are mentioned in the manifest.json
* Update MiniApp.getCustomPermissions to return only the list of custom permissions that are mentioned in the manifest.json

## Links
[MINI-2508](https://jira.rakuten-it.com/jira/browse/MINI-2508)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
