### PR TITLE
[MINI-4334] - Sample app crash fix - Added Photos permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG
 
-### 3.8.0 (release date TBD)
+### 3.8.0 (2021-11-08)
 
 **SDK**
 
@@ -10,6 +10,7 @@
 **Sample app**
 
 - **Feature:** Added Dynamic deeplink support in the sample app.
+- **Feature:** Sample app changes to show support for download files via Mini app.
 
 ---
 ### 3.7.0 (2021-10-08)

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -50,6 +50,8 @@
 	<string>Demo app helps you find more information near you</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Needs Microphone while recording video</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Demo app needs permission to save photos</string>
 	<key>RASProjectId</key>
 	<string>$(RAS_PROJECT_IDENTIFIER)</string>
 	<key>RASProjectSubscriptionKey</key>


### PR DESCRIPTION
# Description
Demo app crashes when we try to save the image in Photos. Added permissions in Sample app to fix this issue.

# Links
MINI-4334

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
