### PR TITLE
[NO-TICKET] Crash fix for file download on iOS 14

### DIFF
--- a/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
@@ -73,21 +73,21 @@ extension ViewController: MiniAppUserInfoDelegate {
         }
         download(url: url, headers: headers) { [weak self] result in
             guard let self = self else { return }
-            switch result {
-            case .success(let data):
-                guard
-                    let savedUrl = self.saveTemporaryFile(data: data, resourceName: fileName, fileExtension: fileExtension)
-                else {
-                    completionHandler(.failure(MASDKDownloadFileError.saveTemporarilyFailed))
-                    return
-                }
-                let activityVc = UIActivityViewController(activityItems: [savedUrl], applicationActivities: nil)
-                DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let data):
+                    guard
+                        let savedUrl = self.saveTemporaryFile(data: data, resourceName: fileName, fileExtension: fileExtension)
+                    else {
+                        completionHandler(.failure(MASDKDownloadFileError.saveTemporarilyFailed))
+                        return
+                    }
+                    let activityVc = UIActivityViewController(activityItems: [savedUrl], applicationActivities: nil)
                     self.presentedViewController?.present(activityVc, animated: true, completion: nil)
+                    completionHandler(.success(fileName))
+                case .failure(let error):
+                    completionHandler(.failure(error))
                 }
-                completionHandler(.success(fileName))
-            case .failure(let error):
-                completionHandler(.failure(error))
             }
         }
     }


### PR DESCRIPTION
# Description
The response to the js sdk caused the app on iOS 14 to crash so putting in on the main thread will fix it

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
