### PR TITLE
[MINI-3489] Support for Admob 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## CHANGELOG
 
-### 3.5.0 (2021-07-30)
+### 3.5.0 (2021-08-03)
 
 **SDK**
 
 - **Feature:** Mini App SDK now supports an optional banner text in message to send to contacts received from MiniApp
 - **Feature:** Added Points Interface `getPoints` to retrieve Rakuten Points
 - **Feature:** Added `rakuten.miniapp.user.POINTS` custom permission
+- **Feature:** Added support for Admob v8.+ in submodule `MiniApp/Admob8`
 
 **Sample app**
 

--- a/MiniApp.podspec
+++ b/MiniApp.podspec
@@ -42,7 +42,16 @@ Pod::Spec.new do |s|
     admob.source_files = 'MiniApp/Classes/admob7/**/*.{swift,h,m}'
     admob.dependency 'MiniApp/Core'
     admob.dependency 'Google-Mobile-Ads-SDK', '~> 7.0'
-    admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB' }
+    admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB -D RMA_SDK_ADMOB7' }
+    admob.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    admob.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  end
+
+  s.subspec 'Admob8' do |admob|
+    admob.source_files = 'MiniApp/Classes/admob/**/*.{swift,h,m}'
+    admob.dependency 'MiniApp/Core'
+    admob.dependency 'Google-Mobile-Ads-SDK', '~> 8.0'
+    admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB -D RMA_SDK_ADMOB8'}
     admob.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
     admob.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   end

