### PR TITLE
Retrieve mini-app directly from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 **SDK**
 - **Feature:** Added support for Carthage
 - **Feature:** Changed deployment target from 13.0 to 14.0
-
+- **Feature:** Updated create method with optional `fromCache` variable that helps to load the mini-app from cache.
+`MiniApp#create(appId:versionId:queryParams:completionHandler:messageInterface:adsDisplayer:fromCache)`
+`MiniApp#create(appInfo:queryParams:completionHandler:messageInterface:adsDisplayer:fromCache)`
 
 **Sample app**
 - **Bugfix:** Added error message when name and email are invalid when adding contacts

--- a/Sources/Classes/core/Downloader/MiniAppDownloader.swift
+++ b/Sources/Classes/core/Downloader/MiniAppDownloader.swift
@@ -41,7 +41,6 @@ class MiniAppDownloader {
                 completionHandler(.success(miniAppStoragePath))
             } else {
                 MiniAppLogger.w("Cached Mini App did not pass the hash verification. The Mini App will be re-downloaded.")
-
                 cleanApp(appId, for: "")
                 download(appId: appId, versionId: versionId, completionHandler: completionHandler)
             }
@@ -133,6 +132,10 @@ class MiniAppDownloader {
         if urlToDirectoryMap.isEmpty {
             completionHandler(.success(miniAppPath))
         }
+    }
+
+    internal func isCacheSecure(appId: String, versionId: String) -> Bool {
+        return cacheVerifier.verify(appId: appId, version: versionId)
     }
 }
 

