### PR TITLE
Fix for GitHub action swiftlint

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Repository checkout
       uses: actions/checkout@v2
     - name: Run SwiftLint
-      run: swiftlint
+      run: swiftlint --strict

--- a/Example/Controllers/Storyboards/Base.lproj/Settings.storyboard
+++ b/Example/Controllers/Storyboards/Base.lproj/Settings.storyboard
@@ -712,6 +712,9 @@
                                                     <rect key="frame" x="20" y="26" width="374" height="38"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                                     <textInputTraits key="textInputTraits" spellCheckingType="no" keyboardType="numberPad" returnKeyType="done" textContentType="tel"/>
+                                                    <connections>
+                                                        <outlet property="delegate" destination="7ap-jg-cep" id="lWx-a2-iyA"/>
+                                                    </connections>
                                                 </textField>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Points (Cash)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bim-Ui-9JX">
                                                     <rect key="frame" x="20" y="7" width="93" height="18"/>


### PR DESCRIPTION
# Description
Swiftlint GitHub actions doesn't fail even if there is a violation, so adding `--strict` would fail the workflow if there is any violation

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
