### PR TITLE
Added VersionId to MiniAppManifest

### DIFF
--- a/MiniApp/Classes/core/MiniAppInfoFetcher.swift
+++ b/MiniApp/Classes/core/MiniAppInfoFetcher.swift
@@ -53,18 +53,20 @@ internal class MiniAppInfoFetcher {
                 }
                 return completionHandler(.success(
                                             self.prepareMiniAppManifest(
-                                                metaDataResponse: decodeResponse.bundleManifest)))
+                                                metaDataResponse: decodeResponse.bundleManifest,
+                                                versionId: miniAppVersion)))
             case .failure(let error):
                 return completionHandler(.failure(.fromError(error: error)))
             }
         }
     }
 
-    func prepareMiniAppManifest(metaDataResponse: MetaDataCustomPermissionModel) -> MiniAppManifest {
+    func prepareMiniAppManifest(metaDataResponse: MetaDataCustomPermissionModel, versionId: String) -> MiniAppManifest {
         return MiniAppManifest(requiredPermissions: getCustomPermissionModel(metaDataCustomPermissionResponse: metaDataResponse.reqPermissions),
             optionalPermissions: getCustomPermissionModel(
                 metaDataCustomPermissionResponse: metaDataResponse.optPermissions),
-            customMetaData: metaDataResponse.customMetaData)
+            customMetaData: metaDataResponse.customMetaData,
+            versionId: versionId)
     }
 
     private func getCustomPermissionModel(metaDataCustomPermissionResponse: [MACustomPermissionsResponse]?) -> [MASDKCustomPermissionModel]? {

--- a/MiniApp/Classes/core/Models/MiniAppManifest.swift
+++ b/MiniApp/Classes/core/Models/MiniAppManifest.swift
@@ -40,19 +40,24 @@ public struct MiniAppManifest: Codable, Equatable {
     public let optionalPermissions: [MASDKCustomPermissionModel]?
     /// Key-value pair data that is received from the endpoint
     public let customMetaData: [String: String]?
+    /// VersionId of the Mini-App
+    public let versionId: String?
 
     private enum CodingKeys: String, CodingKey {
         case requiredPermissions,
              optionalPermissions,
-             customMetaData
+             customMetaData,
+             versionId
     }
 
     init(requiredPermissions: [MASDKCustomPermissionModel]?,
          optionalPermissions: [MASDKCustomPermissionModel]?,
-         customMetaData: [String: String]?) {
+         customMetaData: [String: String]?,
+         versionId: String?) {
         self.requiredPermissions = requiredPermissions
         self.optionalPermissions = optionalPermissions
         self.customMetaData = customMetaData
+        self.versionId = versionId
     }
 
     public static func == (lhs: MiniAppManifest, rhs: MiniAppManifest) -> Bool {

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -160,7 +160,8 @@ class MockMiniAppInfoFetcher: MiniAppInfoFetcher {
                 if let decodeResponse = ResponseDecoder.decode(decodeType: MetaDataResponse.self,
                                                                data: responseData.data) {
                     return completionHandler(.success(self.prepareMiniAppManifest(
-                                                        metaDataResponse: decodeResponse.bundleManifest)))
+                                                        metaDataResponse: decodeResponse.bundleManifest,
+                                                        versionId: miniAppVersion)))
                 }
                 return completionHandler(.failure(.invalidResponseData))
             case .failure(let error):
@@ -365,7 +366,7 @@ var mockMiniAppManifest: MiniAppManifest {
                                                                                         permissionRequestDescription: "Contact List custom permission")
                                                             ]
     let customMetaData: [String: String] = ["exampleKey": "exampleValue"]
-    let manifest = MiniAppManifest.init(requiredPermissions: requiredPermissions, optionalPermissions: optionalPermissions, customMetaData: customMetaData)
+    let manifest = MiniAppManifest.init(requiredPermissions: requiredPermissions, optionalPermissions: optionalPermissions, customMetaData: customMetaData, versionId: "ver-id-test")
     return manifest
 }
 


### PR DESCRIPTION
# Description
* Existing cached mini-app `manifest` will return nil, `Manifest` that will be stored from now on will be stored along with `VersionId`

## Links
* MINI-2936

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
