### PR TITLE
localizable crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Feature:** Mini App SDK now supports code updates in preview mode
 - **Deprecated:** `getUniqueId()` in `MiniAppMessageDelegate` protocol is deprecated. You should use `getUniqueId(completionHandler:)` instead
 - **Deprecated:** `getContacts()` in `MiniAppUserInfoDelegate` protocol is deprecated. You should use `getContacts(completionHandler:)` instead
+- **Deprecated:** `localize(bundle:_:params:)` in `MASDKLocale` class is deprecated. You should use `localize(bundle:_:)` instead
 - **Fixed:** Long messages were truncated in sample app
 
 **Sample App**

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -103,7 +103,7 @@ extension ViewController: MiniAppNavigationDelegate {
             switch error {
             case .metaDataFailure:
                 guard let miniAppInfo = currentMiniAppInfo else {
-                    errorMessage =  MASDKLocale.localize("miniapp.sdk.ios.error.message.metadata", MASDKLocale.localize(.downloadFailed))
+                    errorMessage =  String(format: MASDKLocale.localize("miniapp.sdk.ios.error.message.metadata"), MASDKLocale.localize(.downloadFailed))
                     return
                 }
                 self.showFirstTimeLaunchScreen(miniAppInfo: miniAppInfo)

--- a/MiniApp/Classes/admob7/AdMobDisplayer.swift
+++ b/MiniApp/Classes/admob7/AdMobDisplayer.swift
@@ -42,15 +42,15 @@ public class AdMobDisplayer: MiniAppAdDisplayer {
     }
 
     func createNotLoadingReqError(adUnitId: String) -> String {
-        MASDKLocale.localize(.adNotLoadedError, adUnitId)
+        String(format: MASDKLocale.localize(.adNotLoadedError), adUnitId)
     }
 
     func createLoadReqError(adUnitId: String) -> String {
-        MASDKLocale.localize(.adLoadingError, adUnitId)
+        String(format: MASDKLocale.localize(.adLoadingError), adUnitId)
     }
 
     func createLoadTwiceError(adUnitId: String) -> String {
-        MASDKLocale.localize(.adLoadedError, adUnitId)
+        String(format: MASDKLocale.localize(.adLoadedError), adUnitId)
     }
 
     public override func loadInterstitial(for adId: String, onLoaded: @escaping (Result<Void, Error>) -> Void) {

--- a/MiniApp/Classes/core/Display/ViewControllers/Custom Permissions/CustomPermissionsRequestViewController.swift
+++ b/MiniApp/Classes/core/Display/ViewControllers/Custom Permissions/CustomPermissionsRequestViewController.swift
@@ -51,7 +51,7 @@ class CustomPermissionsRequestViewController: UIViewController {
     }
 
     func addFooterInfo() {
-        self.footerLabel.text = MASDKLocale.localize(.firstLaunchFooter, miniAppTitle)
+        footerLabel.text = String(format: MASDKLocale.localize(.firstLaunchFooter), miniAppTitle)
     }
 }
 

--- a/MiniApp/Classes/core/MASDKError.swift
+++ b/MiniApp/Classes/core/MASDKError.swift
@@ -64,7 +64,7 @@ extension MASDKError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .serverError(let code, let message):
-            return MASDKLocale.localize(.serverError, code, message)
+            return String(format: MASDKLocale.localize(.serverError), "\(code)", message)
         case .invalidURLError:
             return MASDKLocale.localize(.invalidUrl)
         case .invalidAppId:
@@ -87,7 +87,7 @@ extension MASDKError: LocalizedError {
             return MASDKLocale.localize(.invalidContactId)
 
         case .unknownError(let domain, let code, let description):
-            return MASDKLocale.localize(.unknownError, domain, code, description)
+            return String(format: MASDKLocale.localize(.unknownError), domain, "\(code)", description)
         }
     }
 }

