### PR TITLE
[MINI-3229] getContacts async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **Feature:** Added `rakuten.miniapp.user.SEND_MESSAGE` custom permission
 - **Feature:** Support Email addresses (`mailto:`) hyperlinks from a mini app. See [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
+- **Deprecated:** `getUniqueId()` in `MiniAppMessageDelegate` protocol is deprecated. You should use `getUniqueId(completionHandler:)` instead
+- **Deprecated:** `getContacts()` in `MiniAppUserInfoDelegate` protocol is deprecated. You should use `getContacts(completionHandler:)` instead
 
 **Sample App**
 
@@ -72,7 +74,7 @@
 - **Feature** Added analytics for Mini App usage tracking
 - **Feature** Updated `getUserName` and `getProfilePhoto` interfaces to be asynchronous. Old methods are deprecated
 - **Feature** Updated `MiniApp().shared.create` interface to accept another optional query string parameter.
-- **Deprecated:** `requestPermission(permissionType:completionHandler:)` in `MiniAppMessageDelegate` protocol is deprecated. You should use `requestDevicePermission(permissionType:completionHandler:))` instead
+- **Deprecated:** `requestPermission(permissionType:completionHandler:)` in `MiniAppMessageDelegate` protocol is deprecated. You should use `requestDevicePermission(permissionType:completionHandler:)` instead
 - **Fixed** Geolocation was not updated after the first GPS fix
 
 **Sample App**
@@ -124,7 +126,7 @@
 - **Feature:** Added support for Orientation lock, that enables the mini app to lock `portrait` or `landscape` orientation for the mini-app. [Please check here](USERGUIDE.md#orientation-lock)
 - **Feature:** Added support to retrieve Access token and expiry date
 - **Feature:** Added default implementation in SDK for `requestCustomPermissions(permissions:miniAppTitle:completionHandler:)` [Please check here](USERGUIDE.md#request-custom-permission)
-- **Deprecated:** `requestCustomPermissions(permissions:completionHandler:)` in `MiniAppCallbackProtocol` protocol is deprecated. You should use `requestCustomPermissions(permissions:miniAppTitle:completionHandler:))` instead
+- **Deprecated:** `requestCustomPermissions(permissions:completionHandler:)` in `MiniAppCallbackProtocol` protocol is deprecated. You should use `requestCustomPermissions(permissions:miniAppTitle:completionHandler:)` instead
 
 **Sample App**
 

--- a/Example/Controllers/Extensions/ViewController+ChatDelegate.swift
+++ b/Example/Controllers/Extensions/ViewController+ChatDelegate.swift
@@ -32,16 +32,23 @@ extension ViewController: ChatMessageBridgeDelegate {
     }
 
     public func sendMessageToContactId(_ contactId: String, message: MessageToContact, completionHandler: @escaping ChatContactHandler) {
-        if let contacts = getContacts(), let contact = contacts.first(where: { $0.id == contactId }) {
-            presentContactsPicker { chatContactsSelectorViewController in
-                switchCancelHandler(singleIdHandler: completionHandler)
-                chatContactsSelectorViewController.contactToSend = contact
-                chatContactsSelectorViewController.contactHandlerJob = completionHandler
-                chatContactsSelectorViewController.message = message
-                chatContactsSelectorViewController.title = NSLocalizedString("Single contact", comment: "")
+        getContacts { result in
+            switch result {
+            case .success(let contacts):
+                if let contact = contacts?.first(where: { $0.id == contactId }) {
+                    self.presentContactsPicker { chatContactsSelectorViewController in
+                        self.switchCancelHandler(singleIdHandler: completionHandler)
+                        chatContactsSelectorViewController.contactToSend = contact
+                        chatContactsSelectorViewController.contactHandlerJob = completionHandler
+                        chatContactsSelectorViewController.message = message
+                        chatContactsSelectorViewController.title = NSLocalizedString("Single contact", comment: "")
+                    }
+                } else {
+                    fallthrough
+                }
+            default:
+                completionHandler(.failure(.invalidContactId))
             }
-        } else {
-            completionHandler(.failure(.invalidContactId))
         }
     }
 

--- a/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
@@ -16,11 +16,11 @@ extension ViewController: MiniAppUserInfoDelegate {
         completionHandler(.success(userProfilePhoto))
     }
 
-    func getContacts() -> [MAContact]? {
-        guard let userProfile = getProfileSettings(), let contactList = userProfile.contactList else {
-            return nil
+    func getContacts(completionHandler: @escaping (Result<[MAContact]?, MASDKError>) -> ()) {
+        if let userProfile = getProfileSettings(), let contactsList = userProfile.contactList {
+            return completionHandler(.success(contactsList))
         }
-        return contactList
+        completionHandler(.failure(.unknownError(domain: "Unknown Error", code: 1, description: "Failed to retrieve contacts list")))
     }
 
     func getAccessToken(miniAppId: String,

--- a/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
@@ -16,7 +16,7 @@ extension ViewController: MiniAppUserInfoDelegate {
         completionHandler(.success(userProfilePhoto))
     }
 
-    func getContacts(completionHandler: @escaping (Result<[MAContact]?, MASDKError>) -> ()) {
+    func getContacts(completionHandler: @escaping (Result<[MAContact]?, MASDKError>) -> Void) {
         if let userProfile = getProfileSettings(), let contactsList = userProfile.contactList {
             return completionHandler(.success(contactsList))
         }

--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -391,7 +391,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     } else {
                         fallthrough
                     }
-                case .failure(_):
+                case .failure:
                     executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.internalError))
                 }
             }

--- a/MiniApp/Classes/core/Protocols/MiniAppMessageDelegate.swift
+++ b/MiniApp/Classes/core/Protocols/MiniAppMessageDelegate.swift
@@ -51,7 +51,19 @@ public extension MiniAppMessageDelegate {
     @available(*, deprecated,
         renamed: "getUniqueId(completionHandler:)")
     func getUniqueId() -> String? {
-        return nil
+        let semaphore = DispatchSemaphore(value: 0)
+        var uniqueId: String?
+        getUniqueId { result in
+            switch result {
+            case .success(let id):
+                uniqueId = id
+            default:
+                uniqueId = nil
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return uniqueId
     }
 }
 

--- a/Podfile
+++ b/Podfile
@@ -14,8 +14,8 @@ target sdk_name + '_Example' do
 
   target sdk_name + '_Tests' do
     inherit! :search_paths
-    pod 'Quick', '~>9.0.0'
-    pod 'Nimble', '~>3.1.2'
+    pod 'Nimble', '~>9.0.0'
+    pod 'Quick', '~>3.1.2'
   end
 end
 

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 sdk_name = "MiniApp"

--- a/Podfile
+++ b/Podfile
@@ -14,8 +14,8 @@ target sdk_name + '_Example' do
 
   target sdk_name + '_Tests' do
     inherit! :search_paths
-    pod 'Quick'
-    pod 'Nimble'
+    pod 'Quick', '~>9.0.0'
+    pod 'Nimble', '~>3.1.2'
   end
 end
 

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,4 @@
+source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 sdk_name = "MiniApp"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,29 +5,36 @@ PODS:
   - Google-Mobile-Ads-SDK (7.69.0):
     - GoogleAppMeasurement (~> 7.0)
     - GoogleUserMessagingPlatform (~> 1.1)
-  - GoogleAppMeasurement (7.10.0):
+  - GoogleAppMeasurement (7.11.0):
+    - GoogleAppMeasurement/AdIdSupport (= 7.11.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/MethodSwizzler (~> 7.0)
+    - GoogleUtilities/Network (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (7.11.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30908.0)
   - GoogleUserMessagingPlatform (1.4.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.3.1):
+  - GoogleUtilities/AppDelegateSwizzler (7.4.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.3.1):
+  - GoogleUtilities/Environment (7.4.0):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (7.3.1):
+  - GoogleUtilities/Logger (7.4.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.3.1):
+  - GoogleUtilities/MethodSwizzler (7.4.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.3.1):
+  - GoogleUtilities/Network (7.4.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.3.1)"
-  - GoogleUtilities/Reachability (7.3.1):
+  - "GoogleUtilities/NSData+zlib (7.4.0)"
+  - GoogleUtilities/Reachability (7.4.0):
     - GoogleUtilities/Logger
   - MiniApp/Admob (3.2.0):
     - Google-Mobile-Ads-SDK (~> 7.0)
@@ -39,9 +46,9 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Nimble (9.0.0)
+  - Nimble (9.2.0)
   - PromisesObjC (1.2.12)
-  - Quick (3.1.2)
+  - Quick (4.0.0)
   - ZIPFoundation (0.9.12)
 
 DEPENDENCIES:
@@ -71,14 +78,14 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppCenter: cd53e3ed3563cc720bcb806c9731a12389b40d44
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
-  GoogleAppMeasurement: 1c863b1161fc3c8cf614a7460d1be6a7c262aab3
+  GoogleAppMeasurement: fd19169c3034975cb934e865e5667bfdce59df7f
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
-  GoogleUtilities: e1d9ed4e544fc32a93e00e721400cbc3f377200d
+  GoogleUtilities: 284cddc7fffc14ae1907efb6f78ab95c1fccaedc
   MiniApp: 1fcaffcfa4c75738424c414c39584d3c5f3cde40
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
+  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
+  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
 PODFILE CHECKSUM: 0d4a6b3c4863132cc471d772f3d37fe43826db20

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -59,7 +59,7 @@ DEPENDENCIES:
   - Quick
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - AppCenter
     - Google-Mobile-Ads-SDK
     - GoogleAppMeasurement
@@ -88,6 +88,6 @@ SPEC CHECKSUMS:
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 0d4a6b3c4863132cc471d772f3d37fe43826db20
+PODFILE CHECKSUM: 5ebd48f8a691819563d81a11f591885bd461f08a
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -46,17 +46,17 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Nimble (9.2.0)
+  - Nimble (9.0.1)
   - PromisesObjC (1.2.12)
-  - Quick (4.0.0)
+  - Quick (3.1.2)
   - ZIPFoundation (0.9.12)
 
 DEPENDENCIES:
   - AppCenter/Crashes
   - Google-Mobile-Ads-SDK
   - MiniApp/Admob (from `./`)
-  - Nimble
-  - Quick
+  - Nimble (~> 9.0.0)
+  - Quick (~> 3.1.2)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -83,11 +83,11 @@ SPEC CHECKSUMS:
   GoogleUtilities: 284cddc7fffc14ae1907efb6f78ab95c1fccaedc
   MiniApp: 1fcaffcfa4c75738424c414c39584d3c5f3cde40
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
+  Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
+  Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 0d4a6b3c4863132cc471d772f3d37fe43826db20
+PODFILE CHECKSUM: af5a3a26d15a7b9bc2768143d68172dec2992e95
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -59,7 +59,7 @@ DEPENDENCIES:
   - Quick
 
 SPEC REPOS:
-  trunk:
+  https://github.com/CocoaPods/Specs.git:
     - AppCenter
     - Google-Mobile-Ads-SDK
     - GoogleAppMeasurement
@@ -88,6 +88,6 @@ SPEC CHECKSUMS:
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 5ebd48f8a691819563d81a11f591885bd461f08a
+PODFILE CHECKSUM: 0d4a6b3c4863132cc471d772f3d37fe43826db20
 
 COCOAPODS: 1.10.1

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -348,15 +348,15 @@ class MockMessageInterface: MiniAppMessageDelegate {
     }
 
     func getUserName() -> String? {
-        return mockUserName
+        mockUserName
     }
 
     func getProfilePhoto() -> String? {
-        return mockProfilePhoto
+        mockProfilePhoto
     }
 
-    func getContacts() -> [MAContact]? {
-        return mockContactList
+    func getContacts(completionHandler: @escaping (Result<[MAContact]?, MASDKError>) -> ()) {
+        completionHandler(.success(mockContactList))
     }
 
     func getAccessToken(miniAppId: String, scopes: MASDKAccessTokenScopes, completionHandler: @escaping (Result<MATokenInfo, MASDKCustomPermissionError>) -> Void) {

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -355,7 +355,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
         mockProfilePhoto
     }
 
-    func getContacts(completionHandler: @escaping (Result<[MAContact]?, MASDKError>) -> ()) {
+    func getContacts(completionHandler: @escaping (Result<[MAContact]?, MASDKError>) -> Void) {
         completionHandler(.success(mockContactList))
     }
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -375,9 +375,9 @@ Retrieve the Contact list of the User
 
 ```swift
 extension ViewController: MiniAppMessageDelegate {
-    func getContacts() -> [MAContact]? {
+    func getContacts(completionHandler: @escaping (Result<[MAContact]?, MASDKError>) -> Void) {
         // Implementation to return the contact list
-        return []
+        completionHandler(.success([]))
     }
 }
 ```
@@ -428,13 +428,18 @@ extension ViewController: MiniAppMessageDelegate {
   }
 
   public func sendMessageToContactId(_ contactId: String, message: MessageToContact, completionHandler: @escaping (Result<String?, MASDKError>) -> Void) {
-    if let contacts = getContacts(), let contact = contacts.first(where: { $0.id == contactId }) {
-      presentContactsPicker { chatContactsSelectorViewController in
-        // insert here code to send the message
-        completionHandler(.success(contact.id))
+    getContacts { result in
+      switch result {
+      case success(let contacts):
+        if let contact = contacts.first(where: { $0.id == contactId }) {
+          // insert here code to send the message
+          completionHandler(.success(contact.id))
+        } else {
+          fallthrough
+        }
+      default:
+        completionHandler(.failure(.invalidContactId))
       }
-    } else {
-      completionHandler(.success(contact.id))
     }
   }
 


### PR DESCRIPTION
# Description
makes getContacts method async, keeping old implementation with a deprecated fallback.

## Links
[MINI-3229](https://jira.rakuten-it.com/jira/browse/MINI-3229)

# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
