### PR TITLE
Add base64 data download support and update error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 **SDK**
 - **Feature:** Added a new interface `getMessagingUnique` in `MiniAppMessageDelegate` for future support of MAUID v2 and another interface `getMauid` in `MiniAppMessageDelegate` for retrieving the MAUID
+- **Feature:** Added file download error type for HTTP errors: `MASDKDownloadFileError.downloadHttpError`.
+- **Fix:** Updated error type names for `MASDKDownloadFileError` so that they are correctly parsed by JS SDK.
 
 **Sample app**
 - **Enhancement:** Added `GET MESSAGING UNIQUE ID` and `GET MAUID` for retrieving the ID's. (Messaging Unique ID for now will return the same as Unique ID)
+- **Feature:** Added support for Mini Apps to download Base64 `data:` URIs with the `MiniApp.downloadFile` feature.
 
 ### 4.1.0 (2022-04-11)
 

--- a/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
@@ -110,7 +110,8 @@ extension ViewController: MiniAppUserInfoDelegate {
             guard
                 statusCode >= 200 && statusCode <= 300
             else {
-                completion?(.failure(MASDKDownloadFileError.downloadFailed(code: statusCode, reason: "download failed")))
+                let reason = HTTPURLResponse.localizedString(forStatusCode: statusCode)
+                completion?(.failure(MASDKDownloadFileError.downloadHttpError(code: statusCode, reason: reason)))
                 return
             }
             guard

--- a/Example/Utils/Base64UriHelper.swift
+++ b/Example/Utils/Base64UriHelper.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+class Base64UriHelper {
+    /// regex splits the string into 4 groups (whole match, 1st group "image" / "application", 2nd group "jpg", "zip" etc, meta data
+    static let base64CapturePattern = #"^data:([a-z0-9\.\-\+]+)\/([a-z0-9\,\.\-\+]+);([\s]?[\S]*;)?base64,"#
+
+    static func isBase64String(text: String) -> Bool {
+        let capturePattern = base64CapturePattern
+        guard
+            let captureRegex = try? NSRegularExpression(
+                pattern: capturePattern,
+                options: []
+            )
+        else { return false }
+        let textRange = NSRange(
+            text.startIndex..<text.endIndex,
+            in: text
+        )
+        return captureRegex.firstMatch(in: text, options: [], range: textRange) != nil
+    }
+
+    static func decodeBase64String(text: String) -> Data? {
+        let capturePattern = base64CapturePattern
+        guard
+            let captureRegex = try? NSRegularExpression(
+                pattern: capturePattern,
+                options: []
+            )
+        else { return nil }
+
+        let textRange = NSRange(
+            text.startIndex..<text.endIndex,
+            in: text
+        )
+
+        if let match = captureRegex.firstMatch(in: text, options: [], range: textRange) {
+            guard match.numberOfRanges >= 3 else { return nil }
+
+            let base64String = removeBase64Header(text: text, range: match.range(at: 0))
+            guard
+                let baseData = base64String.data(using: .utf8),
+                let baseEncodedData = Data(base64Encoded: baseData, options: .ignoreUnknownCharacters)
+            else { return nil }
+
+            return baseEncodedData
+        } else { return nil }
+    }
+
+    static func removeBase64Header(text: String, range: NSRange? = nil) -> String {
+        if let objcRange = range, let swiftRange = Range(objcRange, in: text) {
+            var base64Text = text
+            base64Text.removeSubrange(swiftRange)
+            return base64Text
+        } else { // fallback method if something is wrong with the range
+            return text.replacingOccurrences(of: base64CapturePattern, with: "", options: .regularExpression)
+        }
+    }
+}

--- a/Sample.xcodeproj/project.pbxproj
+++ b/Sample.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		A13C249826A15048003ADC6D /* UserPointsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13C249726A15048003ADC6D /* UserPointsModel.swift */; };
 		A1FDEAC026A141CC00E48831 /* PointsSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FDEABF26A141CC00E48831 /* PointsSettingsTableViewController.swift */; };
 		D07452312567B72A00B6E842 /* MASDKErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07452302567B72A00B6E842 /* MASDKErrorTests.swift */; };
+		D0CACE26281A68D700E39920 /* Base64UriHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CACE25281A68D700E39920 /* Base64UriHelper.swift */; };
 		F7C8804626D8974800B828C6 /* UITableView+EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7C8804526D8974800B828C6 /* UITableView+EmptyView.swift */; };
 /* End PBXBuildFile section */
 
@@ -249,6 +250,7 @@
 		A1FDEABF26A141CC00E48831 /* PointsSettingsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointsSettingsTableViewController.swift; sourceTree = "<group>"; };
 		A78AF8E4D879DF8FC03A7E9F /* MiniApp.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = MiniApp.podspec; sourceTree = "<group>"; };
 		D07452302567B72A00B6E842 /* MASDKErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MASDKErrorTests.swift; sourceTree = "<group>"; };
+		D0CACE25281A68D700E39920 /* Base64UriHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64UriHelper.swift; sourceTree = "<group>"; };
 		D85784C7998D04CE64578236 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		F7C8804526D8974800B828C6 /* UITableView+EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+EmptyView.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -418,6 +420,7 @@
 				31850BC0269837F300CFE422 /* UIColor+MiniApp.swift */,
 				2AE218EF269D46DA00F9D1E7 /* UITextView+MiniApp.swift */,
 				F7C8804526D8974800B828C6 /* UITableView+EmptyView.swift */,
