### PR TITLE
[MINI-3965] Fix to authorize unsecure URL loading + itms url schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 **Sample app**
 
 - **Feature:** First time permissions screen now displays requested scopes
+- **Feature:** Added support for App Store URL schemes
+- **Feature:** ATS deactivated to match production needs
 
 ### 3.5.0 (2021-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 - **Feature:** Store Manifest as a json file
 - **Feature:** A secure check is performed on manifest permissions before launching the Mini App
+- **Feature:** Added support for App Store URL schemes
 
 **Sample app**
 
 - **Feature:** First time permissions screen now displays requested scopes
-- **Feature:** Added support for App Store URL schemes
 - **Feature:** ATS deactivated to match production needs
 
 ### 3.5.0 (2021-08-05)

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -41,16 +41,8 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<false/>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>This will let you to take Photos</string>

--- a/MiniApp/Classes/core/Display/MiniAppExternalWebViewController.swift
+++ b/MiniApp/Classes/core/Display/MiniAppExternalWebViewController.swift
@@ -93,6 +93,10 @@ extension MiniAppExternalWebViewController: WKNavigationDelegate {
         self.forwardBarButton.isEnabled = webView.canGoForward
     }
 
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        MiniAppLogger.e(String(describing: navigation), error)
+    }
+
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         let navigationTypes: [WKNavigationType] = [.linkActivated, .formSubmitted]
         if navigationTypes.contains(navigationAction.navigationType) {

--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -25,7 +25,8 @@ enum JavaScriptExecResult: String {
 enum MiniAppSupportedSchemes: String {
     case tel // used for phone calls
     case about // used to reveal internal state and built-in functions (e.g.: alert dialog)
-    case mailto
+    case mailto // used for e-mails
+    case itmsapps = "itms-apps" // used for app-store links
 }
 
 /// List of Device Permissions supported by the SDK that can be requested by a Mini app

--- a/Tests/Unit/MiniAppDownloaderTests.swift
+++ b/Tests/Unit/MiniAppDownloaderTests.swift
@@ -165,7 +165,7 @@ class MiniAppDownloaderTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["http://example.com/map-published-v2/min-abc/ver-abc/Mac/Testing.txt"]
+                        "manifest": ["test://example.com/map-published-v2/min-abc/ver-abc/Mac/Testing.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -178,7 +178,7 @@ class MiniAppDownloaderTests: QuickSpec {
                             testError = error as NSError
                         }
                     }
-                    expect(testError?.code).toEventually(equal(-1022), timeout: .seconds(20))
+                    expect(testError).toEventuallyNot(beNil())
                 }
             }
         }


### PR DESCRIPTION
# Description
Some URL loading on Link application were blocked in Demo app. As a requirement I had to set the arbitrary load to on.
Some web sites required `itms-apps` links to be handled by our webview in order to display a web page

## Links
[MINI-3965](https://jira.rakuten-it.com/jira/browse/MINI-3965)

# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
