### PR TITLE
[MINI-1976] MiniApp custom events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **SDK**
 
+- **Feature:** MiniApp custom events (pause, resume, external webview closed)
+
 ### 3.7.0 (2021-10-08)
 
 **SDK**

--- a/MiniApp/Classes/core/Assets/console.js
+++ b/MiniApp/Classes/core/Assets/console.js
@@ -1,0 +1,22 @@
+function log(emoji, type, args) {
+  window.webkit.messageHandlers.logging.postMessage(
+    `${emoji} console.${type}: ${Object.values(args)
+      .map(v => typeof(v) === "undefined" ? "undefined" : typeof(v) === "object" ? JSON.stringify(v) : v.toString())
+      .map(v => v.substring(0, 3000)) // Limit msg to 3000 chars
+      .join(", ")}`
+  )
+}
+
+let originalLog = console.log
+let originalWarn = console.warn
+let originalError = console.error
+let originalDebug = console.debug
+
+console.log = function() { log("📗", "log", arguments); originalLog.apply(null, arguments) }
+console.warn = function() { log("📙", "warning", arguments); originalWarn.apply(null, arguments) }
+console.error = function() { log("📕", "error", arguments); originalError.apply(null, arguments) }
+console.debug = function() { log("📘", "debug", arguments); originalDebug.apply(null, arguments) }
+
+window.addEventListener("error", function(e) {
+   log("💥", "Uncaught", [`${e.message} at ${e.filename}:${e.lineno}:${e.colno}`])
+})

