### PR TITLE
Fix for MINI-4165

### DIFF
--- a/MiniApp/Classes/core/MASDKError.swift
+++ b/MiniApp/Classes/core/MASDKError.swift
@@ -19,9 +19,6 @@ public enum MASDKError: Error {
     /// The provided mini app version ID was invalid. For example, the value cannot be an empty string.
     case invalidVersionId
 
-    /// ZIP archive signature has changed during download phase
-    case invalidSignature
-
     /// The server provided an invalid response body.
     case invalidResponseData
 
@@ -42,6 +39,9 @@ public enum MASDKError: Error {
 
     /// Host app failed to implement required interface
     case failedToConformToProtocol
+
+    /// ZIP archive signature has changed during download phase
+    case invalidSignature
 
     /// An unexpected error occurred.
     ///


### PR DESCRIPTION
# Description
This change is done because [fromError(error: Error)](https://github.com/rakutentech/ios-miniapp/blob/master/MiniApp/Classes/core/MASDKError.swift#L101) method returns wrong MASDKError 

## Links
* MINI-4165

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
