### PR TITLE
Fix/mini 3853 permissions

### DIFF
--- a/MiniApp/Classes/core/RealMiniApp.swift
+++ b/MiniApp/Classes/core/RealMiniApp.swift
@@ -243,7 +243,6 @@ internal class RealMiniApp {
 
     func retrieveMiniAppMetaData(appId: String,
                                  version: String,
-                                 clearPermissions: Bool = true,
                                  completionHandler: @escaping (Result<MiniAppManifest, MASDKError>) -> Void) {
         if appId.isEmpty {
             return completionHandler(.failure(.invalidAppId))
@@ -256,21 +255,10 @@ internal class RealMiniApp {
                                               apiClient: self.miniAppClient) { (result) in
             switch result {
             case .success(let metaData):
-                if clearPermissions {
-                    self.cleanUpCustomPermissions(appId: appId, latestManifest: metaData)
-                }
                 completionHandler(.success(metaData))
             case .failure(let error):
                 completionHandler(.failure(error))
             }
-        }
-    }
-
-    /// In Preview mode, when Codebase is updated, & if there is a change in Manifest, it is good to delete the old Custom Permissions from the Keychain.
-    /// Because the user has to agree to the new MiniAppManifest, also this will help to compare the latest manifest.
-    func cleanUpCustomPermissions(appId: String, latestManifest: MiniAppManifest) {
-        if self.getCachedManifestData(appId: appId) != latestManifest {
-            miniAppPermissionStorage.removeKey(for: appId)
         }
     }
 
@@ -287,7 +275,7 @@ internal class RealMiniApp {
     func isRequiredPermissionsAllowed(appId: String, versionId: String, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
         let cachedMetaData = self.miniAppManifestStorage.getManifestInfo(forMiniApp: appId)
         if cachedMetaData?.version != versionId || miniAppClient.environment.isPreviewMode {
-            retrieveMiniAppMetaData(appId: appId, version: versionId, clearPermissions: false) { (result) in
+            retrieveMiniAppMetaData(appId: appId, version: versionId) { (result) in
                 switch result {
                 case .success(let manifest):
                     self.miniAppManifestStorage.saveManifestInfo(forMiniApp: appId,

--- a/MiniApp/Classes/core/Storage/MiniAppStatus.swift
+++ b/MiniApp/Classes/core/Storage/MiniAppStatus.swift
@@ -76,7 +76,10 @@ class MiniAppStatus {
         var returnList: MASDKDownloadedListPermissionsPair = []
         _ = downloadedMiniAppsList.map { (miniAppInfo: MiniAppInfo) in
             if let permMod = finalList[miniAppInfo.id] {
-                returnList.append((miniAppInfo, permMod))
+                /// This will make sure that we return the Mini Apps list that has atleast 1 permission.
+                if permMod.count != 0 {
+                    returnList.append((miniAppInfo, permMod))
+                }
             } else {
                 returnList.append((miniAppInfo, []))
             }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -36,12 +36,12 @@ PODS:
   - "GoogleUtilities/NSData+zlib (7.5.0)"
   - GoogleUtilities/Reachability (7.5.0):
     - GoogleUtilities/Logger
-  - MiniApp/Admob (3.4.0):
+  - MiniApp/Admob (3.5.0):
     - Google-Mobile-Ads-SDK (~> 7.0)
     - MiniApp/Core
-  - MiniApp/Core (3.4.0):
+  - MiniApp/Core (3.5.0):
     - ZIPFoundation (= 0.9.12)
-  - MiniApp/UI (3.4.0):
+  - MiniApp/UI (3.5.0):
     - MiniApp/Core
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
@@ -88,7 +88,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: fd19169c3034975cb934e865e5667bfdce59df7f
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
   GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
-  MiniApp: 36b6d8194a13da3fea6196965ce4f61759073d2d
+  MiniApp: a0e9d4dd0d770c2f6b03bd3fa9e3b821c8e9d17c
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58


### PR DESCRIPTION
# Description
* Fix for MINI-3853
* Also, Mini Apps downloaded list will return only the Mini Apps that has at least 0 permissions


## Links
[MINI-3853](https://jira.rakuten-it.com/jira/browse/MINI-3853)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
