### PR TITLE
Fix for Mini app Offline loading

### DIFF
--- a/Example/Controllers/ViewController.swift
+++ b/Example/Controllers/ViewController.swift
@@ -111,7 +111,7 @@ class ViewController: UIViewController {
             case .success(let manifestData):
                 self.checkIfManifestChanged(latestManifest: manifestData, oldManifest: downloadedManifest, miniAppInfo: miniAppInfo)
             case .failure(let error):
-                if self.isDownloadingFailed(error: error) {
+                if error.isDeviceOfflineDownloadError() {
                     self.displayMiniApp(miniAppInfo: miniAppInfo)
                 } else {
                     completionHandler(.failure(error))
@@ -168,14 +168,6 @@ class ViewController: UIViewController {
             self.currentMiniAppInfo = miniAppInfo
             self.fetchMiniApp(for: miniAppInfo)
             self.currentMiniAppTitle = miniAppInfo.displayName
-        }
-    }
-
-    func isDownloadingFailed(error: MASDKError) -> Bool {
-        if error.isDeviceOfflineDownloadError() {
-            return true
-        } else {
-            return false
         }
     }
 }

--- a/Example/Controllers/ViewController.swift
+++ b/Example/Controllers/ViewController.swift
@@ -111,7 +111,11 @@ class ViewController: UIViewController {
             case .success(let manifestData):
                 self.checkIfManifestChanged(latestManifest: manifestData, oldManifest: downloadedManifest, miniAppInfo: miniAppInfo)
             case .failure(let error):
-                completionHandler(.failure(error))
+                if self.isDownloadingFailed(error: error) {
+                    self.displayMiniApp(miniAppInfo: miniAppInfo)
+                } else {
+                    completionHandler(.failure(error))
+                }
             }
         }
     }
@@ -164,6 +168,14 @@ class ViewController: UIViewController {
             self.currentMiniAppInfo = miniAppInfo
             self.fetchMiniApp(for: miniAppInfo)
             self.currentMiniAppTitle = miniAppInfo.displayName
+        }
+    }
+
+    func isDownloadingFailed(error: MASDKError) -> Bool {
+        if error.isDeviceOfflineDownloadError() {
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/MiniApp/Classes/core/MASDKError.swift
+++ b/MiniApp/Classes/core/MASDKError.swift
@@ -47,13 +47,10 @@ public enum MASDKError: Error {
     public func isDeviceOfflineDownloadError() -> Bool {
         switch self {
         case .unknownError(_, let code, _):
-            if offlineErrorCodeList.contains(code) {
-                return true
-            }
+            return offlineErrorCodeList.contains(code)
         default:
             return false
         }
-        return false
     }
 }
 

--- a/MiniApp/Classes/core/MASDKError.swift
+++ b/MiniApp/Classes/core/MASDKError.swift
@@ -41,6 +41,20 @@ public enum MASDKError: Error {
     ///     - message: The code from the original NSError.
     ///     - description: The description from the original NSError
     case unknownError(domain: String, code: Int, description: String)
+
+    /// Checks if the error is due to the Internet availability, returns true if yes
+    /// - Returns: Bool value - returns true if there is there error contains code from offlineErrorCodeList
+    public func isDeviceOfflineDownloadError() -> Bool {
+        switch self {
+        case .unknownError(_, let code, _):
+            if offlineErrorCodeList.contains(code) {
+                return true
+            }
+        default:
+            return false
+        }
+        return false
+    }
 }
 
 extension MASDKError: LocalizedError {

--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -321,12 +321,10 @@ internal class RealMiniApp {
     }
 
     func isDeviceOfflineError(error: NSError) -> Bool {
-        if error.domain == MASDKErrorDomain {
-            return (error as? MASDKError)?.isDeviceOfflineDownloadError() ?? false
-        } else if offlineErrorCodeList.contains(error.code) {
-            return true
-        }
-        return false
+        if error.domain == MASDKErrorDomain, let maSDKError = error as? MASDKError {
+            return maSDKError.isDeviceOfflineDownloadError()
+        } 
+        return offlineErrorCodeList.contains(error.code)
     }
 }
 

--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -7,7 +7,6 @@ internal class RealMiniApp {
     var miniAppStatus: MiniAppStatus
     var miniAppPermissionStorage: MiniAppPermissionsStorage
     var miniAppManifestStorage: MAManifestStorage
-    let offlineErrorCodeList: [Int] = [NSURLErrorNotConnectedToInternet, NSURLErrorTimedOut]
 
     convenience init() {
         self.init(with: nil)
@@ -165,7 +164,7 @@ internal class RealMiniApp {
                                     messageInterface: MiniAppMessageDelegate? = nil,
                                     adsDisplayer: MiniAppAdDisplayer? = nil) {
         let downloadError = error as NSError
-        if self.offlineErrorCodeList.contains(downloadError.code) {
+        if isDeviceOfflineError(error: downloadError) {
             guard let miniAppInfo = self.miniAppStatus.getMiniAppInfo(appId: appId) else {
                 return completionHandler(.failure(error))
             }
@@ -307,6 +306,18 @@ internal class RealMiniApp {
     /// - Returns: MiniAppManifest object
     func getCachedManifestData(appId: String) -> MiniAppManifest? {
         return self.miniAppManifestStorage.getManifestInfo(forMiniApp: appId)?.miniAppManifest
+    }
+
+    func isDeviceOfflineError(error: NSError) -> Bool {
+        if error.domain == MASDKErrorDomain {
+            guard let sdkError = error as? MASDKError, sdkError.isDeviceOfflineDownloadError() else {
+                return false
+            }
+            return true
+        } else if offlineErrorCodeList.contains(error.code) {
+            return true
+        }
+        return false
     }
 }
 

--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -322,10 +322,7 @@ internal class RealMiniApp {
 
     func isDeviceOfflineError(error: NSError) -> Bool {
         if error.domain == MASDKErrorDomain {
-            guard let sdkError = error as? MASDKError, sdkError.isDeviceOfflineDownloadError() else {
-                return false
-            }
-            return true
+            return (error as? MASDKError)?.isDeviceOfflineDownloadError() ?? false
         } else if offlineErrorCodeList.contains(error.code) {
             return true
         }

--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -323,7 +323,7 @@ internal class RealMiniApp {
     func isDeviceOfflineError(error: NSError) -> Bool {
         if error.domain == MASDKErrorDomain, let maSDKError = error as? MASDKError {
             return maSDKError.isDeviceOfflineDownloadError()
-        } 
+        }
         return offlineErrorCodeList.contains(error.code)
     }
 }

--- a/MiniApp/Classes/core/Utilities/Constants.swift
+++ b/MiniApp/Classes/core/Utilities/Constants.swift
@@ -7,3 +7,5 @@ struct Constants {
 }
 
 public typealias MASDKDownloadedListPermissionsPair = [(MiniAppInfo, [MASDKCustomPermissionModel])]
+
+let offlineErrorCodeList: [Int] = [NSURLErrorNotConnectedToInternet, NSURLErrorTimedOut]


### PR DESCRIPTION
# Description
* Updated code to check both MASDKError and Error for Offline caching flow.

## Links
* MINI-3035

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
