### PR TITLE
Disable navigation buttons at initial launch.

### DIFF
--- a/MiniApp/Classes/ui/MiniAppViewController.swift
+++ b/MiniApp/Classes/ui/MiniAppViewController.swift
@@ -128,6 +128,8 @@ public class MiniAppViewController: UIViewController {
             fallbackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             fallbackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+        backButton.isEnabled = false
+        forwardButton.isEnabled = false
     }
 
     func setupMiniApp() {


### PR DESCRIPTION
# Description
Though navigation buttons are disabled after the Mini App is loaded, buttons are still active during the transition phase. So fixed it.

## Links
[MINI-3922](https://jira.rakuten-it.com/jira/browse/MINI-3922)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
