### PR TITLE
[FIX] MiniApp SDK does not compile when Signature is not in podfile

### DIFF
--- a/MiniApp/Classes/core/Downloader/MiniAppClient.swift
+++ b/MiniApp/Classes/core/Downloader/MiniAppClient.swift
@@ -278,7 +278,7 @@ internal class MiniAppClient: NSObject, URLSessionDownloadDelegate {
                 delegate?.fileDownloaded(at: location, downloadedURL: destinationURL, signatureChecked: !requireMiniAppSignatureVerification)
             }
         #else
-            MiniAppAnalytics.sendAnalytics(event: .signatureFailure, miniAppId: ids.0, miniAppVersion: ids.1)
+        MiniAppAnalytics.sendAnalytics(event: .signatureFailure, miniAppId: ids?.0, miniAppVersion: ids?.1)
             delegate?.fileDownloaded(at: location, downloadedURL: destinationURL)
         #endif
     }


### PR DESCRIPTION
# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