--- a/MiniApp/Classes/core/Utilities/MASDKLocale.swift
+++ b/MiniApp/Classes/core/Utilities/MASDKLocale.swift
@@ -28,24 +28,35 @@ public struct MASDKLocale {
         case adLoadedError                          = "miniapp.sdk.ios.error.message.ad_loaded"
     }
 
+    @available(*, deprecated, message: "This method is strongly dependant to the string format parameters and might lead to a crash", renamed:"localize(bundle:_:)")
     public static func localize(bundle path: String? = nil, _ key: String, _ params: CVarArg...) -> String {
-        let localizedString: String
-        if let path = path {
-            localizedString = key.localizedString(path: path)
-        } else {
-            localizedString = key.localizedString()
-        }
+        let localizedString = Self.localize(bundle: path, key)
         if params.count > 0 {
             return String(format: localizedString, arguments: params)
         }
         return localizedString
     }
 
+    public static func localize(bundle path: String? = nil, _ key: String) -> String {
+        let localizedString: String
+        if let path = path {
+            localizedString = key.localizedString(path: path)
+        } else {
+            localizedString = key.localizedString()
+        }
+        return localizedString
+    }
+
+    @available(*, deprecated, message: "This method is strongly dependant to the string format parameters and might lead to a crash", renamed:"localize(bundle:_:)")
     public static func localize(bundle path: String? = nil, _ key: LocalizableKey, _ params: CVarArg...) -> String {
         if params.count > 0 {
             return localize(bundle: path, key.rawValue, params.first!)
         } else {
-            return localize(bundle: path, key.rawValue, params)
+            return localize(bundle: path, key.rawValue)
         }
+    }
+
+    public static func localize(bundle path: String? = nil, _ key: LocalizableKey) -> String {
+        localize(bundle: path, key.rawValue)
     }
 }

--- a/MiniApp/Classes/core/Utilities/MASDKLocale.swift
+++ b/MiniApp/Classes/core/Utilities/MASDKLocale.swift
@@ -37,6 +37,12 @@ public struct MASDKLocale {
         return localizedString
     }
 
+    /// Method to retrieve a localizable from its key
+    ///
+    /// - Parameters:
+    ///   - path: the optional path to the bundle where the strings file is located
+    ///   - key: the key that defines the localizable in the strings file
+    /// - Returns:
     public static func localize(bundle path: String? = nil, _ key: String) -> String {
         let localizedString: String
         if let path = path {
@@ -56,6 +62,12 @@ public struct MASDKLocale {
         }
     }
 
+    /// Method to retrieve a MiniApp SDK localizable from its key
+    ///
+    /// - Parameters:
+    ///   - path: the optional path to the bundle where the strings file is located
+    ///   - key: a LocalizableKey that defines the localizable in the strings file
+    /// - Returns:
     public static func localize(bundle path: String? = nil, _ key: LocalizableKey) -> String {
         localize(bundle: path, key.rawValue)
     }

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -671,6 +671,9 @@ Mini App SDK will look in the host app `Localizable.strings` for these keys to f
 | `miniapp.sdk.ios.error.message.ad_not_loaded`                 | error reporting (decription) | Ad %@<sup>[1]</sup> is not loaded yet | <sup>[1]</sup>Ad id |
 | `miniapp.sdk.ios.error.message.ad_loading`                    | error reporting (decription) | Previous %@<sup>[1]</sup> is still in progress | <sup>[1]</sup>Ad id |
 | `miniapp.sdk.ios.error.message.ad_loaded`                     | error reporting (decription) | Ad %@<sup>[1]</sup> is already loaded | <sup>[1]</sup>Ad id |
+
+If you need to use one of this strings in your host application, you can use the convenience method `MASDKLocale.localize(_:_:)`
+
 <a id="custom-navigation"></a>
 
 #### Add a web navigation interface to the MiniApp view


### PR DESCRIPTION
# Description
variadic methods to manage string formats are working well, but unfortunately if the localizable string format is not well formatted the resulting crash is difficult to investigate. So I suggest to deprecate them and let the developer use the String(format:_:) method himself, as you can see in this pull request

# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
