### PR TITLE
Allow mini app to request only permissions that is defined in manifest

### DIFF
--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppJavaScriptPermissionManager.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppJavaScriptPermissionManager.swift
@@ -27,8 +27,13 @@ extension MiniAppScriptMessageHandler {
             miniAppPermissionRequestModelList.contains($0)
         }
 
-        let userNotRespondedRequestList = miniAppPermissionRequestModelList.filter {
+        var userNotRespondedRequestList = miniAppPermissionRequestModelList.filter {
             !allowedList.contains($0)
+        }
+
+        /// To make sure that only permissions mentioned in the manifest is allowed at run-time
+        userNotRespondedRequestList = userNotRespondedRequestList.filter {
+            cachedPermissionsList.contains($0)
         }
 
         if userNotRespondedRequestList.count > 0 {

--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -17,6 +17,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     var miniAppTitle: String
     var userAlreadyRespondedRequestList = [MASDKCustomPermissionModel]()
     var cachedUnknownCustomPermissionRequest = [MiniAppCustomPermissionsListResponse]()
+    var permissionsNotAddedInManifest = [MASDKCustomPermissionModel]()
     var miniAppKeyStore = MiniAppPermissionsStorage()
 
     init(delegate: MiniAppCallbackDelegate, hostAppMessageDelegate: MiniAppMessageDelegate, adsDisplayer: MiniAppAdDisplayer?, miniAppId: String, miniAppTitle: String) {

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -212,6 +212,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         adsDisplayer: mockAdsDelegate,
                         miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
                     )
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppID, permissionType: .userName, status: .allowed)
                     mockMessageInterface.customPermissions = true
                     let mockMessage = MockWKScriptMessage(
                         name: "", body: "{\"action\":\"requestCustomPermissions\",\"param\":{\"permissions\":" + "[{\"name\":\"rakuten.miniapp.user.USER_NAME\"," +
@@ -222,8 +223,12 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         return
                     }
                     let decodedObj = try JSONDecoder().decode(MiniAppCustomPermissionsResponse.self, from: responseData)
-                    expect(decodedObj.permissions[0].name).toEventually(equal("rakuten.miniapp.user.USER_NAME"), timeout: .seconds(10))
-                    expect(decodedObj.permissions[0].status).toEventually(equal("ALLOWED"), timeout: .seconds(10))
+                    if decodedObj.permissions.count > 0 {
+                        expect(decodedObj.permissions[0].name).toEventually(equal("rakuten.miniapp.user.USER_NAME"), timeout: .seconds(10))
+                        expect(decodedObj.permissions[0].status).toEventually(equal("ALLOWED"), timeout: .seconds(10))
+                    } else {
+                        fail("create MiniApp failure")
+                    }
                 }
             }
             context("when MiniAppScriptMessageHandler receives valid custom permissions command but invalid permission object title instead of name") {

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -75,12 +75,6 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             }
             context("when handleBridgeMessage receive valid action, invalid id") {
                 it("will return error") {
-                    let scriptMessageHandler = MiniAppScriptMessageHandler(
-                        delegate: callbackProtocol,
-                        hostAppMessageDelegate: mockMessageInterface,
-                        adsDisplayer: mockAdsDelegate,
-                        miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
-                    )
                     let requestParam = RequestParameters(
                         action: "",
                         permission: "location",
@@ -98,12 +92,6 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             context("when handleActionCommand receive valid action, but failed to retrieve unique id") {
                 it("will return error") {
                     mockMessageInterface.mockUniqueId = true
-                    let scriptMessageHandler = MiniAppScriptMessageHandler(
-                        delegate: callbackProtocol,
-                        hostAppMessageDelegate: mockMessageInterface,
-                        adsDisplayer: mockAdsDelegate,
-                        miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
-                    )
                     scriptMessageHandler.sendUniqueId(messageId: "1234")
                     expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.internalError.rawValue))
                     expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.internalError.description))
@@ -111,12 +99,6 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             }
             context("when MiniAppScriptMessageHandler receives valid requestPermission command and request parameter, but user allow the location permission") {
                 it("will return ALLOWED") {
-                    let scriptMessageHandler = MiniAppScriptMessageHandler(
-                        delegate: callbackProtocol,
-                        hostAppMessageDelegate: mockMessageInterface,
-                        adsDisplayer: mockAdsDelegate,
-                        miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
-                    )
                     mockMessageInterface.locationAllowed = true
                     let mockMessage = MockWKScriptMessage(name: "", body: "{\"action\": \"requestPermission\", \"param\": { \"permission\": \"location\"}, \"id\":\"12345\"}" as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
@@ -125,12 +107,6 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             }
             context("when MiniAppScriptMessageHandler receives valid requestPermission command and request parameter, but user denied the permission") {
                 it("will return denied") {
-                    let scriptMessageHandler = MiniAppScriptMessageHandler(
-                        delegate: callbackProtocol,
-                        hostAppMessageDelegate: mockMessageInterface,
-                        adsDisplayer: mockAdsDelegate,
-                        miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
-                    )
                     mockMessageInterface.locationAllowed = false
                     let mockMessage = MockWKScriptMessage(name: "", body: "{\"action\": \"requestPermission\", \"param\": { \"permission\": \"location\"}, \"id\":\"12345\"}" as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -182,12 +182,6 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
 
             context("when MiniAppScriptMessageHandler receives valid custom permissions command") {
                 it("will return response with name and status for all permission that is requested") {
-                    let scriptMessageHandler = MiniAppScriptMessageHandler(
-                        delegate: callbackProtocol,
-                        hostAppMessageDelegate: mockMessageInterface,
-                        adsDisplayer: mockAdsDelegate,
-                        miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
-                    )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppID, permissionType: .userName, status: .allowed)
                     mockMessageInterface.customPermissions = true
                     let mockMessage = MockWKScriptMessage(
@@ -209,12 +203,6 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             }
             context("when MiniAppScriptMessageHandler receives valid custom permissions command but invalid permission object title instead of name") {
                 it("will return error response with error title and description for permission that is requested") {
-                    let scriptMessageHandler = MiniAppScriptMessageHandler(
-                        delegate: callbackProtocol,
-                        hostAppMessageDelegate: mockMessageInterface,
-                        adsDisplayer: mockAdsDelegate,
-                        miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
-                    )
                     mockMessageInterface.customPermissions = true
                     let mockMessage = MockWKScriptMessage(
                         name: "", body: "{\"action\":\"requestCustomPermissions\",\"param\":{\"permissions\":" + "[{\"title\":\"rakuten.miniapp.user.USER_NAME\"," +
@@ -226,12 +214,6 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             }
             context("when MiniAppScriptMessageHandler receives valid custom permissions command but only one unknown custom permission") {
                 it("will return error response with error title and description for permission that is requested") {
-                    let scriptMessageHandler = MiniAppScriptMessageHandler(
-                        delegate: callbackProtocol,
-                        hostAppMessageDelegate: mockMessageInterface,
-                        adsDisplayer: mockAdsDelegate,
-                        miniAppId: mockMiniAppID, miniAppTitle: mockMiniAppTitle
-                    )
                     mockMessageInterface.customPermissions = true
                     let mockMessage = MockWKScriptMessage(
                         name: "", body: "{\"action\":\"requestCustomPermissions\",\"param\":{\"permissions\":" + "[{\"name\":\"rakuten.miniapp.user.LOCATION\"," +


### PR DESCRIPTION
# Description
Ignore/filter to not request custom permissions if it is not mentioned in manifest

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
