### PR TITLE
Fix/first time screen

### DIFF
--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -106,13 +106,20 @@ extension ViewController: MiniAppNavigationDelegate {
     func checkSDKErrorAndDisplay(error: MASDKError) {
         switch error {
         case .metaDataFailure:
-            guard let miniAppInfo = currentMiniAppInfo else {
-                return self.displayAlert(title: MASDKLocale.localize("miniapp.sdk.ios.error.title"),
-                                         message: String(format: MASDKLocale.localize("miniapp.sdk.ios.error.message.metadata"), MASDKLocale.localize(.downloadFailed)), dismissController: true) { _ in
-                    self.fetchAppList(inBackground: true)
+            /// We need to dismiss current Mini App controller to show First time screen.
+            /// This is due to the recent change on how we display Miniapp, MiniAppUI.shared().launch()
+            DispatchQueue.main.async {
+                self.dismiss(animated: true) {
+                    guard let miniAppInfo = self.currentMiniAppInfo else {
+                        return self.displayAlert(title: MASDKLocale.localize("miniapp.sdk.ios.error.title"),
+                                                 message: String(format: MASDKLocale.localize("miniapp.sdk.ios.error.message.metadata"), MASDKLocale.localize(.downloadFailed)),
+                                                 dismissController: true) { _ in
+                            self.fetchAppList(inBackground: true)
+                        }
+                    }
+                    self.fetchMiniAppMetaData(miniAppInfo: miniAppInfo)
                 }
             }
-            self.showFirstTimeLaunchScreen(miniAppInfo: miniAppInfo)
         default:
             self.displayAlert(title: MASDKLocale.localize("miniapp.sdk.ios.error.title"), message: MASDKLocale.localize(.downloadFailed), dismissController: true) { _ in
                 self.fetchAppList(inBackground: true)

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -106,23 +106,27 @@ extension ViewController: MiniAppNavigationDelegate {
     func checkSDKErrorAndDisplay(error: MASDKError) {
         switch error {
         case .metaDataFailure:
-            // We need to dismiss current Mini App controller to show First time screen.
-            // This is due to the recent change on how we display Miniapp, MiniAppUI.shared().launch()
-            DispatchQueue.main.async {
-                self.dismiss(animated: true) {
-                    guard let miniAppInfo = self.currentMiniAppInfo else {
-                        return self.displayAlert(title: MASDKLocale.localize("miniapp.sdk.ios.error.title"),
-                                                 message: String(format: MASDKLocale.localize("miniapp.sdk.ios.error.message.metadata"), MASDKLocale.localize(.downloadFailed)),
-                                                 dismissController: true) { _ in
-                            self.fetchAppList(inBackground: true)
-                        }
-                    }
-                    self.fetchMiniAppMetaData(miniAppInfo: miniAppInfo)
-                }
-            }
+            metaDataFailure()
         default:
             self.displayAlert(title: MASDKLocale.localize("miniapp.sdk.ios.error.title"), message: MASDKLocale.localize(.downloadFailed), dismissController: true) { _ in
                 self.fetchAppList(inBackground: true)
+            }
+        }
+    }
+
+    // We need to dismiss current Mini App controller to show First time screen.
+    // This is due to the recent change on how we display Miniapp, MiniAppUI.shared().launch()
+    func metaDataFailure() {
+        DispatchQueue.main.async {
+            self.dismiss(animated: true) {
+                guard let miniAppInfo = self.currentMiniAppInfo else {
+                    return self.displayAlert(title: MASDKLocale.localize("miniapp.sdk.ios.error.title"),
+                                             message: String(format: MASDKLocale.localize("miniapp.sdk.ios.error.message.metadata"), MASDKLocale.localize(.downloadFailed)),
+                                             dismissController: true) { _ in
+                        self.fetchAppList(inBackground: true)
+                    }
+                }
+                self.fetchMiniAppMetaData(miniAppInfo: miniAppInfo)
             }
         }
     }

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -106,8 +106,8 @@ extension ViewController: MiniAppNavigationDelegate {
     func checkSDKErrorAndDisplay(error: MASDKError) {
         switch error {
         case .metaDataFailure:
-            /// We need to dismiss current Mini App controller to show First time screen.
-            /// This is due to the recent change on how we display Miniapp, MiniAppUI.shared().launch()
+            // We need to dismiss current Mini App controller to show First time screen.
+            // This is due to the recent change on how we display Miniapp, MiniAppUI.shared().launch()
             DispatchQueue.main.async {
                 self.dismiss(animated: true) {
                     guard let miniAppInfo = self.currentMiniAppInfo else {


### PR DESCRIPTION
# Description
When you toggle off one of the **required permission** from **Setting-> Permissions** , we get metaDataFailure error but first-time screen is not shown again. Fixed it.


# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
