### PR TITLE
[MINI-4142] Launch mini app using QR even if application is not in foreground.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Feature:** Added support for App Store URL schemes
 - **Feature:** Added new public interface `getMiniAppPreviewInfo` to get Mini app info using preview token
 - **Feature:** Added SSL pinning check for API calls
+- **Feature:** Added `getHostEnvironmentInfo(completionHandler:)` interface to return `MAHostEnvironmentInfo` details to miniapp
 
 **Sample app**
 
@@ -18,6 +19,7 @@
 - **Feature:** ATS deactivated to match production needs
 - **Feature:** Added support for previewing mini app using QR Code
 
+---
 ### 3.5.0 (2021-08-05)
 
 **SDK**
@@ -32,6 +34,7 @@
 - **Feature:** Display of a banner on message contact picker when required
 - **Feature:** Added Points to the settings screen to change `getPoints` response values 
 
+---
 ### 3.4.0 (2021-06-25)
 
 **SDK**

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -16,6 +16,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window?.tintColor = UIColor.accent
         GADMobileAds.sharedInstance().start(completionHandler: nil)
         AnalyticsManager.shared().set(loggingLevel: .debug)
+        if let url = launchOptions?[.url] as? URL {
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+                return true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now()+2, execute: {
+                self.deepLinkToMiniApp(using: components.path.replacingOccurrences(of: "/preview/", with: ""))
+            })
+        }
         return true
     }
 


### PR DESCRIPTION
# Description
* Updated code to launch Mini app using QR (Even if the demo app is closed state)
* Updated documentation

## Links
[MINI-4142](https://jira.rakuten-it.com/jira/browse/MINI-4142)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