--- a/Sources/Classes/core/MASDKError.swift
+++ b/Sources/Classes/core/MASDKError.swift
@@ -43,6 +43,9 @@ public enum MASDKError: Error {
     /// ZIP archive signature has changed during download phase
     case invalidSignature
 
+    /// Error code to let the Host app know that Mini app is modified or corrupted after downloading
+    case miniAppCorrupted
+
     /// An unexpected error occurred.
     ///
     /// - Parameters:
@@ -90,6 +93,8 @@ extension MASDKError: LocalizedError {
             return MASDKLocale.localize(.failedToConformToProtocol)
         case .invalidContactId:
             return MASDKLocale.localize(.invalidContactId)
+        case .miniAppCorrupted:
+            return MASDKLocale.localize(.miniAppCorrupted)
 
         case .unknownError(let domain, let code, let description):
             return String(format: MASDKLocale.localize(.unknownError), domain, "\(code)", description)

--- a/Sources/Classes/core/MiniApp.swift
+++ b/Sources/Classes/core/MiniApp.swift
@@ -55,14 +55,21 @@ public class MiniApp: NSObject {
     ///         -   MASDKError: MASDKError details if Mini App View creating is failed
     ///   - messageInterface: Protocol implemented by the user that helps to communicate between Mini App and native application
     ///   - adsDisplayer: a MiniAppAdDisplayer that will handle Miniapp ads requests
-    public func create(appId: String, version: String? = nil, queryParams: String? = nil, completionHandler: @escaping (Result<MiniAppDisplayDelegate, MASDKError>) -> Void, messageInterface: MiniAppMessageDelegate, adsDisplayer: MiniAppAdDisplayer? = nil) {
+    public func create(appId: String,
+                       version: String? = nil,
+                       queryParams: String? = nil,
+                       completionHandler: @escaping (Result<MiniAppDisplayDelegate, MASDKError>) -> Void,
+                       messageInterface: MiniAppMessageDelegate,
+                       adsDisplayer: MiniAppAdDisplayer? = nil,
+                       fromCache: Bool? = false) {
         return realMiniApp.createMiniApp(
-                appId: appId,
-                version: version,
-                queryParams: queryParams,
-                completionHandler: completionHandler,
-                messageInterface: messageInterface,
-                adsDisplayer: adsDisplayer)
+            appId: appId,
+            version: version,
+            queryParams: queryParams,
+            completionHandler: completionHandler,
+            messageInterface: messageInterface,
+            adsDisplayer: adsDisplayer,
+            fromCache: fromCache)
     }
 
     /// Cache the Custom permissions status for a given MiniApp ID
@@ -101,13 +108,19 @@ public class MiniApp: NSObject {
     ///         -   MASDKError: MASDKError details if Mini App View creating is failed
     ///   - messageInterface: Protocol implemented by the user that helps to communicate between Mini App and native application
     ///   - adsDisplayer: a MiniAppAdDisplayer that will handle Miniapp ads requests
-    public func create(appInfo: MiniAppInfo, queryParams: String? = nil, completionHandler: @escaping (Result<MiniAppDisplayDelegate, MASDKError>) -> Void, messageInterface: MiniAppMessageDelegate, adsDisplayer: MiniAppAdDisplayer? = nil) {
+    public func create(appInfo: MiniAppInfo,
+                       queryParams: String? = nil,
+                       completionHandler: @escaping (Result<MiniAppDisplayDelegate, MASDKError>) -> Void,
+                       messageInterface: MiniAppMessageDelegate,
+                       adsDisplayer: MiniAppAdDisplayer? = nil,
+                       fromCache: Bool? = false) {
         return realMiniApp.createMiniApp(
-                appInfo: appInfo,
-                queryParams: queryParams,
-                completionHandler: completionHandler,
-                messageInterface: messageInterface,
-                adsDisplayer: adsDisplayer)
+            appInfo: appInfo,
+            queryParams: queryParams,
+            completionHandler: completionHandler,
+            messageInterface: messageInterface,
+            adsDisplayer: adsDisplayer,
+            fromCache: fromCache)
     }
 
     /// Method to return the meta-data information of a mini-app

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 internal class RealMiniApp {
     var miniAppInfoFetcher: MiniAppInfoFetcher
     var metaDataDownloader: MetaDataDownloader
@@ -61,33 +62,45 @@ internal class RealMiniApp {
                        queryParams: String? = nil,
                        completionHandler: @escaping (Result<MiniAppDisplayDelegate, MASDKError>) -> Void,
                        messageInterface: MiniAppMessageDelegate? = nil,
-                       adsDisplayer: MiniAppAdDisplayer? = nil) {
-        getMiniApp(miniAppId: appInfo.id, miniAppVersion: appInfo.version.versionId) { (result) in
-            switch result {
-            case .success(let responseData):
-                if appInfo.version.versionId != responseData.version.versionId {
+                       adsDisplayer: MiniAppAdDisplayer? = nil,
+                       fromCache: Bool? = false) {
+        if fromCache ?? false {
+            getCachedMiniApp(appId: appInfo.id,
+                             version: appInfo.version.versionId,
+                             queryParams: queryParams,
+                             completionHandler: completionHandler,
+                             messageInterface: messageInterface,
+                             adsDisplayer: adsDisplayer)
+        } else {
+            getMiniApp(miniAppId: appInfo.id, miniAppVersion: appInfo.version.versionId) { (result) in
+                switch result {
+                case .success(let responseData):
+                    if appInfo.version.versionId != responseData.version.versionId {
+                        self.downloadMiniApp(
+                                appInfo: responseData,
+                                queryParams: queryParams,
+                                completionHandler: completionHandler,
+                                messageInterface: messageInterface,
+                                adsDisplayer: adsDisplayer)
+                        return
+                    }
                     self.downloadMiniApp(
-                            appInfo: responseData,
+                            appInfo: appInfo,
+                            queryParams: queryParams,
+                            completionHandler: completionHandler,
+                            messageInterface: messageInterface)
+                case .failure(let error):
+                    self.handleMiniAppDownloadError(
+                            appId: appInfo.id,
+                            error: error,
                             queryParams: queryParams,
                             completionHandler: completionHandler,
                             messageInterface: messageInterface,
                             adsDisplayer: adsDisplayer)
-                    return
                 }
-                self.downloadMiniApp(
-                        appInfo: appInfo,
-                        queryParams: queryParams,
-                        completionHandler: completionHandler,
-                        messageInterface: messageInterface)
-            case .failure(let error):
-                self.handleMiniAppDownloadError(
-                        appId: appInfo.id,
-                        error: error,
-                        queryParams: queryParams,
-                        completionHandler: completionHandler,
-                        messageInterface: messageInterface,
-                        adsDisplayer: adsDisplayer)
-            } }
+            }
+        }
+
     }
 
     func createMiniApp(appId: String,
@@ -95,27 +108,39 @@ internal class RealMiniApp {
                        queryParams: String? = nil,
                        completionHandler: @escaping (Result<MiniAppDisplayDelegate, MASDKError>) -> Void,
                        messageInterface: MiniAppMessageDelegate? = nil,
-                       adsDisplayer: MiniAppAdDisplayer? = nil) {
+                       adsDisplayer: MiniAppAdDisplayer? = nil,
+                       fromCache: Bool? = false) {
         if appId.isEmpty {
             return completionHandler(.failure(.invalidAppId))
         }
-        getMiniApp(miniAppId: appId, miniAppVersion: version) { (result) in
-            switch result {
-            case .success(let responseData):
-                self.miniAppStatus.saveMiniAppInfo(appInfo: responseData, key: responseData.id)
-                self.downloadMiniApp(appInfo: responseData,
+        if fromCache ?? false {
+            getCachedMiniApp(appId: appId,
+                             version: version ?? "",
+                             queryParams: queryParams,
+                             completionHandler: completionHandler,
+                             messageInterface: messageInterface,
+                             adsDisplayer: adsDisplayer)
+        } else {
+            getMiniApp(miniAppId: appId, miniAppVersion: version) { (result) in
+                switch result {
+                case .success(let responseData):
+                    self.miniAppStatus.saveMiniAppInfo(appInfo: responseData, key: responseData.id)
+                    self.downloadMiniApp(appInfo: responseData,
+                                         queryParams: queryParams,
+                                         completionHandler: completionHandler,
+                                         messageInterface: messageInterface,
+                                         adsDisplayer: adsDisplayer)
+                case .failure(let error):
+                    self.handleMiniAppDownloadError(appId: appId,
+                                     error: error,
                                      queryParams: queryParams,
                                      completionHandler: completionHandler,
                                      messageInterface: messageInterface,
                                      adsDisplayer: adsDisplayer)
-            case .failure(let error):
-                self.handleMiniAppDownloadError(appId: appId,
-                                 error: error,
-                                 queryParams: queryParams,
-                                 completionHandler: completionHandler,
-                                 messageInterface: messageInterface,
-                                 adsDisplayer: adsDisplayer)
-            } }
+                }
+            }
+        }
+
     }
 
     func createMiniApp(url: URL, queryParams: String? = nil, errorHandler: @escaping (MASDKError) -> Void, messageInterface: MiniAppMessageDelegate? = nil, adsDisplayer: MiniAppAdDisplayer? = nil) -> MiniAppDisplayDelegate {
@@ -360,6 +385,35 @@ internal class RealMiniApp {
 
     func getMiniAppPreviewInfo(using token: String, completionHandler: @escaping (Result<PreviewMiniAppInfo, MASDKError>) -> Void) {
         previewMiniAppInfoFetcher.fetchPreviewMiniAppInfo(apiClient: miniAppClient, using: token, completionHandler: completionHandler)
+    }
+
+    func getCachedMiniApp(appId: String,
+                          version: String,
+                          queryParams: String? = nil,
+                          completionHandler: @escaping (Result<MiniAppDisplayDelegate, MASDKError>) -> Void,
+                          messageInterface: MiniAppMessageDelegate? = nil,
+                          adsDisplayer: MiniAppAdDisplayer? = nil) {
+        if appId.isEmpty {
+            return completionHandler(.failure(.invalidAppId))
+        }
+        if version.isEmpty {
+            return completionHandler(.failure(.invalidVersionId))
+        }
+        if miniAppDownloader.isCacheSecure(appId: appId, versionId: version) {
+            /// Retrieving Cached Manifest Data to get the display name
+            let miniAppInfo = self.miniAppStatus.getMiniAppInfo(appId: appId)
+            verifyUserHasAgreedToManifest(miniAppId: appId,
+                                          versionId: version,
+                                          projectId: self.miniAppClient.environment.projectId,
+                                          miniAppTitle: miniAppInfo?.displayName ?? "Mini app",
+                                          queryParams: queryParams,
+                                          hostAppMessageDelegate: messageInterface ?? self,
+                                          adsDisplayer: adsDisplayer,
+                                          analyticsConfig: self.miniAppAnalyticsConfig,
+                                          completionHandler: completionHandler)
+        } else {
+            completionHandler(.failure(.miniAppCorrupted))
+        }
     }
 }
 

--- a/Sources/Classes/core/Utilities/MASDKLocale.swift
+++ b/Sources/Classes/core/Utilities/MASDKLocale.swift
@@ -21,6 +21,7 @@ public struct MASDKLocale {
         case invalidResponse                        = "miniapp.sdk.ios.error.message.invalid_response"
         case downloadFailed                         = "miniapp.sdk.ios.error.message.download_failed"
         case signatureFailed                        = "miniapp.sdk.ios.error.message.signature_failed"
+        case miniAppCorrupted                       = "miniapp.sdk.ios.error.message.miniapp_corrupted"
         case noPublishedVersion                     = "miniapp.sdk.ios.error.message.no_published_version"
         case miniappIdNotFound                      = "miniapp.sdk.ios.error.message.miniapp_id_not_found"
         case metaDataRequiredPermissionsFailure     = "miniapp.sdk.ios.error.message.miniapp_meta_data_required_permissions_failure"

--- a/Sources/en.lproj/Localizable.strings
+++ b/Sources/en.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "miniapp.sdk.ios.error.message.failed_to_conform_to_protocol"   = "Host app failed to implement required interface";
 "miniapp.sdk.ios.error.message.no_published_version"            = "Server returned no published versions for the provided Mini App ID.";
 "miniapp.sdk.ios.error.message.miniapp_id_not_found"            = "Server could not find the provided Mini App ID.";
+"miniapp.sdk.ios.error.message.miniapp_corrupted"               = "Mini app is not downloaded properly or corrupted";
 
 /* MASDKUI */
 "miniapp.sdk.ios.ui.nav.button.close"                           = "Close";

--- a/Sources/ja.lproj/Localizable.strings
+++ b/Sources/ja.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "miniapp.sdk.ios.error.message.failed_to_conform_to_protocol"   = "Host app failed to implement required interface";
 "miniapp.sdk.ios.error.message.no_published_version"            = "Server returned no published versions for the provided Mini App ID.";
 "miniapp.sdk.ios.error.message.miniapp_id_not_found"            = "Server could not find the provided Mini App ID.";
+"miniapp.sdk.ios.error.message.miniapp_corrupted"               = "Mini app is not downloaded properly or corrupted";
 
 /* MASDKUI */
 "miniapp.sdk.ios.ui.nav.button.close"                           = "Close";

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -483,6 +483,151 @@ class RealMiniAppTests: QuickSpec {
                     expect(testError?.errorDescription).toEventually(equal(MASDKError.invalidURLError.errorDescription), timeout: .seconds(2))
                 }
             }
+
+            context("when mini-app is requested from cache") {
+                it("will check the app-id is not empty") {
+                    var testError: MASDKError?
+
+                    MiniApp.shared().create(appId: "",
+                                            version: "",
+                                            queryParams: nil, completionHandler: { (result) in
+                        switch result {
+                        case .success:
+                            break
+                        case .failure(let error):
+                            testError = error
+                        }
+                    }, messageInterface: mockMessageInterface, adsDisplayer: nil, fromCache: true)
+                    expect(testError?.errorDescription).toEventually(equal(MASDKError.invalidAppId.errorDescription), timeout: .seconds(2))
+                }
+                it("will check the version is not empty") {
+                    var testError: MASDKError?
+
+                    MiniApp.shared().create(appId: mockMiniAppInfo.id,
+                                            version: "",
+                                            queryParams: nil, completionHandler: { (result) in
+                        switch result {
+                        case .success:
+                            break
+                        case .failure(let error):
+                            testError = error
+                        }
+                    }, messageInterface: mockMessageInterface, adsDisplayer: nil, fromCache: true)
+                    expect(testError?.errorDescription).toEventually(equal(MASDKError.invalidVersionId.errorDescription), timeout: .seconds(2))
+                }
+                it("will check the app-id and version is not empty, also if mini app is downloaded already") {
+                    var testError: MASDKError?
+
+                    MiniApp.shared().create(appId: mockMiniAppInfo.id,
+                                            version: mockMiniAppInfo.version.versionId,
+                                            queryParams: nil, completionHandler: { (result) in
+                        switch result {
+                        case .success:
+                            break
+                        case .failure(let error):
+                            testError = error
+                        }
+                    }, messageInterface: mockMessageInterface, adsDisplayer: nil, fromCache: true)
+                    expect(testError?.errorDescription).toEventually(equal(MASDKError.miniAppCorrupted.errorDescription), timeout: .seconds(2))
+                }
+                it("download a mini app first and try to return the cached version using app id and version id") {
+                    let responseString = """
+                    [{
+                        "id": "\(mockMiniAppInfo.id)",
+                        "displayName": "Test",
+                        "icon": "https://test.com",
+                        "version": {
+                            "versionTag": "1.0.0",
+                            "versionId": "\(mockMiniAppInfo.version.versionId)",
+                        }
+                      }]
+                    """
+                    let manifestResponse = """
+                      {
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                      }
+                    """
+                    mockAPIClient.data = responseString.data(using: .utf8)
+                    mockAPIClient.metaData = mockMetaDataString.data(using: .utf8)
+                    mockAPIClient.manifestData = manifestResponse.data(using: .utf8)
+                    realMiniApp.storeCustomPermissions(forMiniApp: mockMiniAppInfo.id,
+                                                       permissionList: [MASDKCustomPermissionModel(permissionName: .userName,
+                                                                                                   isPermissionGranted: .allowed,
+                                                                                                   permissionRequestDescription: ""),
+                                                                        MASDKCustomPermissionModel(permissionName: .profilePhoto,
+                                                                                                   isPermissionGranted: .allowed,
+                                                                                                   permissionRequestDescription: "")])
+                    var responseData: RealMiniAppView?
+                    realMiniApp.createMiniApp(appInfo: mockMiniAppInfo, completionHandler: { (result) in
+                        switch result {
+                        case .success(let response):
+                            responseData = response as? RealMiniAppView
+                        case .failure:
+                            fail("create MiniApp failure")
+                        }
+                    }, fromCache: false)
+                    expect(responseData).toEventually(beAnInstanceOf(RealMiniAppView.self), timeout: .seconds(10))
+                    var testResponseData: MiniAppDisplayDelegate?
+                    realMiniApp.createMiniApp(appId: mockMiniAppInfo.id,
+                                              version: mockMiniAppInfo.version.versionId, completionHandler: { (result) in
+                        switch result {
+                        case .success(let responseData):
+                            testResponseData = responseData
+                        case .failure:
+                            fail("create MiniApp failure")
+                        }
+                    }, messageInterface: mockMessageInterface, fromCache: true)
+                    expect(testResponseData).toEventually(beAnInstanceOf(RealMiniAppView.self), timeout: .seconds(10))
+                }
+                it("download a mini app first and try to return the cached version using app info") {
+                    let responseString = """
+                    [{
+                        "id": "\(mockMiniAppInfo.id)",
+                        "displayName": "Test",
+                        "icon": "https://test.com",
+                        "version": {
+                            "versionTag": "1.0.0",
+                            "versionId": "\(mockMiniAppInfo.version.versionId)",
+                        }
+                      }]
+                    """
+                    let manifestResponse = """
+                      {
+                        "manifest": ["\(mockHost)/map-published-v2/min-abc/ver-abc/HelloWorld.txt"]
+                      }
+                    """
+                    mockAPIClient.data = responseString.data(using: .utf8)
+                    mockAPIClient.metaData = mockMetaDataString.data(using: .utf8)
+                    mockAPIClient.manifestData = manifestResponse.data(using: .utf8)
+                    realMiniApp.storeCustomPermissions(forMiniApp: mockMiniAppInfo.id,
+                                                       permissionList: [MASDKCustomPermissionModel(permissionName: .userName,
+                                                                                                   isPermissionGranted: .allowed,
+                                                                                                   permissionRequestDescription: ""),
+                                                                        MASDKCustomPermissionModel(permissionName: .profilePhoto,
+                                                                                                   isPermissionGranted: .allowed,
+                                                                                                   permissionRequestDescription: "")])
+                    var responseData: RealMiniAppView?
+                    realMiniApp.createMiniApp(appInfo: mockMiniAppInfo, completionHandler: { (result) in
+                        switch result {
+                        case .success(let response):
+                            responseData = response as? RealMiniAppView
+                        case .failure:
+                            fail("create MiniApp failure")
+                        }
+                    }, fromCache: false)
+                    expect(responseData).toEventually(beAnInstanceOf(RealMiniAppView.self), timeout: .seconds(10))
+                    var testResponseData: MiniAppDisplayDelegate?
+                    realMiniApp.createMiniApp(appInfo: mockMiniAppInfo, completionHandler: { (result) in
+                        switch result {
+                        case .success(let responseData):
+                            testResponseData = responseData
+                        case .failure:
+                            fail("create MiniApp failure")
+                        }
+                    }, messageInterface: mockMessageInterface, fromCache: true)
+                    expect(testResponseData).toEventually(beAnInstanceOf(RealMiniAppView.self), timeout: .seconds(10))
+                }
+            }
         }
     }
 }

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -128,6 +128,7 @@ Config.userDefaults?.set("MY_CUSTOM_ID", forKey: Config.Key.subscriptionKey.rawV
     * [Passing Query parameters while creating Mini App](#query-param-mini-app)
     * [Permissions required from the Host app](#permissions-from-host-app)
     * [MiniApp events](#miniapp-events)
+    * [Load Mini app from Cache](#miniapp-load-cache)
 
 <a id="create-mini-app"></a>
 
@@ -935,6 +936,27 @@ Mini App SDK allows MiniApps to react to several events triggered by host app. T
 | `pause` |  MiniApp view controller will disappear, MiniApp will open an external web view, host application will resign to be active |
 | `resume` | MiniApp view controller did appear, user closed a web view launched by MiniApp, host application did become active|
 | `externalWebViewClosed` | user closed a web view launched by MiniApp |
+
+### Load Mini app from Cache
+
+Load Mini-app from cache directly using the following approach,
+
+```swift
+MiniApp.shared().create(appId: String, completionHandler: { (result) in
+	switch result {
+            case .success(let miniAppDisplay):
+                let view = miniAppDisplay.getMiniAppView()
+                view.frame = self.view.bounds
+                self.view.addSubview(view)
+            case .failure(let error):
+                print("Error: ", error.localizedDescription)
+            }
+}, messageInterface: self, fromCache: true)
+
+```
+
+`fromCache` helps to retrieve the already downloaded mini-app from the cache.
+NOTE: Using the above approach will never retrieve/query latest version of the mini-app.
 
 <a id="faqs-and-troubleshooting"></a>
 


### PR DESCRIPTION
# Description
* Retrieve mini-app from cache directly using `fromCache` variable.
  * Offline support is enable already, however SDK is trying to fetch the info of a mini-app when `create()` is called. This change would provide an option to the Host app to directly fetch the mini-app from cache.

## Links
[MINI-4777](https://jira.rakuten-it.com/jira/browse/MINI-4777)

# Checklist
- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
