### PR TITLE
Fix for mini app memory leak

### DIFF
--- a/Sources/Classes/core/Display/RealMiniAppView.swift
+++ b/Sources/Classes/core/Display/RealMiniAppView.swift
@@ -89,11 +89,11 @@ internal class RealMiniAppView: UIView {
     }
 
     fileprivate func initExternalWebViewClosures() {
-        onExternalWebviewResponse = { (url) in
-            self.webView.load(URLRequest(url: url))
+        onExternalWebviewResponse = { [weak self] (url) in
+            self?.webView.load(URLRequest(url: url))
         }
-        onExternalWebviewClose = { (url) in
-            self.didReceiveEvent(.externalWebViewClosed, message: url.absoluteString)
+        onExternalWebviewClose = { [weak self] (url) in
+            self?.didReceiveEvent(.externalWebViewClosed, message: url.absoluteString)
             NotificationCenter.default.sendCustomEvent(MiniAppEvent.Event(type: .resume, comment: "MiniApp close external webview"))
         }
     }
@@ -141,11 +141,11 @@ internal class RealMiniAppView: UIView {
     }
 
     func observeWebView() {
-        canGoBackObservation = webView.observe(\.canGoBack, options: .initial) { (webView, _) in
-            self.navigationDelegate?.miniAppNavigationCanGo(back: webView.canGoBack, forward: webView.canGoForward)
+        canGoBackObservation = webView.observe(\.canGoBack, options: .initial) { [weak self] (webView, _) in
+            self?.navigationDelegate?.miniAppNavigationCanGo(back: webView.canGoBack, forward: webView.canGoForward)
         }
-        canGoForwardObservation = webView.observe(\.canGoForward) { (webView, _) in
-            self.navigationDelegate?.miniAppNavigationCanGo(back: webView.canGoBack, forward: webView.canGoForward)
+        canGoForwardObservation = webView.observe(\.canGoForward) { [weak self] (webView, _) in
+            self?.navigationDelegate?.miniAppNavigationCanGo(back: webView.canGoBack, forward: webView.canGoForward)
         }
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(sendCustomEvent(notification:)),


### PR DESCRIPTION
# Description
* Even after the mini-app is closed, due to strong references of these closures, `RealMiniAppView` object is not removed from memory. Added weak references for the closures so that it gets deleted when `RealMiniAppView` is removed 

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
