### PR TITLE
Updated code to support Enable/Disable Nav buttons  in MiniAppUI

### DIFF
--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -2,8 +2,13 @@ import MiniApp
 
 extension ViewController: MiniAppNavigationDelegate {
     func miniAppNavigationCanGo(back: Bool, forward: Bool) {
-        let testing = displayController?.topViewController as? DisplayController
-        testing?.refreshNavigationBarButtons(backButtonEnabled: back, forwardButtonEnabled: forward)
+        guard let miniAppDisplayController = UINavigationController.topViewController() as? MiniAppViewController else {
+            guard let miniAppDisplayController = UINavigationController.topViewController() as? DisplayController else {
+                return
+            }
+            return miniAppDisplayController.refreshNavigationBarButtons(backButtonEnabled: back, forwardButtonEnabled: forward)
+        }
+        miniAppDisplayController.refreshNavigationBarButtons(backButtonEnabled: back, forwardButtonEnabled: forward)
     }
 
     func fetchAppList(inBackground: Bool) {

--- a/MiniApp/Classes/ui/MiniAppUI.swift
+++ b/MiniApp/Classes/ui/MiniAppUI.swift
@@ -81,7 +81,7 @@ internal class RealMiniAppUI {
 
     func launch(base: UIViewController, params: MiniAppUIParams, delegate: MiniAppUIDelegate) {
         let miniAppVC = create(params: params)
-        miniAppVC.delegate = delegate
+        miniAppVC.miniAppUiDelegate = delegate
         let nvc = UINavigationController(rootViewController: miniAppVC)
         nvc.modalPresentationStyle = .fullScreen
         base.present(nvc, animated: true, completion: nil)

--- a/MiniApp/Classes/ui/MiniAppViewController.swift
+++ b/MiniApp/Classes/ui/MiniAppViewController.swift
@@ -36,7 +36,7 @@ public class MiniAppViewController: UIViewController {
     weak var navDelegate: MiniAppNavigationDelegate?
     weak var navBarDelegate: MiniAppNavigationBarDelegate?
 
-    weak var delegate: MiniAppUIDelegate?
+    weak var miniAppUiDelegate: MiniAppUIDelegate?
 
     // MARK: UI - Navigation
     private lazy var backButton: UIBarButtonItem = {
@@ -154,10 +154,10 @@ public class MiniAppViewController: UIViewController {
                         view.frame = self.view.bounds
                         self.view.addSubview(view)
                         self.navBarDelegate = miniAppDisplay as? MiniAppNavigationBarDelegate
-                        self.delegate?.miniApp(self, didLoadWith: nil)
+                        self.miniAppUiDelegate?.miniApp(self, didLoadWith: nil)
                         self.state = .success
                     case .failure(let error):
-                        self.delegate?.miniApp(self, didLoadWith: error)
+                        self.miniAppUiDelegate?.miniApp(self, didLoadWith: error)
                         self.state = .error
                     }
                 },
@@ -191,31 +191,27 @@ public class MiniAppViewController: UIViewController {
 
     @objc
     public func backPressed() {
-        if delegate == nil {
-            navBarDelegate?.miniAppNavigationBar(didTriggerAction: .back)
-        } else {
-            delegate?.miniApp(self, shouldExecute: .back)
-        }
+        navBarDelegate?.miniAppNavigationBar(didTriggerAction: .back)
     }
 
     @objc
     public func forwardPressed() {
-        if delegate == nil {
-            navBarDelegate?.miniAppNavigationBar(didTriggerAction: .forward)
-        } else {
-            delegate?.miniApp(self, shouldExecute: .forward)
-        }
+        navBarDelegate?.miniAppNavigationBar(didTriggerAction: .forward)
     }
 
     @objc
     public func closePressed() {
-        if delegate == nil {
+        if miniAppUiDelegate == nil {
             dismiss(animated: true, completion: nil)
         } else {
-            delegate?.onClose()
+            miniAppUiDelegate?.onClose()
         }
     }
 
+    public func refreshNavigationBarButtons(backButtonEnabled: Bool, forwardButtonEnabled: Bool) {
+        backButton.isEnabled = backButtonEnabled
+        forwardButton.isEnabled = forwardButtonEnabled
+    }
 }
 
 // MARK: - MiniAppNavigationDelegate


### PR DESCRIPTION

# Description
* Initial support for this behavior is added in this [Pull Request](https://github.com/rakutentech/ios-miniapp/pull/309), but looks like there is a recent change on how we launch the Mini App from the sample app.
* Code is updated with `MiniAppUI.shared().launch()` so we have to add support for Enabling/Disabling buttons for this one as well, hence the PR.

## Links
[MINI-3351](https://jira.rakuten-it.com/jira/browse/MINI-3351)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