--- a/MiniApp/Classes/admob/AdMobDisplayer.swift
+++ b/MiniApp/Classes/admob/AdMobDisplayer.swift
@@ -42,15 +42,15 @@ public class AdMobDisplayer: MiniAppAdDisplayer {
     }
 
     func createNotLoadingReqError(adUnitId: String) -> String {
-        MiniAppLocalizable.localize(.adNotLoadedError, adUnitId)
+        String(format: MASDKLocale.localize(.adNotLoadedError), adUnitId)
     }
 
     func createLoadReqError(adUnitId: String) -> String {
-        MiniAppLocalizable.localize(.adLoadingError, adUnitId)
+        String(format: MASDKLocale.localize(.adLoadingError), adUnitId)
     }
 
     func createLoadTwiceError(adUnitId: String) -> String {
-        MiniAppLocalizable.localize(.adLoadedError, adUnitId)
+        String(format: MASDKLocale.localize(.adLoadedError), adUnitId)
     }
 
     public override func loadInterstitial(for adId: String, onLoaded: @escaping (Result<Void, Error>) -> Void) {
@@ -62,7 +62,7 @@ public class AdMobDisplayer: MiniAppAdDisplayer {
             GADInterstitialAd.load(withAdUnitID: adId, request: request) { [weak self]  (interstitialAd, error) in
                 if let error = error {
                     self?.onInterstitialLoaded[adId]?(.failure(error))
-                    cleanInterstitial(adId)
+                    self?.cleanInterstitial(adId)
                 } else {
                     interstitialAd?.fullScreenContentDelegate = self
                     self?.interstitialAds[adId] = interstitialAd
@@ -81,7 +81,7 @@ public class AdMobDisplayer: MiniAppAdDisplayer {
                     request: request, completionHandler: { [weak self] (rewardedAd, error) in
                 if let err = error {
                     onLoaded(.failure(err))
-                    cleanReward(adId)
+                    self?.cleanReward(adId)
                 } else {
                     rewardedAd?.fullScreenContentDelegate = self
                     self?.rewardedAds[adId] = rewardedAd

--- a/Podfile
+++ b/Podfile
@@ -8,9 +8,8 @@ platform :ios, '13.0'
 target sdk_name + '_Example' do
   project sdk_name + '.xcodeproj'
   workspace sdk_name + '.xcworkspace'
-  pod 'MiniApp/Admob', :path => './'
+  pod 'MiniApp/Admob8', :path => './'
   pod 'MiniApp/UI', :path => './'
-  pod 'Google-Mobile-Ads-SDK'
   pod 'AppCenter/Crashes'
   pod 'RAnalytics', :source => 'https://github.com/rakutentech/ios-analytics-framework.git'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,23 +2,23 @@ PODS:
   - AppCenter/Core (4.2.0)
   - AppCenter/Crashes (4.2.0):
     - AppCenter/Core
-  - Google-Mobile-Ads-SDK (7.69.0):
-    - GoogleAppMeasurement (~> 7.0)
-    - GoogleUserMessagingPlatform (~> 1.1)
-  - GoogleAppMeasurement (7.11.0):
-    - GoogleAppMeasurement/AdIdSupport (= 7.11.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
-    - GoogleUtilities/MethodSwizzler (~> 7.0)
-    - GoogleUtilities/Network (~> 7.0)
-    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+  - Google-Mobile-Ads-SDK (8.8.0):
+    - GoogleAppMeasurement (< 9.0, >= 7.0)
+    - GoogleUserMessagingPlatform (>= 1.1)
+  - GoogleAppMeasurement (8.4.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.4.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
+    - GoogleUtilities/MethodSwizzler (~> 7.4)
+    - GoogleUtilities/Network (~> 7.4)
+    - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (7.11.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
-    - GoogleUtilities/MethodSwizzler (~> 7.0)
-    - GoogleUtilities/Network (~> 7.0)
-    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+  - GoogleAppMeasurement/AdIdSupport (8.4.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
+    - GoogleUtilities/MethodSwizzler (~> 7.4)
+    - GoogleUtilities/Network (~> 7.4)
+    - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - GoogleUserMessagingPlatform (1.4.0)
+  - GoogleUserMessagingPlatform (2.0.0)
   - GoogleUtilities/AppDelegateSwizzler (7.5.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -36,12 +36,12 @@ PODS:
   - "GoogleUtilities/NSData+zlib (7.5.0)"
   - GoogleUtilities/Reachability (7.5.0):
     - GoogleUtilities/Logger
-  - MiniApp/Admob (3.4.0):
-    - Google-Mobile-Ads-SDK (~> 7.0)
+  - MiniApp/Admob8 (3.5.0):
+    - Google-Mobile-Ads-SDK (~> 8.0)
     - MiniApp/Core
-  - MiniApp/Core (3.4.0):
+  - MiniApp/Core (3.5.0):
     - ZIPFoundation (= 0.9.12)
-  - MiniApp/UI (3.4.0):
+  - MiniApp/UI (3.5.0):
     - MiniApp/Core
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
@@ -51,13 +51,12 @@ PODS:
   - Nimble (9.0.1)
   - PromisesObjC (2.0.0)
   - Quick (3.1.2)
-  - RAnalytics (8.1.1)
+  - RAnalytics (8.2.1)
   - ZIPFoundation (0.9.12)
 
 DEPENDENCIES:
   - AppCenter/Crashes
-  - Google-Mobile-Ads-SDK
-  - MiniApp/Admob (from `./`)
+  - MiniApp/Admob8 (from `./`)
   - MiniApp/UI (from `./`)
   - Nimble (~> 9.0.0)
   - Quick (~> 3.1.2)
@@ -84,18 +83,18 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppCenter: 87ef6eefd8ade4df59e88951288587429f3dd2a5
-  Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
-  GoogleAppMeasurement: fd19169c3034975cb934e865e5667bfdce59df7f
-  GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
+  Google-Mobile-Ads-SDK: 1fccd8fd76aca1cef9bfe0711124c9731dad9307
+  GoogleAppMeasurement: 6b6a08fd9c71f4dbc89e0e812acca81d797aa342
+  GoogleUserMessagingPlatform: ab890ce5f6620f293a21b6bdd82e416a2c73aeca
   GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
-  MiniApp: 36b6d8194a13da3fea6196965ce4f61759073d2d
+  MiniApp: 596cd95529ca9da38124eb0b1892424426347c15
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
-  RAnalytics: e5856a17418a7b2be3e7c135b7de3c8be8be288c
+  RAnalytics: ab09bc6648a4804e10a9524f8156e9a393b426fb
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: f993d8669e23079ea5a4e10ccfa00cd585938f09
+PODFILE CHECKSUM: db7b06cb4ed8788872d7584732de601a15eb17d7
 
 COCOAPODS: 1.10.1

--- a/Tests/Unit/UIModule/AdMobDisplayerTests.swift
+++ b/Tests/Unit/UIModule/AdMobDisplayerTests.swift
@@ -5,62 +5,62 @@ import GoogleMobileAds
 @testable import MiniApp
 
 class AdMobDisplayerTests: QuickSpec {
-    #if RMA_SDK_ADMOB
-        override func spec() {
-            let adId = "AdUnitId"
-            let key1 = "AdKey1"
-            let key2 = "AdKey2"
-            describe("AdMobDisplayerTests") {
-                context("when cleanInterstitial method is called") {
-                    it("will clear all the keys from the AdMobDisplayer") {
-                        let adMobDisplayer = AdMobDisplayer()
-                        #if RMA_SDK_ADMOB7
-                            adMobDisplayer.interstitialAds = [key1: GADInterstitial(adUnitID: adId), key2: GADInterstitial(adUnitID: adId)]
-                        #elseif RMA_SDK_ADMOB8
-                            adMobDisplayer.interstitialAds = [key1: GADInterstitialAd(), key2: GADInterstitialAd()]
-                        #endif
-                        expect(adMobDisplayer.interstitialAds.count).to(equal(2))
-                        adMobDisplayer.cleanInterstitial(key1)
-                        adMobDisplayer.cleanInterstitial(key2)
-                        expect(adMobDisplayer.interstitialAds.count).to(equal(0))
-                    }
+#if RMA_SDK_ADMOB
+    override func spec() {
+        let adId = "AdUnitId"
+        let key1 = "AdKey1"
+        let key2 = "AdKey2"
+        describe("AdMobDisplayerTests") {
+            context("when cleanInterstitial method is called") {
+                it("will clear all the keys from the AdMobDisplayer") {
+                    let adMobDisplayer = AdMobDisplayer()
+                    #if RMA_SDK_ADMOB7
+                        adMobDisplayer.interstitialAds = [key1: GADInterstitial(adUnitID: adId), key2: GADInterstitial(adUnitID: adId)]
+                    #elseif RMA_SDK_ADMOB8
+                        adMobDisplayer.interstitialAds = [key1: GADInterstitialAd(), key2: GADInterstitialAd()]
+                    #endif
+                    expect(adMobDisplayer.interstitialAds.count).to(equal(2))
+                    adMobDisplayer.cleanInterstitial(key1)
+                    adMobDisplayer.cleanInterstitial(key2)
+                    expect(adMobDisplayer.interstitialAds.count).to(equal(0))
                 }
-                context("when cleanReward method is called") {
-                    it("will clear all the keys from the AdMobDisplayer") {
-                        let adMobDisplayer = AdMobDisplayer()
-                        #if RMA_SDK_ADMOB7
-                            adMobDisplayer.rewardedAds = [key1: GADRewardedAd(adUnitID: adId), key2: GADRewardedAd(adUnitID: adId)]
-                        #elseif RMA_SDK_ADMOB8
-                            adMobDisplayer.rewardedAds = [key1: GADRewardedAd(), key2: GADRewardedAd()]
-                        #endif
-                        expect(adMobDisplayer.rewardedAds.count).to(equal(2))
-                        adMobDisplayer.cleanReward(key1)
-                        adMobDisplayer.cleanReward(key2)
-                        expect(adMobDisplayer.rewardedAds.count).to(equal(0))
-                    }
+            }
+            context("when cleanReward method is called") {
+                it("will clear all the keys from the AdMobDisplayer") {
+                    let adMobDisplayer = AdMobDisplayer()
+                    #if RMA_SDK_ADMOB7
+                        adMobDisplayer.rewardedAds = [key1: GADRewardedAd(adUnitID: adId), key2: GADRewardedAd(adUnitID: adId)]
+                    #elseif RMA_SDK_ADMOB8
+                        adMobDisplayer.rewardedAds = [key1: GADRewardedAd(), key2: GADRewardedAd()]
+                    #endif
+                    expect(adMobDisplayer.rewardedAds.count).to(equal(2))
+                    adMobDisplayer.cleanReward(key1)
+                    adMobDisplayer.cleanReward(key2)
+                    expect(adMobDisplayer.rewardedAds.count).to(equal(0))
                 }
-                context("when createNotLoadingReqError method is called") {
-                    it("will return error string with adUnitId") {
-                        let adMobDisplayer = AdMobDisplayer()
-                        let error = adMobDisplayer.createNotLoadingReqError(adUnitId: adId)
-                        expect(error).to(equal(String(format: MASDKLocale.localize(.adNotLoadedError), adId)))
-                    }
+            }
+            context("when createNotLoadingReqError method is called") {
+                it("will return error string with adUnitId") {
+                    let adMobDisplayer = AdMobDisplayer()
+                    let error = adMobDisplayer.createNotLoadingReqError(adUnitId: adId)
+                    expect(error).to(equal(String(format: MASDKLocale.localize(.adNotLoadedError), adId)))
                 }
-                context("when createNotLoadingReqError method is called") {
-                    it("will return error string with adUnitId") {
-                        let adMobDisplayer = AdMobDisplayer()
-                        let error = adMobDisplayer.createLoadReqError(adUnitId: adId)
-                        expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadingError), adId)))
-                    }
+            }
+            context("when createNotLoadingReqError method is called") {
+                it("will return error string with adUnitId") {
+                    let adMobDisplayer = AdMobDisplayer()
+                    let error = adMobDisplayer.createLoadReqError(adUnitId: adId)
+                    expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadingError), adId)))
                 }
-                context("when createLoadTwiceError method is called") {
-                    it("will return error string with adUnitId") {
-                        let adMobDisplayer = AdMobDisplayer()
-                        let error = adMobDisplayer.createLoadTwiceError(adUnitId: adId)
-                        expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadedError), adId)))
-                    }
+            }
+            context("when createLoadTwiceError method is called") {
+                it("will return error string with adUnitId") {
+                    let adMobDisplayer = AdMobDisplayer()
+                    let error = adMobDisplayer.createLoadTwiceError(adUnitId: adId)
+                    expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadedError), adId)))
                 }
             }
         }
-    #endif
+    }
+#endif
 }

--- a/Tests/Unit/UIModule/AdMobDisplayerTests.swift
+++ b/Tests/Unit/UIModule/AdMobDisplayerTests.swift
@@ -4,6 +4,7 @@ import GoogleMobileAds
 
 @testable import MiniApp
 
+// swiftlint:disable function_body_length
 class AdMobDisplayerTests: QuickSpec {
 #if RMA_SDK_ADMOB
     override func spec() {

--- a/Tests/Unit/UIModule/AdMobDisplayerTests.swift
+++ b/Tests/Unit/UIModule/AdMobDisplayerTests.swift
@@ -5,53 +5,62 @@ import GoogleMobileAds
 @testable import MiniApp
 
 class AdMobDisplayerTests: QuickSpec {
-
-    override func spec() {
-        let adId = "AdUnitId"
-        let key1 = "AdKey1"
-        let key2 = "AdKey2"
-        describe("AdMobDisplayerTests") {
-            context("when cleanInterstitial method is called") {
-                it("will clear all the keys from the AdMobDisplayer") {
-                    let adMobDisplayer = AdMobDisplayer()
-                    adMobDisplayer.interstitialAds = [key1: GADInterstitial(adUnitID: adId), key2: GADInterstitial(adUnitID: adId)]
-                    expect(adMobDisplayer.interstitialAds.count).to(equal(2))
-                    adMobDisplayer.cleanInterstitial(key1)
-                    adMobDisplayer.cleanInterstitial(key2)
-                    expect(adMobDisplayer.interstitialAds.count).to(equal(0))
+    #if RMA_SDK_ADMOB
+        override func spec() {
+            let adId = "AdUnitId"
+            let key1 = "AdKey1"
+            let key2 = "AdKey2"
+            describe("AdMobDisplayerTests") {
+                context("when cleanInterstitial method is called") {
+                    it("will clear all the keys from the AdMobDisplayer") {
+                        let adMobDisplayer = AdMobDisplayer()
+                        #if RMA_SDK_ADMOB7
+                            adMobDisplayer.interstitialAds = [key1: GADInterstitial(adUnitID: adId), key2: GADInterstitial(adUnitID: adId)]
+                        #elseif RMA_SDK_ADMOB8
+                            adMobDisplayer.interstitialAds = [key1: GADInterstitialAd(), key2: GADInterstitialAd()]
+                        #endif
+                        expect(adMobDisplayer.interstitialAds.count).to(equal(2))
+                        adMobDisplayer.cleanInterstitial(key1)
+                        adMobDisplayer.cleanInterstitial(key2)
+                        expect(adMobDisplayer.interstitialAds.count).to(equal(0))
+                    }
                 }
-            }
-            context("when cleanReward method is called") {
-                it("will clear all the keys from the AdMobDisplayer") {
-                    let adMobDisplayer = AdMobDisplayer()
-                    adMobDisplayer.rewardedAds = [key1: GADRewardedAd(adUnitID: adId), key2: GADRewardedAd(adUnitID: adId)]
-                    expect(adMobDisplayer.rewardedAds.count).to(equal(2))
-                    adMobDisplayer.cleanReward(key1)
-                    adMobDisplayer.cleanReward(key2)
-                    expect(adMobDisplayer.rewardedAds.count).to(equal(0))
+                context("when cleanReward method is called") {
+                    it("will clear all the keys from the AdMobDisplayer") {
+                        let adMobDisplayer = AdMobDisplayer()
+                        #if RMA_SDK_ADMOB7
+                            adMobDisplayer.rewardedAds = [key1: GADRewardedAd(adUnitID: adId), key2: GADRewardedAd(adUnitID: adId)]
+                        #elseif RMA_SDK_ADMOB8
+                            adMobDisplayer.rewardedAds = [key1: GADRewardedAd(), key2: GADRewardedAd()]
+                        #endif
+                        expect(adMobDisplayer.rewardedAds.count).to(equal(2))
+                        adMobDisplayer.cleanReward(key1)
+                        adMobDisplayer.cleanReward(key2)
+                        expect(adMobDisplayer.rewardedAds.count).to(equal(0))
+                    }
                 }
-            }
-            context("when createNotLoadingReqError method is called") {
-                it("will return error string with adUnitId") {
-                    let adMobDisplayer = AdMobDisplayer()
-                    let error = adMobDisplayer.createNotLoadingReqError(adUnitId: adId)
-                    expect(error).to(equal(String(format: MASDKLocale.localize(.adNotLoadedError), adId)))
+                context("when createNotLoadingReqError method is called") {
+                    it("will return error string with adUnitId") {
+                        let adMobDisplayer = AdMobDisplayer()
+                        let error = adMobDisplayer.createNotLoadingReqError(adUnitId: adId)
+                        expect(error).to(equal(String(format: MASDKLocale.localize(.adNotLoadedError), adId)))
+                    }
                 }
-            }
-            context("when createNotLoadingReqError method is called") {
-                it("will return error string with adUnitId") {
-                    let adMobDisplayer = AdMobDisplayer()
-                    let error = adMobDisplayer.createLoadReqError(adUnitId: adId)
-                    expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadingError), adId)))
+                context("when createNotLoadingReqError method is called") {
+                    it("will return error string with adUnitId") {
+                        let adMobDisplayer = AdMobDisplayer()
+                        let error = adMobDisplayer.createLoadReqError(adUnitId: adId)
+                        expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadingError), adId)))
+                    }
                 }
-            }
-            context("when createLoadTwiceError method is called") {
-                it("will return error string with adUnitId") {
-                    let adMobDisplayer = AdMobDisplayer()
-                    let error = adMobDisplayer.createLoadTwiceError(adUnitId: adId)
-                    expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadedError), adId)))
+                context("when createLoadTwiceError method is called") {
+                    it("will return error string with adUnitId") {
+                        let adMobDisplayer = AdMobDisplayer()
+                        let error = adMobDisplayer.createLoadTwiceError(adUnitId: adId)
+                        expect(error).to(equal(String(format: MASDKLocale.localize(.adLoadedError), adId)))
+                    }
                 }
             }
         }
-    }
+    #endif
 }

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -248,7 +248,7 @@ extension ViewController: MiniAppMessageDelegate {
 Mini App SDK gives you the possibility to display ads triggered by your Mini App from your host app.
 There are 2 ways to achieve this: 
 - by implementing [MiniAppAdDisplayDelegate](https://rakutentech.github.io/ios-miniapp/Protocols/MiniAppAdDisplayDelegate.html) by yourself 
-- if you rely on Google ads to display your ads you can simply implement `pod MiniApp/Admob` into your pod dependencies (see [settings section](#setting-admob)).
+- if you rely on Google ads to display your ads you can simply implement `pod MiniApp/Admob` (Admob 7.+) or `pod MiniApp/Admob8` (Admob 8.+) into your pod dependencies (see [settings section](#setting-admob)).
 ###### Google ads displayer
 
 When you chose to implement Google Ads support for your Mini Apps (see [configuration section](#setting-admob)), you must provide an [`AdMobDisplayer`](https://rakutentech.github.io/ios-miniapp/Classes/AdMobDisplayer.html) as adsDelegate parameter when creating your Mini App display:


### PR DESCRIPTION
# Description
Brings support for Admob 8 SDK as a new `admob8` submodule

## Links
[MINI-3489](https://jira.rakuten-it.com/jira/browse/MINI-3489)

# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
