### PR TITLE
[MINI-3128] Updated Mini app error message for access token

### DIFF
--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -458,13 +458,13 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     }
                     self.executeJavaScriptCallback(responseStatus: .onSuccess, messageId: callbackId, response: jsonResponse)
                 case .failure(let error):
-                    self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(error))
+                    self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMiniAppError(error))
                 }
             }
         }
     }
     private func sendScopeError(callbackId: String, type: MiniAppJavaScriptError) {
-        executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(type))
+        executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMiniAppError(type))
     }
 
     func handleMASDKError(error: MASDKError, callbackId: String) {

--- a/MiniApp/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
+++ b/MiniApp/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
@@ -25,6 +25,11 @@ func getMiniAppErrorMessage<T: MiniAppErrorProtocol>(_ error: T) -> String {
     "\(error.name): \(error.description)"
 }
 
+/// Method to send in error in proper format i.e {type: "SomeError", message: "message"}
+func prepareMiniAppError<T: MiniAppErrorProtocol>(_ error: T) -> String {
+    "{type: \"\(error.name)\", message: \"\(error.description)\"}"
+}
+
 enum MiniAppJavaScriptError: String, Codable, MiniAppErrorProtocol {
     case internalError
     case unexpectedMessageFormat

--- a/MiniApp/Classes/core/Utilities/MASDKLocale.swift
+++ b/MiniApp/Classes/core/Utilities/MASDKLocale.swift
@@ -7,7 +7,6 @@ public struct MASDKLocale {
         case cancel                                 = "miniapp.sdk.ios.alert.title.cancel"
         case allow                                  = "miniapp.sdk.ios.ui.allow"
         case save                                   = "miniapp.sdk.all.ui.save"
-        case customSettingsFooter                   = "miniapp.sdk.ios.customsettingsfooter"
         case firstLaunchFooter                      = "miniapp.sdk.ios.firstlaunch.footer"
         case serverError                            = "miniapp.sdk.ios.error.message.server"
         case invalidUrl                             = "miniapp.sdk.ios.error.message.invalid_url"


### PR DESCRIPTION
# Description
* Updated error message format for getAccessToken method
* The same error should be followed for any new methods that is added to the SDK

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