+				D0CACE25281A68D700E39920 /* Base64UriHelper.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -787,6 +790,7 @@
 				2AA894BA26D6895F0078B2F4 /* RATNotificationCenter.swift in Sources */,
 				2A54C85C26676377002B204F /* UITextField.swift in Sources */,
 				3878D4D423B44F85001E27F8 /* AppDelegate.swift in Sources */,
+				D0CACE26281A68D700E39920 /* Base64UriHelper.swift in Sources */,
 				31CC3B4626DF97F200441154 /* SignatureSettingsTableViewController.swift in Sources */,
 				38920B05251D9C57004C5DDD /* SettingsTableViewController.swift in Sources */,
 				38920AF4251D9C57004C5DDD /* String+MiniApp.swift in Sources */,

--- a/Sources/Classes/core/JavascriptBridge/MAJavascriptErrorHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MAJavascriptErrorHandler.swift
@@ -30,3 +30,7 @@ func prepareMAJavascriptError<T: MiniAppErrorProtocol>(_ error: T) -> String {
 func prepareMAJSGeolocationError(error: MAJSNaviGeolocationError) -> String {
     return prepareJSONString(MAJSLocationErrorResponseModel(code: error.code, message: error.message))
 }
+
+func prepareMAJSDownloadFileError(error: MASDKDownloadFileError) -> String {
+    return prepareJSONString(MAJSDownloadFileErrorResponseModel(type: error.name, message: error.description, code: error.code))
+}

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -579,7 +579,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     self.executeJavaScriptCallback(
                         responseStatus: .onError,
                         messageId: callbackId,
-                        response: prepareMAJavascriptError(error)
+                        response: prepareMAJSDownloadFileError(error: error)
                     )
                 }
             }

--- a/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
@@ -8,6 +8,12 @@ internal struct MAJSLocationErrorResponseModel: Codable {
     var message: String?
 }
 
+internal struct MAJSDownloadFileErrorResponseModel: Codable {
+    var type: String
+    var message: String
+    var code: Int?
+}
+
 enum MiniAppErrorType: String, Codable, MiniAppErrorProtocol {
     case hostAppError
     case unknownError
@@ -236,13 +242,14 @@ enum MAJSNaviGeolocationError: Error {
 }
 
 /// Enumeration that is used to return DownloadFile error
-public enum MASDKDownloadFileError: Error, MiniAppErrorProtocol {
+public enum MASDKDownloadFileError: Error {
 
     /// Host app failed to implement required interface
     ///
     case failedToConformToProtocol
     case invalidUrl
     case downloadFailed(code: Int?, reason: String)
+    case downloadHttpError(code: Int, reason: String)
     case saveTemporarilyFailed
     case error(description: String)
 
@@ -253,12 +260,26 @@ public enum MASDKDownloadFileError: Error, MiniAppErrorProtocol {
             return MASDKLocale.localize(.failedToConformToProtocol)
         case .invalidUrl:
             return MASDKLocale.localize(.invalidUrl)
-        case .downloadFailed(let code, let reason):
-            return "\(code ?? -1): \(reason); (\(MASDKLocale.localize(.downloadFailed))"
+        case .downloadFailed(_, let reason):
+            return  "\(reason); \(MASDKLocale.localize(.downloadFailed))"
+        case .downloadHttpError(_, let reason):
+            return "\(reason); \(MASDKLocale.localize(.downloadFailed))"
         case .saveTemporarilyFailed:
             return MASDKLocale.localize(.unknownError)
         case .error(let description):
             return description
+        }
+    }
+
+    /// Status code in the case of HTTP error
+    public var code: Int? {
+        switch self {
+        case .downloadFailed(let code, _):
+            return code
+        case .downloadHttpError(let code, _):
+            return code
+        default:
+            return nil
         }
     }
 
@@ -268,11 +289,13 @@ public enum MASDKDownloadFileError: Error, MiniAppErrorProtocol {
         case .failedToConformToProtocol:
             return "FailedToConformToProtocol"
         case .invalidUrl:
-            return "InvalidUrl"
+            return "InvalidUrlError"
         case .downloadFailed:
-            return "DownloadFailed"
+            return "DownloadFailedError"
+        case .downloadHttpError:
+            return "DownloadHttpError"
         case .saveTemporarilyFailed:
-            return "SaveTemporarilyFailed"
+            return "SaveFailureError"
         case .error:
             return ""
         }


### PR DESCRIPTION
# Description
Added support for `data:` URIs to the Download File feature. Also updated the Download File error types to match the parsing which is on the JS side.

## Links
MINI-4980

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
