### PR TITLE
retry mechanism on 500 errors

### DIFF
--- a/MiniApp/Classes/core/MiniAppClient.swift
+++ b/MiniApp/Classes/core/MiniAppClient.swift
@@ -100,8 +100,7 @@ internal class MiniAppClient: NSObject, URLSessionDownloadDelegate {
                         let backOff = 2.0
                         let retry = retry500 + 1
                         let waitTime = 0.5*pow(backOff, Double(retry500))
-                        let failureMessage = "urlRequest \(urlRequest.url?.absoluteString ?? "-") : Failure (\(retry))."
-
+                        let failureMessage = "\(failure.localizedDescription) : Attempt [\(retry)]."
                         MiniAppLogger.d("\(failureMessage) \nRetry in \(waitTime)s", "🟠")
                         return DispatchQueue.main.asyncAfter(deadline: .now() + waitTime) {
                             self.requestFromServer(urlRequest: urlRequest, retry500: retry, completionHandler: completionHandler)


### PR DESCRIPTION
# Description
Currently the SDK only tries a request one time. There are some circumstances where the backend could be unstable and return a 500 response.

Implement request retries in the SDK for the `500` response code. The SDK should retry 5 times, with a backoff multiplier of 2. For example:

Initial Request --> failed --> wait 0.5 seconds --> First retry --> failed --> wait 1 second --> Second retry --> failed --> wait 2 seconds --> etc...

## Links
[MINI-1640](https://jira.rakuten-it.com/jira/browse/MINI-1640)

# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