--- a/MiniApp/Classes/core/Display/MiniAppExternalWebViewController.swift
+++ b/MiniApp/Classes/core/Display/MiniAppExternalWebViewController.swift
@@ -8,6 +8,7 @@ class MiniAppExternalWebViewController: UIViewController {
     private var currentURL: URL?
     private var customMiniAppURL: URL?
     private var miniAppExternalUrlLoader: MiniAppExternalUrlLoader?
+    private var miniAppExternalUrlClose: MiniAppNavigationResponseHandler?
 
     lazy var backBarButton: UIBarButtonItem = {
         let view = UIBarButtonItem(image: UIImage(named: "arrow_left-24", in: Bundle.miniAppSDKBundle(), with: .none), style: .plain, target: self, action: #selector(navigateBack))
@@ -30,8 +31,10 @@ class MiniAppExternalWebViewController: UIViewController {
     ///
     public class func presentModally(url: URL,
                                      externalLinkResponseHandler: MiniAppNavigationResponseHandler?,
-                                     customMiniAppURL: URL? = nil) {
+                                     customMiniAppURL: URL? = nil,
+                                     onCloseHandler: MiniAppNavigationResponseHandler?) {
         let webctrl = MiniAppExternalWebViewController()
+        webctrl.miniAppExternalUrlClose = onCloseHandler
         webctrl.currentURL = url
         webctrl.customMiniAppURL = customMiniAppURL
         let navigationController = MiniAppCloseNavigationController(rootViewController: webctrl)
@@ -73,6 +76,12 @@ class MiniAppExternalWebViewController: UIViewController {
 
         // back/forward navigation buttons
         navigationItem.setLeftBarButtonItems([backBarButton, forwardBarButton], animated: true)
+    }
+
+    deinit {
+        if let url = webView.url {
+            miniAppExternalUrlClose?(url)
+        }
     }
 
     @objc

--- a/MiniApp/Classes/core/Display/MiniAppNavigationConfig.swift
+++ b/MiniApp/Classes/core/Display/MiniAppNavigationConfig.swift
@@ -35,7 +35,7 @@ public protocol MiniAppNavigationDelegate: AnyObject {
     /// - Parameters:
     ///   - url: the external URL triggered from the MiniApp
     ///   - responseHandler: a `MiniAppNavigationResponseHandler` used to provide an URL to the Mini App
-    func miniAppNavigation(shouldOpen url: URL, with responseHandler: @escaping MiniAppNavigationResponseHandler)
+    func miniAppNavigation(shouldOpen url: URL, with responseHandler: @escaping MiniAppNavigationResponseHandler, onClose closeHandler: MiniAppNavigationResponseHandler?)
     /// This delegate method is called when an external URL is tapped into a url loaded Mini App
     /// so you can display your own webview to load the url parameter, for example.
     /// A `MiniAppNavigationResponseHandler` is also provided so you can give a proper
@@ -45,7 +45,10 @@ public protocol MiniAppNavigationDelegate: AnyObject {
     ///   - url: the external URL triggered from the MiniApp
     ///   - responseHandler: a `MiniAppNavigationResponseHandler` used to provide an URL to the Mini App
     ///   - customMiniAppURL: The url that was used to load the Mini App.
-    func miniAppNavigation(shouldOpen url: URL, with responseHandler: @escaping MiniAppNavigationResponseHandler, customMiniAppURL: URL)
+    func miniAppNavigation(shouldOpen url: URL,
+                           with responseHandler: @escaping MiniAppNavigationResponseHandler,
+                           onClose closeHandler: MiniAppNavigationResponseHandler?,
+                           customMiniAppURL: URL)
     /// This delegate method is called when a navigation is performed inside the Mini App.
     /// - Parameters:
     ///   - actions: a list of `MiniAppNavigationAction` that can be used to navigate inside the Mini App
@@ -63,21 +66,26 @@ public protocol MiniAppNavigationDelegate: AnyObject {
 }
 
 public extension MiniAppNavigationDelegate {
-    func miniAppNavigation(shouldOpen url: URL, with responseHandler: @escaping MiniAppNavigationResponseHandler) {
+    func miniAppNavigation(shouldOpen url: URL,
+                           with responseHandler: @escaping MiniAppNavigationResponseHandler,
+                           onClose closeHandler: MiniAppNavigationResponseHandler?) {
         MiniAppExternalWebViewController.presentModally(url: url,
                                                         externalLinkResponseHandler: responseHandler,
-                                                        customMiniAppURL: nil)
+                                                        customMiniAppURL: nil,
+                                                        onCloseHandler: closeHandler)
     }
 
     func miniAppNavigation(shouldOpen url: URL,
                            with responseHandler: @escaping MiniAppNavigationResponseHandler,
+                           onClose closeHandler: MiniAppNavigationResponseHandler?,
                            customMiniAppURL: URL) {
         checkWebsiteSecurity(url: url) { canLaunch in
             DispatchQueue.main.async {
                 if canLaunch {
                     MiniAppExternalWebViewController.presentModally(url: url,
                                                                     externalLinkResponseHandler: responseHandler,
-                                                                    customMiniAppURL: customMiniAppURL)
+                                                                    customMiniAppURL: customMiniAppURL,
+                                                                    onCloseHandler: closeHandler)
                 } else {
                     UIApplication.shared.open(url)
                 }

--- a/MiniApp/Classes/core/Extensions/NotificationCenter+MiniApp.swift
+++ b/MiniApp/Classes/core/Extensions/NotificationCenter+MiniApp.swift
@@ -24,4 +24,8 @@ internal extension NotificationCenter {
             self.post(name: MiniAppAnalytics.notificationName, object: parameters)
         }
     }
+
+    func sendCustomEvent(_ event: MiniAppEvent.Event) {
+        post(name: MiniAppEvent.notificationName, object: event)
+    }
 }

--- a/MiniApp/Classes/core/Extensions/WKUserContentController+MiniApp.swift
+++ b/MiniApp/Classes/core/Extensions/WKUserContentController+MiniApp.swift
@@ -10,25 +10,37 @@ extension WKUserContentController {
     ///   - miniAppId: Mini App id String value
     ///   - miniAppTitle: Mini App title provided to Javascript handler
     func addMiniAppScriptMessageHandler(delegate: MiniAppCallbackDelegate, hostAppMessageDelegate: MiniAppMessageDelegate, adsDisplayer: MiniAppAdDisplayer?, miniAppId: String, miniAppTitle: String) {
-        add(MiniAppScriptMessageHandler(
-                delegate: delegate,
-                hostAppMessageDelegate: hostAppMessageDelegate,
-                adsDisplayer: adsDisplayer,
-                miniAppId: miniAppId,
-                miniAppTitle: miniAppTitle
-        ), name: Constants.javascriptInterfaceName)
+        [Constants.JavaScript.interfaceName,
+         Constants.JavaScript.logHandler].forEach { (name) in
+            add(MiniAppScriptMessageHandler(
+                    delegate: delegate,
+                    hostAppMessageDelegate: hostAppMessageDelegate,
+                    adsDisplayer: adsDisplayer,
+                    miniAppId: miniAppId,
+                    miniAppTitle: miniAppTitle
+            ), name: name)
+        }
     }
 
     /// Method to remove the custom WKScriptMessageHandler. Removing the message handler will help to avoid memory leaks
     func removeMessageHandler() {
-        removeScriptMessageHandler(forName: Constants.javascriptInterfaceName)
+        removeScriptMessageHandler(forName: Constants.JavaScript.interfaceName)
     }
 
     /// Method to add the Bridging Javascript to the WebView User Controller
     /// This JavaScript is responsible for communication between SDK and Mini App
     /// Any request from Mini App is communicated via the contract available in the Bridging script
     func addBridgingJavaScript(podBundle: Bundle = Bundle.miniAppSDKBundle()) {
-        guard let javascriptPath = podBundle.path(forResource: "bridge", ofType: "js"),
+        injectScript(from: "bridge", in: podBundle)
+
+        #if DEBUG
+        // copy logs from javascript console
+        injectScript(from: "console", in: podBundle)
+        #endif
+    }
+
+    func injectScript(from file: String, in bundle: Bundle) {
+        guard let javascriptPath = bundle.path(forResource: file, ofType: "js"),
             let javascriptSource = try? String(contentsOfFile: javascriptPath) else { return }
 
         let userScript = WKUserScript(source: javascriptSource, injectionTime: .atDocumentStart, forMainFrameOnly: true)

--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -112,3 +112,16 @@ enum MiniAppAdType: Int {
     /// Rewarded ads are interstistial ads that provide a pre-defined reward to the user if they display it for a certain time
     case rewarded
 }
+
+enum MiniAppEvent: String {
+    case externalWebViewClosed = "miniappwebviewclosed"
+    case pause = "miniapppause"
+    case resume = "miniappresume"
+
+    static let notificationName = Notification.Name("notificationName")
+
+    struct Event {
+        var type: MiniAppEvent
+        var comment: String
+    }
+}

--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -34,6 +34,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         if let messageBody = message.body as? String {
             MiniAppLogger.d(messageBody, "♨️️")
+            if message.name == Constants.JavaScript.logHandler { return }
             let bodyData: Data = messageBody.data(using: .utf8)!
             let responseJson = ResponseDecoder.decode(decodeType: MiniAppJavaScriptMessageInfo.self, data: bodyData)
             handleBridgeMessage(responseJson: responseJson)

--- a/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/MiniApp/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -5,6 +5,7 @@ import CoreLocation
 protocol MiniAppCallbackDelegate: AnyObject {
     func didReceiveScriptMessageResponse(messageId: String, response: String)
     func didReceiveScriptMessageError(messageId: String, errorMessage: String)
+    func didReceiveEvent(_ event: MiniAppEvent, message: String)
 }
 
 // swiftlint:disable file_length
@@ -328,6 +329,10 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         case .onError:
             delegate?.didReceiveScriptMessageError(messageId: messageId, errorMessage: response)
         }
+    }
+
+    func execCustomEventsCallback(with event: MiniAppEvent, message: String) {
+        delegate?.didReceiveEvent(event, message: message)
     }
 
     func shareContent(requestParam: RequestParameters?, callbackId: String) {

--- a/MiniApp/Classes/core/Utilities/Constants.swift
+++ b/MiniApp/Classes/core/Utilities/Constants.swift
@@ -1,9 +1,13 @@
-struct Constants {
+enum Constants {
     static let miniAppSchemePrefix = "mscheme."
     static let rootFileName = "index.html"
-    static let javascriptInterfaceName = "MiniAppiOS"
-    static let javascriptSuccessCallback = "MiniAppBridge.execSuccessCallback"
-    static let javascriptErrorCallback = "MiniAppBridge.execErrorCallback"
+    enum JavaScript {
+        static let interfaceName = "MiniAppiOS"
+        static let logHandler = "logging"
+        static let successCallback = "MiniAppBridge.execSuccessCallback"
+        static let errorCallback = "MiniAppBridge.execErrorCallback"
+        static let eventCallback = "MiniAppBridge.execCustomEventsCallback"
+    }
 }
 
 public typealias MASDKDownloadedListPermissionsPair = [(MiniAppInfo, [MASDKCustomPermissionModel])]

--- a/MiniApp/Classes/ui/MiniAppViewController.swift
+++ b/MiniApp/Classes/ui/MiniAppViewController.swift
@@ -32,6 +32,16 @@ public class MiniAppViewController: UIViewController {
         didSet { update() }
     }
 
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        NotificationCenter.default.sendCustomEvent(MiniAppEvent.Event(type: .resume, comment: "MiniApp view did appear"))
+    }
+
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.sendCustomEvent(MiniAppEvent.Event(type: .resume, comment: "MiniApp view will disappear"))
+    }
+
     weak var messageDelegate: MiniAppMessageDelegate?
     weak var navDelegate: MiniAppNavigationDelegate?
     weak var navBarDelegate: MiniAppNavigationBarDelegate?

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,17 +2,24 @@ PODS:
   - AppCenter/Core (4.3.0)
   - AppCenter/Crashes (4.3.0):
     - AppCenter/Core
-  - Google-Mobile-Ads-SDK (8.10.0):
+  - Google-Mobile-Ads-SDK (8.12.0):
     - GoogleAppMeasurement (< 9.0, >= 7.0)
     - GoogleUserMessagingPlatform (>= 1.1)
-  - GoogleAppMeasurement (8.7.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.7.0)
+  - GoogleAppMeasurement (8.8.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.7.0):
+  - GoogleAppMeasurement/AdIdSupport (8.8.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.8.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
+    - GoogleUtilities/MethodSwizzler (~> 7.4)
+    - GoogleUtilities/Network (~> 7.4)
+    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.8.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
@@ -36,15 +43,15 @@ PODS:
   - "GoogleUtilities/NSData+zlib (7.5.2)"
   - GoogleUtilities/Reachability (7.5.2):
     - GoogleUtilities/Logger
-  - MiniApp/Admob8 (3.6.0):
+  - MiniApp/Admob8 (3.8.0):
     - Google-Mobile-Ads-SDK (~> 8.0)
     - MiniApp/Core
-  - MiniApp/Core (3.6.0):
+  - MiniApp/Core (3.8.0):
     - TrustKit (~> 2.0)
     - ZIPFoundation (= 0.9.12)
-  - MiniApp/Signature (3.6.0):
+  - MiniApp/Signature (3.8.0):
     - MiniApp/Core
-  - MiniApp/UI (3.6.0):
+  - MiniApp/UI (3.8.0):
     - MiniApp/Core
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
@@ -54,7 +61,7 @@ PODS:
   - Nimble (9.2.1)
   - PromisesObjC (2.0.0)
   - Quick (4.0.0)
-  - RAnalytics (8.2.1)
+  - RAnalytics (8.2.2)
   - TrustKit (2.0.0)
   - ZIPFoundation (0.9.12)
 
@@ -68,7 +75,9 @@ DEPENDENCIES:
   - RAnalytics
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/rakutentech/ios-analytics-framework.git:
+    - RAnalytics
+  trunk:
     - AppCenter
     - Google-Mobile-Ads-SDK
     - GoogleAppMeasurement
@@ -80,8 +89,6 @@ SPEC REPOS:
     - Quick
     - TrustKit
     - ZIPFoundation
-  https://github.com/rakutentech/ios-analytics-framework.git:
-    - RAnalytics
 
 EXTERNAL SOURCES:
   MiniApp:
@@ -89,16 +96,16 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
-  Google-Mobile-Ads-SDK: 9c78323a7069cd42ddf1ad2fddbaec889b085091
-  GoogleAppMeasurement: 2be61ce546ad074dbe4dd545f222ac6033bb1d9e
+  Google-Mobile-Ads-SDK: fb31b6ef68ef352b551ee29585cd9ceb07230cd0
+  GoogleAppMeasurement: 5ba1164e3c844ba84272555e916d0a6d3d977e91
   GoogleUserMessagingPlatform: ab890ce5f6620f293a21b6bdd82e416a2c73aeca
   GoogleUtilities: 8de2a97a17e15b6b98e38e8770e2d129a57c0040
-  MiniApp: a6b5b474d2bf8f9182afb079a98ba668e74108d8
+  MiniApp: 1920b9dee3b089628feff514a6bdc67cf5704cac
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  RAnalytics: ab09bc6648a4804e10a9524f8156e9a393b426fb
+  RAnalytics: babd40dd92d09d3a33ea031dd8ceeda57c5be471
   TrustKit: 610b8c71c07914756dd74c380040a3408a747798
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -111,6 +111,7 @@ Config.userDefaults?.set("MY_CUSTOM_ID", forKey: Config.Key.subscriptionKey.rawV
     * [Catching analytics events](#analytics-events)
     * [Passing Query parameters while creating Mini App](#query-param-mini-app)
     * [Permissions required from the Host app](#permissions-from-host-app)
+    * [MiniApp events](#miniapp-events)
 
 <a id="create-mini-app"></a>
 
@@ -894,6 +895,18 @@ Mini App SDK requires the host app to include the following set of device permis
 | [NSLocationAlwaysAndWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationalwaysandwheninuseusagedescription) |  Location  | Mini app to track/get the current location of the user |
 | [NSCameraUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nscamerausagedescription)                                         |   Camera   | Camera permission required by Mini app to take pictures                              |
 | [NSMicrophoneUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmicrophoneusagedescription)                                 | Microphone | Microphone permission required by Mini app to record a video.                             |
+
+<a id="miniapp-events"></a>
+
+### MiniApp events
+
+Mini App SDK allows MiniApps to react to several events triggered by host app. These include
+
+| Event | Reason |
+|-------|--------|
+| `pause` |  MiniApp view controller will disappear, MiniApp will open an external web view, host application will resign to be active |
+| `resume` | MiniApp view controller did appear, user closed a web view launched by MiniApp, host application did become active|
+| `externalWebViewClosed` | user closed a web view launched by MiniApp |
 
 <a id="faqs-and-troubleshooting"></a>
 


### PR DESCRIPTION
# Description

- Implemented custom event mechanism (for now: pause, resume and webview closed)
- Duplicates JS logs into Swift console for a better debugging (DEBUG mode)

pause/resume events partly rely on notification Center due to the variety of different reasons that lead a MiniApp to appear/disappear.

## Links
[MINI-1976](https://jira.rakuten-it.com/jira/browse/MINI-1976)

# Checklist
- [X] I have read the [contributing guidelines](CONTRIBUTING.md).
- [X] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
