### PR TITLE
[MINI-2673] - Changes to sync with navigator default error response

### DIFF
--- a/MiniApp/Classes/core/JavascriptBridge/MAJavascriptErrorHandler.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MAJavascriptErrorHandler.swift
@@ -23,3 +23,8 @@ func prepareMAJavascriptError<T: MiniAppErrorProtocol>(_ error: T) -> String {
     }
     return prepareJSONString(MAJavascriptErrorModel(type: error.name, message: error.description))
 }
+
+/// Method to send in navigator.geolocation error in proper format i.e {code: 1, message: "message"}
+func prepareMAJSGeolocationError(error: MAJSNaviGeolocationError) -> String {
+    return prepareJSONString(MAJSLocationErrorResponseModel(code: error.code, message: error.message))
+}

--- a/MiniApp/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
+++ b/MiniApp/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
@@ -3,6 +3,11 @@ struct MiniAppErrorDetail: Codable, Error {
     let description: String
 }
 
+internal struct MAJSLocationErrorResponseModel: Codable {
+    var code: Int
+    var message: String?
+}
+
 enum MiniAppErrorType: String, Codable, MiniAppErrorProtocol {
     case hostAppError
     case unknownError
@@ -203,6 +208,29 @@ public enum MASDKPointError: Error, MiniAppErrorProtocol {
             return "FailedToConformToProtocol"
         case .error:
             return ""
+        }
+    }
+}
+
+enum MAJSNaviGeolocationError: Error {
+    case userDenied
+    case devicePermissionDenied
+
+    var code: Int {
+        switch self {
+        case .userDenied:
+        return 1
+        case .devicePermissionDenied:
+        return 2
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .userDenied:
+        return "User denied Geolocation"
+        case .devicePermissionDenied:
+        return "application does not have sufficient geolocation permissions."
         }
     }
 }


### PR DESCRIPTION
# Description
`navigator.geolocation` error responses already supported by default OS on android side. So updated here to return a similar response which Android OS is responding to `navigator.geolocation.getCurrentPosition()` calls.

## Links
[MINI-2673](https://jira.rakuten-it.com/jira/browse/MINI-2673)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
