### PR TITLE
Google ads loading after network failure

### DIFF
--- a/MiniApp/Classes/admob/AdMobDisplayer.swift
+++ b/MiniApp/Classes/admob/AdMobDisplayer.swift
@@ -62,6 +62,7 @@ public class AdMobDisplayer: MiniAppAdDisplayer {
             GADInterstitialAd.load(withAdUnitID: adId, request: request) { [weak self]  (interstitialAd, error) in
                 if let error = error {
                     self?.onInterstitialLoaded[adId]?(.failure(error))
+                    cleanInterstitial(adId)
                 } else {
                     interstitialAd?.fullScreenContentDelegate = self
                     self?.interstitialAds[adId] = interstitialAd
@@ -80,6 +81,7 @@ public class AdMobDisplayer: MiniAppAdDisplayer {
                     request: request, completionHandler: { [weak self] (rewardedAd, error) in
                 if let err = error {
                     onLoaded(.failure(err))
+                    cleanReward(adId)
                 } else {
                     rewardedAd?.fullScreenContentDelegate = self
                     self?.rewardedAds[adId] = rewardedAd

--- a/MiniApp/Classes/admob7/AdMobDisplayer.swift
+++ b/MiniApp/Classes/admob7/AdMobDisplayer.swift
@@ -128,6 +128,7 @@ extension AdMobDisplayer: GADInterstitialDelegate {
     public func interstitial(_ ad: GADInterstitial, didFailToReceiveAdWithError error: GADRequestError) { // swiftlint:disable:this identifier_name
         if let id = ad.adUnitID {
             onInterstitialLoaded[id]?(.failure(error))
+            cleanInterstitial(id)
         }
     }
 }

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -16,7 +16,7 @@ All the MiniApp files downloaded by the MiniApp iOS library are cached locally
 
 ## Requirements
 
-This module supports **iOS 11.0 and above**. It has been tested on iOS 11.0 and above.
+This module supports **iOS 13.0 and above**. It has been tested on iOS 13.0 and above.
 
 It is written in Swift 5.0 and can be used in compatible Xcode versions.
 


### PR DESCRIPTION
# Description
Google ads were not loadable at all after a loading failure


# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
