### PR TITLE
Fix SSL pinning and unit tests

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -41,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let rootController = window?.rootViewController as? UINavigationController
         guard let controllersStack = rootController?.viewControllers else { return }
         if let homeViewController = controllersStack.first(where: { $0 is ViewController }) as? ViewController {
-            homeViewController.getMiniAppPreviewInfo(previewToken: token)
+            homeViewController.getMiniAppPreviewInfo(previewToken: token, config: Config.current(pinningEnabled: true))
         }
     }
 }

--- a/Example/Controllers/ViewController.swift
+++ b/Example/Controllers/ViewController.swift
@@ -164,9 +164,9 @@ class ViewController: UIViewController {
         }
     }
 
-    func getMiniAppPreviewInfo(previewToken: String) {
+    func getMiniAppPreviewInfo(previewToken: String, config: MiniAppSdkConfig) {
         self.showProgressIndicator {
-            MiniApp.shared().getMiniAppPreviewInfo(using: previewToken) { (result) in
+            MiniApp.shared(with: config).getMiniAppPreviewInfo(using: previewToken) { (result) in
                 switch result {
                 case .success(let previewInfo):
                     self.dismissProgressIndicator {

--- a/Example/Utils/Config.swift
+++ b/Example/Utils/Config.swift
@@ -3,14 +3,14 @@ import MiniApp
 
 class Config: NSObject {
     enum Key: String {
-        case applicationIdentifier = "RASApplicationIdentifier",
-        projectId = "RASProjectId",
-        version = "CFBundleShortVersionString",
-        subscriptionKey = "RASProjectSubscriptionKey",
-        endpoint = "RMAAPIEndpoint",
-        isPreviewMode = "RMAIsPreviewMode",
-        requireMiniAppSignatureVerification = "RMARequireMiniAppSignatureVerification",
-        sslKeyHash = "RMASSLKeyHash"
+        case applicationIdentifier               = "RASApplicationIdentifier",
+             projectId                           = "RASProjectId",
+             version                             = "CFBundleShortVersionString",
+             subscriptionKey                     = "RASProjectSubscriptionKey",
+             endpoint                            = "RMAAPIEndpoint",
+             isPreviewMode                       = "RMAIsPreviewMode",
+             requireMiniAppSignatureVerification = "RMARequireMiniAppSignatureVerification",
+             sslKeyHash                          = "RMASSLKeyHash"
     }
 
     static let userDefaults = UserDefaults(suiteName: "com.rakuten.tech.mobile.miniapp.MiniAppDemo.settings")
@@ -18,13 +18,19 @@ class Config: NSObject {
     // swiftlint:disable:next todo
     // TODO: Make it as CI Configurable
     class func current(rasProjectId: String? = Config.userDefaults?.string(forKey: Config.Key.projectId.rawValue),
-                       subscriptionKey: String? = Config.userDefaults?.string(forKey: Config.Key.subscriptionKey.rawValue)) -> MiniAppSdkConfig {
-        MiniAppSdkConfig(baseUrl: Config.userDefaults?.string(forKey: Config.Key.endpoint.rawValue),
-            rasProjectId: rasProjectId,
-            subscriptionKey: subscriptionKey,
-            hostAppVersion: Config.userDefaults?.string(forKey: Config.Key.version.rawValue),
-            isPreviewMode: Config.userDefaults?.value(forKey: Config.Key.isPreviewMode.rawValue) as? Bool,
-            analyticsConfigList: [MAAnalyticsConfig(acc: "477", aid: "998")]
+                       subscriptionKey: String? = Config.userDefaults?.string(forKey: Config.Key.subscriptionKey.rawValue), pinningEnabled: Bool = false) -> MiniAppSdkConfig {
+        var pinConf: MiniAppConfigSSLKeyHash?
+        if pinningEnabled, let keyHash = (Bundle.main.object(forInfoDictionaryKey: "RMASSLKeyHash") as? [String: Any?])?["main"] as? String {
+            pinConf = MiniAppConfigSSLKeyHash(pin: keyHash, backup: (Bundle.main.object(forInfoDictionaryKey: "RMASSLKeyHash") as? [String: Any?])?["backup"] as? String)
+        }
+        return MiniAppSdkConfig(
+                baseUrl: Config.userDefaults?.string(forKey: Config.Key.endpoint.rawValue),
+                rasProjectId: rasProjectId,
+                subscriptionKey: subscriptionKey,
+                hostAppVersion: Config.userDefaults?.string(forKey: Config.Key.version.rawValue),
+                isPreviewMode: Config.userDefaults?.value(forKey: Config.Key.isPreviewMode.rawValue) as? Bool,
+                analyticsConfigList: [MAAnalyticsConfig(acc: "477", aid: "998")],
+                sslKeyHash: pinConf
         )
     }
 

--- a/MiniApp/Classes/core/Downloader/MiniAppClient.swift
+++ b/MiniApp/Classes/core/Downloader/MiniAppClient.swift
@@ -64,9 +64,9 @@ internal class MiniAppClient: NSObject, URLSessionDownloadDelegate {
         environment.customAppVersion = config?.hostAppVersion
         environment.customIsPreviewMode = config?.isPreviewMode
         environment.customSignatureVerification = config?.requireMiniAppSignatureVerification
+        environment.customSSLKeyHash = config?.sslKeyHash?.pin
+        environment.customSSLKeyHashBackup = config?.sslKeyHash?.backupPin
         if sslPinningConfig == nil {
-            environment.customSSLKeyHash = config?.sslKeyHash?.pin
-            environment.customSSLKeyHashBackup = config?.sslKeyHash?.backupPin
             updateSSLPinConfig()
         } else if
                 let pins = sslPinningConfig?.domains[environment.host]?[kTSKPublicKeyHashes] as? [String],
@@ -293,7 +293,7 @@ internal class MiniAppClient: NSObject, URLSessionDownloadDelegate {
 
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         updateSSLPinConfig()
-        if sslPinningConfig == nil {
+        if sslPinningConfig == nil || environment.sslKeyHash == nil {
             completionHandler(.performDefaultHandling, nil)
         } else if !TrustKit.sharedInstance().pinningValidator.handle(challenge, completionHandler: completionHandler) {
             MiniAppLogger.w("TrustKit did not handle this challenge: perhaps it was not for server trust or the domain was not pinned. Fall back to the default behavior")

--- a/MiniApp/Classes/core/Environment.swift
+++ b/MiniApp/Classes/core/Environment.swift
@@ -94,11 +94,11 @@ internal class Environment {
     }
 
     var sslKeyHash: String? {
-        customSSLKeyHash ?? dictionary(for: Key.sslKeyHash)?[MiniAppConfigSSLKeyHash.KeyType.main.rawValue] as? String
+        customSSLKeyHash
     }
 
     var sslKeyHashBackup: String? {
-        customSSLKeyHashBackup ?? dictionary(for: Key.sslKeyHash)?[MiniAppConfigSSLKeyHash.KeyType.backup.rawValue] as? String
+        customSSLKeyHashBackup
     }
 
     func value(for field: String?, fallback key: Key) -> String {

--- a/Podfile
+++ b/Podfile
@@ -21,8 +21,8 @@ target sdk_name + '_Example' do
 
   target sdk_name + '_Tests' do
     inherit! :search_paths
-    pod 'Nimble', '~>9.0.0'
-    pod 'Quick', '~>3.1.2'
+    pod 'Nimble', '~>9.2.1'
+    pod 'Quick', '~>4.0.0'
   end
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -51,9 +51,9 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Nimble (9.0.1)
+  - Nimble (9.2.1)
   - PromisesObjC (2.0.0)
-  - Quick (3.1.2)
+  - Quick (4.0.0)
   - RAnalytics (8.2.1)
   - TrustKit (2.0.0)
   - ZIPFoundation (0.9.12)
@@ -63,8 +63,8 @@ DEPENDENCIES:
   - MiniApp/Admob8 (from `./`)
   - MiniApp/Signature (from `./`)
   - MiniApp/UI (from `./`)
-  - Nimble (~> 9.0.0)
-  - Quick (~> 3.1.2)
+  - Nimble (~> 9.2.1)
+  - Quick (~> 4.0.0)
   - RAnalytics
 
 SPEC REPOS:
@@ -95,13 +95,13 @@ SPEC CHECKSUMS:
   GoogleUtilities: 8de2a97a17e15b6b98e38e8770e2d129a57c0040
   MiniApp: a6b5b474d2bf8f9182afb079a98ba668e74108d8
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
+  Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
-  Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
+  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   RAnalytics: ab09bc6648a4804e10a9524f8156e9a393b426fb
   TrustKit: 610b8c71c07914756dd74c380040a3408a747798
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 13bc7439e7c5891907138b5f4a86d360d4ec03a8
+PODFILE CHECKSUM: 67f58014a29f748678ec3b6870d6e4bda2a1a013
 
 COCOAPODS: 1.11.2

--- a/Tests/Unit/EnvironmentTests.swift
+++ b/Tests/Unit/EnvironmentTests.swift
@@ -21,15 +21,6 @@ class EnvironmentTests: QuickSpec {
 
                 expect(environment.projectId).to(equal("1.1"))
             }
-            it("has the expected ssl pins") {
-                let mockBundle = MockBundle()
-                mockBundle.mockSSLPins = ["backup": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=", "main": "AABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="]
-
-                let environment = Environment(bundle: mockBundle)
-
-                expect(environment.sslKeyHash).to(equal("AABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="))
-                expect(environment.sslKeyHashBackup).to(equal("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="))
-            }
             it("has the expected subscription key") {
                 let mockBundle = MockBundle()
                 mockBundle.mockSubscriptionKey = "mini-subscription-key"
@@ -40,10 +31,10 @@ class EnvironmentTests: QuickSpec {
             }
             it("will return base url endpoint") {
                 let mockBundle = MockBundle()
-                mockBundle.mockEndpoint = "https://example-endpoint.com"
+                mockBundle.mockEndpoint = mockHost
                 let environment = Environment(bundle: mockBundle)
 
-                expect(environment.baseUrl?.absoluteString).to(equal("https://example-endpoint.com"))
+                expect(environment.baseUrl?.absoluteString).to(equal(mockHost))
             }
             it("will return host app info") {
                 let mockBundle = MockBundle()
@@ -68,7 +59,6 @@ class EnvironmentTests: QuickSpec {
             mockBundle.mockAppVersion = nil
             mockBundle.mockHostAppUserAgentInfo = nil
             mockBundle.mockValueNotFound = "Value Not Found"
-            mockBundle.mockSSLPins = nil
             let environment = Environment(bundle: mockBundle)
             it("will return app id as nil") {
                 expect(environment.projectId).to(equal(mockBundle.valueNotFound))

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -1,6 +1,7 @@
 @testable import MiniApp
 import WebKit
 import Foundation
+let mockHost = "https://example.com"
 
 let jSONManifest = """
 {
@@ -278,10 +279,9 @@ class MockBundle: EnvironmentProtocol {
     var mockProjectId: String?
     var mockSubscriptionKey: String?
     var mockAppVersion: String?
-    var mockEndpoint: String? = "https://www.example.com/"
+    var mockEndpoint: String? = "\(mockHost)/"
     var mockPreviewMode: Bool?
     var mockHostAppUserAgentInfo: String?
-    var mockSSLPins: [String: String]?
 
     func bool(for key: String) -> Bool? {
         switch key {
@@ -311,8 +311,6 @@ class MockBundle: EnvironmentProtocol {
 
     func object(forInfoDictionaryKey: String) -> Any? {
         switch forInfoDictionaryKey {
-        case "RMASSLKeyHash":
-            return mockSSLPins
         default:
             return nil
         }
@@ -468,7 +466,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
 
 var mockMiniAppInfo: MiniAppInfo {
     let mockVersion = Version(versionTag: "Dev", versionId: "ver-id-test")
-    let info = MiniAppInfo.init(id: "app-id-test", displayName: "Mini App Title", icon: URL(string: "https://www.example.com/icon.png")!, version: mockVersion)
+    let info = MiniAppInfo.init(id: "app-id-test", displayName: "Mini App Title", icon: URL(string: "\(mockHost)/icon.png")!, version: mockVersion)
     return info
 }
 
@@ -753,7 +751,7 @@ extension UIImage {
         var fetchKeyCalledNumTimes = 0
         var fetchedKey: KeyModel? = KeyModel(identifier: "", key: "", pem: "")
 
-        init() { super.init(apiClient: SignatureAPI(), config: Config(baseURL: URL(string: "http://test.com")!, subscriptionKey: "")) }
+        init() { super.init(apiClient: SignatureAPI(), config: Config(baseURL: URL(string: mockHost)!, subscriptionKey: "")) }
 
         override func fetchKey(with keyId: String, completionHandler: @escaping (Result<KeyModel, Error>) -> Void) {
             fetchKeyCalledNumTimes += 1

--- a/Tests/Unit/ListingAPITests.swift
+++ b/Tests/Unit/ListingAPITests.swift
@@ -13,12 +13,12 @@ class ListingAPITests: QuickSpec {
 
             context("when endpoint is properly configured") {
                 it("will return valid URL Request for app listing") {
-                    mockBundle.mockEndpoint = "http://example.com"
+                    mockBundle.mockEndpoint = mockHost
                     expect(listingAPI.createURLRequest()).to(beAnInstanceOf(URLRequest.self))
                 }
 
                 it("will return valid URL Request for app info") {
-                    mockBundle.mockEndpoint = "http://example.com"
+                    mockBundle.mockEndpoint = mockHost
                     expect(listingAPI.createURLRequest(for: "123")).to(beAnInstanceOf(URLRequest.self))
                 }
             }

--- a/Tests/Unit/ManifestAPITests.swift
+++ b/Tests/Unit/ManifestAPITests.swift
@@ -13,7 +13,7 @@ class ManifestAPITests: QuickSpec {
 
             context("when endpoint is properly configured") {
                 it("will return valid URL Request") {
-                    mockBundle.mockEndpoint = "http://example.com"
+                    mockBundle.mockEndpoint = mockHost
                     let urlRequest = manifestAPI.createURLRequest(appId: "1", versionId: "test")
                     expect(urlRequest).to(beAnInstanceOf(URLRequest.self))
                 }

--- a/Tests/Unit/ManifestDownloaderTests.swift
+++ b/Tests/Unit/ManifestDownloaderTests.swift
@@ -16,7 +16,7 @@ class ManifestDownloaderTests: QuickSpec {
                       {
                         "manifest": [
                             "https://test.com",
-                            "https://example.com"
+                            "\(mockHost)"
                         ]
                       }
                     """
@@ -41,7 +41,7 @@ class ManifestDownloaderTests: QuickSpec {
                       {
                         "files": [
                             "https://test.com",
-                            "https://example.com"
+                            "\(mockHost)"
                         ]
                       }
                     """

--- a/Tests/Unit/MetaDataAPITests.swift
+++ b/Tests/Unit/MetaDataAPITests.swift
@@ -13,7 +13,7 @@ class MetaDataAPITests: QuickSpec {
 
             context("when endpoint is properly configured") {
                 it("will return valid URL Request") {
-                    mockBundle.mockEndpoint = "http://example.com"
+                    mockBundle.mockEndpoint = mockHost
                     let urlRequest = manifestAPI.createURLRequest(appId: "1", versionId: "test")
                     expect(urlRequest).to(beAnInstanceOf(URLRequest.self))
                 }

--- a/Tests/Unit/MimeTypesTests.swift
+++ b/Tests/Unit/MimeTypesTests.swift
@@ -8,19 +8,19 @@ class MimeTypesTests: QuickSpec {
         describe("Mime Type Tests") {
             context("when mimeType is called with valid file path extension") {
                 it("will return valid Mime Type") {
-                    let htmlURL = URL(string: "https://example.com/home.svg")
+                    let htmlURL = URL(string: "\(mockHost)/home.svg")
                     expect(htmlURL?.pathExtension.mimeType()).to(equal("image/svg+xml"))
                 }
             }
             context("when mimeType is called with valid file path extension - uppercased") {
                 it("will return valid Mime Type") {
-                    let htmlURL = URL(string: "https://example.com/index.HTML")
+                    let htmlURL = URL(string: "\(mockHost)/index.HTML")
                     expect(htmlURL?.pathExtension.mimeType()).to(equal("text/html"))
                 }
             }
             context("when mimeType is called with invalid file path extension") {
                 it("will return default valid Mime Type") {
-                    let htmlURL = URL(string: "https://example.com/index.abcd")
+                    let htmlURL = URL(string: "\(mockHost)/index.abcd")
                     expect(htmlURL?.pathExtension.mimeType()).to(equal("text/html"))
                 }
             }

--- a/Tests/Unit/MiniApp+NSErrorTests.swift
+++ b/Tests/Unit/MiniApp+NSErrorTests.swift
@@ -21,7 +21,7 @@ class MiniAppNSErrorTests: QuickSpec {
                 }
             }
             context("throws unknown error") {
-                let urlResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 400, httpVersion: "1", headerFields: nil)
+                let urlResponse = HTTPURLResponse(url: URL(string: mockHost)!, statusCode: 400, httpVersion: "1", headerFields: nil)
                 let error = NSError.unknownServerError(httpResponse: urlResponse)
                 it("will return server with NSError type") {
                     expect(error).to(beAnInstanceOf(NSError.self))

--- a/Tests/Unit/MiniApp+URLRequestTests.swift
+++ b/Tests/Unit/MiniApp+URLRequestTests.swift
@@ -6,7 +6,7 @@ class MiniAppURLRequestTests: QuickSpec {
 
     override func spec() {
         describe("create url request") {
-            guard let url = URL(string: "http://example.com") else {
+            guard let url = URL(string: mockHost) else {
                 return
             }
             let mockBundle = MockBundle()

--- a/Tests/Unit/MiniAppClientTests.swift
+++ b/Tests/Unit/MiniAppClientTests.swift
@@ -17,7 +17,7 @@ class MiniAppClientTests: QuickSpec {
 
         func startDataTask(with request: URLRequest, completionHandler: @escaping (Result<ResponseData, Error>) -> Void) {
             attempts += 1
-            urlResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: serverErrorCode, httpVersion: "1", headerFields: nil)
+            urlResponse = HTTPURLResponse(url: URL(string: mockHost)!, statusCode: serverErrorCode, httpVersion: "1", headerFields: nil)
             if let json = jsonObject {
                 data = try? JSONSerialization.data(withJSONObject: json, options: [])
             }
@@ -212,7 +212,7 @@ class MiniAppClientTests: QuickSpec {
                     let mockSession = MockSession(data: ["id": "123",
                         "versionTag": "1.0",
                         "name": "Sample",
-                        "files": ["http://www.example.com"]])
+                        "files": ["\(mockHost)"]])
                     let miniAppClient = MiniAppClient()
                     miniAppClient.session = mockSession
                     miniAppClient.getAppManifest(appId: "abc", versionId: "ver") { (result) in
@@ -283,7 +283,7 @@ class MiniAppClientTests: QuickSpec {
             let endpointKey = "RMAAPIEndpoint"
             let isPreviewMode = "RMAIsPreviewMode"
             let bundle = Bundle.main as EnvironmentProtocol
-            let testURL = "http://dummy.url"
+            let testURL = mockHost
             let testID = "testID"
             let testProjectID = "testProjectID"
             let testKey = "testKey"
@@ -328,7 +328,7 @@ class MiniAppClientTests: QuickSpec {
                         isPreviewMode: true))
 
                     miniAppClient.updateEnvironment(with: MiniAppSdkConfig(
-                        baseUrl: "http://dummy2.url",
+                        baseUrl: mockHost,
                         rasProjectId: "id2",
                         subscriptionKey: "key2",
                         hostAppVersion: "newversion",
@@ -337,7 +337,7 @@ class MiniAppClientTests: QuickSpec {
                     expect(miniAppClient.environment.projectId).to(equal("id2"))
                     expect(miniAppClient.environment.appVersion).to(equal("newversion"))
                     expect(miniAppClient.environment.subscriptionKey).to(equal("key2"))
-                    expect(miniAppClient.environment.baseUrl?.absoluteString).to(equal("http://dummy2.url"))
+                    expect(miniAppClient.environment.baseUrl?.absoluteString).to(equal(mockHost))
                     expect(miniAppClient.environment.isPreviewMode).to(be(false))
                 }
             }

--- a/Tests/Unit/MiniAppExternalUrlLoaderTests.swift
+++ b/Tests/Unit/MiniAppExternalUrlLoaderTests.swift
@@ -27,7 +27,7 @@ class MiniAppExternalUrlLoaderTests: QuickSpec {
             context("when shouldOverrideURLLoading method is called with https URL") {
                 it("will return WKNavigationActionPolicy as allow") {
                     let externalURLLoader = MiniAppExternalUrlLoader()
-                    let str = URLComponents(string: "https://www.google.com")
+                    let str = URLComponents(string: "\(mockHost)")
                     let navigationPolicy = externalURLLoader.shouldOverrideURLLoading(str?.url)
                     expect(navigationPolicy.rawValue).to(equal(WKNavigationActionPolicy.allow.rawValue))
                 }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -563,7 +563,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                       "id" : "1.9034416849400426",
                       "param" : {
                         "messageToContact" : {
-                          "action" : "https://www.example.com\",
+                          "action" : "\(mockHost)\",
                           "caption" : "Sample caption",
                           "image" : "data:image/png;base64,Test==",
                           "text" : "Sample text"
@@ -592,7 +592,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                       "id" : "1.9034416849400426",
                       "param" : {
                         "messageToContact" : {
-                          "action" : "https://www.example.com\",
+                          "action" : "\(mockHost)\",
                           "caption" : "Sample caption",
                           "image" : "data:image/png;base64,Test==",
                           "text" : "Sample text"
@@ -622,7 +622,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         "param" : {
                             "contactId" : "\(mockMiniAppInfo.id)",
                             "messageToContact" : {
-                                "action" : "https://www.example.com/",
+                                "action" : "\(mockHost)/",
                                 "caption" : "Sample caption",
                                 "image" : "data:image/png;base64,Test==",
                                 "text" : "Sample text"
@@ -654,7 +654,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         "param" : {
                             "contactId" : "\(mockMiniAppInfo.id)",
                             "messageToContact" : {
-                                "action" : "https://www.example.com/",
+                                "action" : "\(mockHost)/",
                                 "caption" : "Sample caption",
                                 "image" : "data:image/png;base64,Test==",
                                 "text" : "Sample text"
@@ -678,7 +678,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         "id" : "5.1141101534045745",
                         "param" : {
                             "messageToContact" : {
-                                "action" : "https://www.example.com/",
+                                "action" : "\(mockHost)/",
                                 "caption" : "Sample caption",
                                 "image" : "data:image/png;base64,Test==",
                                 "text" : "Sample text"
@@ -710,7 +710,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         "id" : "5.1141101534045745",
                         "param" : {
                             "messageToContact" : {
-                                "action" : "https://www.example.com/",
+                                "action" : "\(mockHost)/",
                                 "caption" : "Sample caption",
                                 "image" : "data:image/png;base64,Test==",
                                 "text" : "Sample text"

--- a/Tests/Unit/MiniAppSdkConfigTests.swift
+++ b/Tests/Unit/MiniAppSdkConfigTests.swift
@@ -8,12 +8,12 @@ class MiniAppSdkConfigTests: QuickSpec {
         describe("MiniAppSdkConfig") {
             context("when MiniAppSdkConfig is initialized with valid parameters") {
                 it("will return all values") {
-                    let config = MiniAppSdkConfig(baseUrl: "http://example.com", rasProjectId: "mini-app-project-id",
+                    let config = MiniAppSdkConfig(baseUrl: mockHost, rasProjectId: "mini-app-project-id",
                                                   subscriptionKey: "mini-app-sub-key", hostAppVersion: "1.0", isPreviewMode: false,
                                                   analyticsConfigList: [MAAnalyticsConfig(acc: mockRATAcc, aid: mockRATAid)],
                                                   requireMiniAppSignatureVerification: true)
                     let env = Environment(with: config)
-                    expect(config.baseUrl).to(equal("http://example.com"))
+                    expect(config.baseUrl).to(equal(mockHost))
                     expect(config.rasProjectId).to(equal("mini-app-project-id"))
                     expect(config.subscriptionKey).to(equal("mini-app-sub-key"))
                     expect(config.hostAppVersion).to(equal("1.0"))
@@ -38,28 +38,34 @@ class MiniAppSdkConfigTests: QuickSpec {
                     expect(config.customAppVersion).to(beNil())
                     expect(config.customSubscriptionKey).to(beNil())
                     expect(config.customIsPreviewMode).to(beNil())
+                    expect(config.customSSLKeyHash).to(beNil())
+                    expect(config.customSSLKeyHashBackup).to(beNil())
                     expect(config.customSignatureVerification).to(beNil())
                     expect(config.baseUrl).toNot(beNil())
                     expect(config.projectId).toNot(beNil())
                     expect(config.subscriptionKey).toNot(beNil())
                     expect(config.appVersion).toNot(beNil())
                     expect(config.isPreviewMode).to(be(true))
+                    expect(config.sslKeyHash).to(beNil())
+                    expect(config.sslKeyHashBackup).to(beNil())
                     expect(config.requireMiniAppSignatureVerification).to(be(false))
                 }
             }
             context("when MiniAppSdkConfig is initialized with default constructor and value is set later") {
                 it("will return all values") {
+                    let pinConf = MiniAppConfigSSLKeyHash(pin: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=", backup: "AABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=")
                     let config = MiniAppSdkConfig()
-                    config.baseUrl = "http://example.com"
+                    config.baseUrl = mockHost
                     config.rasProjectId = "mini-app-host-id"
                     config.subscriptionKey = "mini-app-sub-key"
                     config.hostAppVersion = "1.0"
                     config.isPreviewMode = false
                     config.requireMiniAppSignatureVerification = true
                     config.analyticsConfigList = [MAAnalyticsConfig(acc: mockRATAcc, aid: mockRATAid)]
+                    config.sslKeyHash = pinConf
                     let env = Environment(with: config)
 
-                    expect(config.baseUrl).to(equal("http://example.com"))
+                    expect(config.baseUrl).to(equal(mockHost))
                     expect(config.rasProjectId).to(equal("mini-app-host-id"))
                     expect(config.subscriptionKey).to(equal("mini-app-sub-key"))
                     expect(config.hostAppVersion).to(equal("1.0"))
@@ -68,12 +74,16 @@ class MiniAppSdkConfigTests: QuickSpec {
                     expect(config.analyticsConfigList?[0].acc).to(be(mockRATAcc))
                     expect(config.analyticsConfigList?[0].aid).to(be(mockRATAid))
                     expect(config.requireMiniAppSignatureVerification).to(be(true))
+                    expect(config.sslKeyHash?.pin).to(equal("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="))
+                    expect(config.sslKeyHash?.backupPin).to(equal("AABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="))
                     expect(env.baseUrl?.absoluteString).to(equal(config.baseUrl))
                     expect(env.projectId).to(equal(config.rasProjectId))
                     expect(env.subscriptionKey).to(equal(config.subscriptionKey))
                     expect(env.appVersion).to(equal(config.hostAppVersion))
                     expect(env.isPreviewMode).to(be(config.isPreviewMode))
                     expect(env.requireMiniAppSignatureVerification).to(be(config.requireMiniAppSignatureVerification))
+                    expect(env.sslKeyHash).to(equal(config.sslKeyHash?.pin))
+                    expect(env.sslKeyHashBackup).to(equal(config.sslKeyHash?.backupPin))
                 }
             }
         }

--- a/Tests/Unit/MiniAppStatusTests.swift
+++ b/Tests/Unit/MiniAppStatusTests.swift
@@ -101,7 +101,7 @@ class MiniAppStatusTests: QuickSpec {
                     miniAppKeyStore.storeCustomPermissions(permissions: getDefaultSupportedPermissions(), forMiniApp: mockMiniAppInfo.id)
                     let miniAppCustomPermissionList = miniAppStatus.checkStoredPermissionList(downloadedMiniAppsList: [mockMiniAppInfo])
                     expect(miniAppCustomPermissionList.keys).to(contain(mockMiniAppInfo.id))
-                    let miniAppInfo = MiniAppInfo(id: "123", displayName: "Test", icon: URL(string: "https://www.example.com/icon.png")!, version: mockMiniAppInfo.version)
+                    let miniAppInfo = MiniAppInfo(id: "123", displayName: "Test", icon: URL(string: "\(mockHost)/icon.png")!, version: mockMiniAppInfo.version)
                     let customPermissionsList = miniAppStatus.checkStoredPermissionList(downloadedMiniAppsList: [miniAppInfo])
                     expect(customPermissionsList.keys).notTo(contain(miniAppInfo.id))
                     expect(customPermissionsList.keys).notTo(contain(mockMiniAppInfo.id))

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -161,7 +161,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
@@ -212,7 +212,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
@@ -261,7 +261,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
@@ -305,7 +305,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -339,7 +339,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -372,7 +372,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     realMiniApp.miniAppInfoFetcher = mockMiniAppInfoFetcher
@@ -408,7 +408,7 @@ class RealMiniAppTests: QuickSpec {
                     """
                     let manifestResponse = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)
@@ -430,7 +430,7 @@ class RealMiniAppTests: QuickSpec {
                 it("will return error") {
                     let responseString = """
                       {
-                        "manifest": ["https://example.com/app-id-test/ver-id-test/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/app-id-test/ver-id-test/HelloWorld.txt"]
                       }
                     """
                     var testError: NSError?

--- a/Tests/Unit/Signature/FetcherTests.swift
+++ b/Tests/Unit/Signature/FetcherTests.swift
@@ -9,7 +9,7 @@ class FetcherSpec: QuickSpec {
         describe("key fetch function") {
             var apiClientMock: APIClientMock!
             var fetcher: SignatureFetcher!
-            let config = SignatureFetcher.Config(baseURL: URL(string: "https://www.endpoint.com")!, subscriptionKey: "my-subkey")
+            let config = SignatureFetcher.Config(baseURL: URL(string: mockHost)!, subscriptionKey: "my-subkey")
 
             beforeEach {
                 apiClientMock = APIClientMock()
@@ -50,7 +50,7 @@ class FetcherSpec: QuickSpec {
 
             it("will not add (another) ras- prefix to the subscription key, if it already exists") {
                 fetcher = SignatureFetcher(apiClient: apiClientMock,
-                                  config: .init(baseURL: URL(string: "https://www.endpoint.com")!, subscriptionKey: "ras-my-subkey"))
+                                  config: .init(baseURL: URL(string: mockHost)!, subscriptionKey: "ras-my-subkey"))
 
                 fetcher.fetchKey(with: "key", completionHandler: { (_) in
                 })

--- a/Tests/Unit/Signature/RealSignatureVerifierTests.swift
+++ b/Tests/Unit/Signature/RealSignatureVerifierTests.swift
@@ -9,7 +9,7 @@ class RealSignatureVerifierSpec: QuickSpec {
 
         describe("RealSignatureVerifier") {
 
-            let config = SignatureFetcher.Config(baseURL: URL(string: "https://www.endpoint.com")!, subscriptionKey: "my-subkey")
+            let config = SignatureFetcher.Config(baseURL: URL(string: mockHost)!, subscriptionKey: "my-subkey")
             let keyStore = SignatureKeyStore(account: config.baseURL.identifier, service: "unit-tests")
             let mockData = "data".data(using: .utf8)!
 

--- a/Tests/Unit/URLSchemeHandlerTests.swift
+++ b/Tests/Unit/URLSchemeHandlerTests.swift
@@ -35,7 +35,7 @@ class URLSchemeHandlerTests: QuickSpec {
                     let downloader = MiniAppDownloader(apiClient: mockAPIClient, manifestDownloader: mockManifestDownloader, status: miniAppStatus)
                     let responseString = """
                       {
-                        "manifest": ["https://google.com/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
                       }
                     """
                     mockAPIClient.data = responseString.data(using: .utf8)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,9 +16,10 @@ platform :ios do
       strict: true,
       ignore_exit_status: false
     )
-    if !is_ci
-      tests
-    end
+# Uncomment this to disable Unit tests on Bitrise
+#     if !is_ci
+       tests
+#     end
 
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,26 +10,35 @@ platform :ios do
     cocoapods(repo_update: ENV['MA_FL_CP_REPO_UPDATE'] || false)
   end
 
-  desc "Build All"
+  desc "Check lint"
   lane :ci do |options|
-    xcversion(version: "~> 13.0")
-
     swiftlint(
       strict: true,
       ignore_exit_status: false
     )
+    if !is_ci
+      tests
+    end
 
-    updatePods
+  end
 
-#     scan(
-#       clean: true,
-#       output_directory: './artifacts/unit-tests',
-#       scheme: 'MiniApp_Tests',
-#       device: 'iPhone X',
-#       code_coverage: true,
-#       output_types: 'json-compilation-database,html,junit',
-#       output_files: 'compile_commands.json,report.html,report.junit')
-
+  desc "Unit tests"
+  lane :tests do |options|
+      xcversion(version: "~> 13.0")
+      updatePods
+      fetched_sim = sh("xcrun simctl list | grep 'Fastlane' | cat")
+      if !fetched_sim.empty?
+          sh("xcrun", "simctl", "delete", "iPhone Fastlane")
+      end
+      sh("xcrun","simctl","create","iPhone Fastlane", "com.apple.CoreSimulator.SimDeviceType.iPhone-7","com.apple.CoreSimulator.SimRuntime.iOS-13-7")
+      scan(
+        clean: true,
+        output_directory: './artifacts/unit-tests',
+        scheme: 'MiniApp_Tests',
+        device: 'iPhone Fastlane',
+        code_coverage: true,
+        output_types: 'json-compilation-database,html,junit',
+        output_files: 'compile_commands.json,report.html,report.junit')
   end
 
   lane :build_simulator do |options|


### PR DESCRIPTION
# Description
Disabled SSL pinning when pin is not provided in config
Cleaned up unit tests and re-enabled CI tests execution 🤞 


# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
