### PR TITLE
Fix for Document generation failure

### DIFF
--- a/Sources/Classes/core/Downloader/MiniAppClient.swift
+++ b/Sources/Classes/core/Downloader/MiniAppClient.swift
@@ -273,7 +273,7 @@ internal class MiniAppClient: NSObject, URLSessionDownloadDelegate {
             }
         #else
             MiniAppAnalytics.sendAnalytics(event: .signatureFailure, miniAppId: ids?.0, miniAppVersion: ids?.1)
-            delegate?.fileDownloaded(at: location, downloadedURL: destinationURL)
+            delegate?.fileDownloaded(at: location, downloadedURL: originalURLString)
             cleanUpTmpFolder(tmpDirectory: ids?.0 ?? "")
         #endif
     }


### PR DESCRIPTION
# Description
Looks like the #else block is not getting compiled/executed and document generation failure happening because of this. Fixed them now

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
