### PR TITLE
Replace MessageDelegate `getSecureStorageSizeLimit` with MiniAppSDKConfig property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Feature:** Added a new interface `getMessagingUnique` in `MiniAppMessageDelegate` for future support of MAUID v2 and another interface `getMauid` in `MiniAppMessageDelegate` for retrieving the MAUID
 - **Feature:** Added file download error type for HTTP errors: `MASDKDownloadFileError.downloadHttpError`.
 - **Fix:** Updated error type names for `MASDKDownloadFileError` so that they are correctly parsed by JS SDK.
-- **Feature:** Added `MiniAppSecureStorage` for MiniApps to store data safely. `MiniAppMessageDelegate` was extended by `getSecureStorageSizeLimit` to define the maximum space in bytes for the secure storage to operate in.
+- **Feature:** Added `MiniAppSecureStorage` for MiniApps to store data safely. `MiniAppSdkConfig` was extended by `storageMaxSizeInBytes` to set the maximum available space in bytes for secure storage.
 
 **Sample app**
 - **Enhancement:** Added `GET MESSAGING UNIQUE ID` and `GET MAUID` for retrieving the ID's. (Messaging Unique ID for now will return the same as Unique ID)

--- a/Example/Controllers/Extensions/ViewController+MiniAppMessageProtocol.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniAppMessageProtocol.swift
@@ -76,8 +76,4 @@ extension ViewController: MiniAppMessageDelegate, CLLocationManagerDelegate {
         let info = MAHostEnvironmentInfo(hostLocale: locale)
         return { return info }
     }
-
-    func getSecureStorageSizeLimit(completionHandler: @escaping (Result<UInt64, MASDKError>) -> Void) {
-        completionHandler(.success(27_000_000))
-    }
 }

--- a/Example/Utils/Config.swift
+++ b/Example/Utils/Config.swift
@@ -47,7 +47,8 @@ class Config: NSObject {
             isPreviewMode: Config.userDefaults?.value(forKey: Config.Key.isPreviewMode.rawValue) as? Bool,
             analyticsConfigList: [MAAnalyticsConfig(acc: "477", aid: "998")],
             requireMiniAppSignatureVerification: Config.userDefaults?.value(forKey: Config.Key.requireMiniAppSignatureVerification.rawValue) as? Bool,
-            sslKeyHash: pinConf
+            sslKeyHash: pinConf,
+            storageMaxSizeInBytes: 5_000_000
         )
     }
 

--- a/Sources/Classes/core/Display/Displayer.swift
+++ b/Sources/Classes/core/Display/Displayer.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 internal class Displayer {
-    var settings: MiniAppSdkConfig?
+    var sdkConfig: MiniAppSdkConfig?
     var navConfig: MiniAppNavigationConfig?
 
-    init(_ settings: MiniAppSdkConfig? = nil, _ config: MiniAppNavigationConfig? = nil) {
-        self.settings = settings
-        self.navConfig = config
+    init(_ sdkConfig: MiniAppSdkConfig? = nil, _ navConfig: MiniAppNavigationConfig? = nil) {
+        self.sdkConfig = sdkConfig
+        self.navConfig = navConfig
     }
 
     func getMiniAppView(miniAppId: String,
@@ -29,7 +29,7 @@ internal class Displayer {
           navigationDelegate: navConfig?.navigationDelegate,
           navigationView: navConfig?.navigationView,
           analyticsConfig: analyticsConfig,
-          storageMaxSizeInBytes: settings?.storageMaxSizeInBytes
+          storageMaxSizeInBytes: sdkConfig?.storageMaxSizeInBytes
         )
     }
 
@@ -51,7 +51,7 @@ internal class Displayer {
             navigationDelegate: navConfig?.navigationDelegate,
             navigationView: navConfig?.navigationView,
             analyticsConfig: analyticsConfig,
-            storageMaxSizeInBytes: settings?.storageMaxSizeInBytes
+            storageMaxSizeInBytes: sdkConfig?.storageMaxSizeInBytes
         )
     }
 }

--- a/Sources/Classes/core/Display/Displayer.swift
+++ b/Sources/Classes/core/Display/Displayer.swift
@@ -4,7 +4,7 @@ internal class Displayer {
     var settings: MiniAppSdkConfig?
     var navConfig: MiniAppNavigationConfig?
 
-    init(_ settings: MiniAppSdkConfig?, _ config: MiniAppNavigationConfig? = nil) {
+    init(_ settings: MiniAppSdkConfig? = nil, _ config: MiniAppNavigationConfig? = nil) {
         self.settings = settings
         self.navConfig = config
     }

--- a/Sources/Classes/core/Display/Displayer.swift
+++ b/Sources/Classes/core/Display/Displayer.swift
@@ -1,9 +1,11 @@
 import Foundation
 
 internal class Displayer {
+    var settings: MiniAppSdkConfig?
     var navConfig: MiniAppNavigationConfig?
 
-    init(_ config: MiniAppNavigationConfig? = nil) {
+    init(_ settings: MiniAppSdkConfig?, _ config: MiniAppNavigationConfig? = nil) {
+        self.settings = settings
         self.navConfig = config
     }
 
@@ -26,7 +28,9 @@ internal class Displayer {
           displayNavBar: navConfig?.navigationBarVisibility ?? .never,
           navigationDelegate: navConfig?.navigationDelegate,
           navigationView: navConfig?.navigationView,
-            analyticsConfig: analyticsConfig)
+          analyticsConfig: analyticsConfig,
+          storageMaxSizeInBytes: settings?.storageMaxSizeInBytes
+        )
     }
 
     func getMiniAppView(miniAppURL: URL,
@@ -46,6 +50,8 @@ internal class Displayer {
             displayNavBar: navConfig?.navigationBarVisibility ?? .never,
             navigationDelegate: navConfig?.navigationDelegate,
             navigationView: navConfig?.navigationView,
-            analyticsConfig: analyticsConfig)
+            analyticsConfig: analyticsConfig,
+            storageMaxSizeInBytes: settings?.storageMaxSizeInBytes
+        )
     }
 }

--- a/Sources/Classes/core/Display/RealMiniAppView.swift
+++ b/Sources/Classes/core/Display/RealMiniAppView.swift
@@ -41,7 +41,8 @@ internal class RealMiniAppView: UIView {
         displayNavBar: MiniAppNavigationVisibility = .never,
         navigationDelegate: MiniAppNavigationDelegate? = nil,
         navigationView: (UIView & MiniAppNavigationDelegate)? = nil,
-        analyticsConfig: [MAAnalyticsConfig]? = []) {
+        analyticsConfig: [MAAnalyticsConfig]? = [],
+        storageMaxSizeInBytes: UInt64? = nil) {
 
         self.miniAppTitle = miniAppTitle
         webView = MiniAppWebView(miniAppId: miniAppId, versionId: versionId, queryParams: queryParams)
@@ -51,7 +52,7 @@ internal class RealMiniAppView: UIView {
         self.miniAppVersion = versionId
         self.projectId = projectId
         self.analyticsConfig = analyticsConfig
-        self.secureStorage = MiniAppSecureStorage(appId: miniAppId)
+        self.secureStorage = MiniAppSecureStorage(appId: miniAppId, storageMaxSizeInBytes: storageMaxSizeInBytes)
         super.init(frame: .zero)
         commonInit(miniAppId: miniAppId,
                    hostAppMessageDelegate: hostAppMessageDelegate,
@@ -70,7 +71,8 @@ internal class RealMiniAppView: UIView {
         displayNavBar: MiniAppNavigationVisibility = .never,
         navigationDelegate: MiniAppNavigationDelegate? = nil,
         navigationView: (UIView & MiniAppNavigationDelegate)? = nil,
-        analyticsConfig: [MAAnalyticsConfig]? = []) {
+        analyticsConfig: [MAAnalyticsConfig]? = [],
+        storageMaxSizeInBytes: UInt64? = nil) {
 
         let miniAppId = "custom\(Int32.random(in: 0...Int32.max))" // some id is needed to handle permissions
         self.miniAppTitle = miniAppTitle
@@ -81,7 +83,7 @@ internal class RealMiniAppView: UIView {
         navBarVisibility = displayNavBar
         supportedMiniAppOrientation = []
         self.analyticsConfig = analyticsConfig
-        self.secureStorage = MiniAppSecureStorage(appId: miniAppId)
+        self.secureStorage = MiniAppSecureStorage(appId: miniAppId, storageMaxSizeInBytes: storageMaxSizeInBytes)
         super.init(frame: .zero)
         commonInit(miniAppId: miniAppId,
                    hostAppMessageDelegate: hostAppMessageDelegate,
@@ -146,15 +148,6 @@ internal class RealMiniAppView: UIView {
         MiniAppAnalytics.sendAnalytics(event: .open, miniAppId: miniAppId, miniAppVersion: miniAppVersion, projectId: projectId, analyticsConfig: analyticsConfig)
         initExternalWebViewClosures()
         observeWebView()
-
-        hostAppMessageDelegate.getSecureStorageSizeLimit { result in
-            switch result {
-            case .success(let size):
-                self.secureStorage.fileSizeLimit = size
-            case .failure(let error):
-                MiniAppLogger.d("Could not set a file size limit. \(error)")
-            }
-        }
 
         secureStorage.loadStorage { success in
             if success {

--- a/Sources/Classes/core/Display/RealMiniAppView.swift
+++ b/Sources/Classes/core/Display/RealMiniAppView.swift
@@ -106,7 +106,6 @@ internal class RealMiniAppView: UIView {
         }
     }
 
-    // swiftlint:disable function_body_length
     private func commonInit(
         miniAppId: String,
         hostAppMessageDelegate: MiniAppMessageDelegate,

--- a/Sources/Classes/core/MiniApp.swift
+++ b/Sources/Classes/core/MiniApp.swift
@@ -34,7 +34,7 @@ public class MiniApp: NSObject {
     /// - Parameters:
     ///     -   settings: A MiniAppSdkConfig object containing values to override default config settings.
     public class func shared(with settings: MiniAppSdkConfig? = nil, navigationSettings: MiniAppNavigationConfig? = nil) -> MiniApp {
-        shared.realMiniApp.update(with: settings, navigationSettings: navigationSettings)
+        shared.realMiniApp.update(with: settings, navigationConfig: navigationSettings)
         return shared
     }
 

--- a/Sources/Classes/core/MiniAppSdkConfig.swift
+++ b/Sources/Classes/core/MiniAppSdkConfig.swift
@@ -40,6 +40,8 @@ public class MiniAppSdkConfig {
     public var isPreviewMode: Bool?
     /// Bool used to verifty Mini app signature after download is complete
     public var requireMiniAppSignatureVerification: Bool?
+    /// Max size in bytes for secure storage
+    public var storageMaxSizeInBytes: UInt64?
 
     /// Base Endpoint URL
     public var baseUrl: String? {
@@ -116,7 +118,8 @@ public class MiniAppSdkConfig {
                 isPreviewMode: Bool? = nil,
                 analyticsConfigList: [MAAnalyticsConfig]? = [],
                 requireMiniAppSignatureVerification: Bool? = nil,
-                sslKeyHash: MiniAppConfigSSLKeyHash? = nil) {
+                sslKeyHash: MiniAppConfigSSLKeyHash? = nil,
+                storageMaxSizeInBytes: UInt64? = nil) {
         self.isPreviewMode = isPreviewMode
         self.baseUrl = baseUrl?.count ?? 0 > 0 ? baseUrl : nil
         self.rasProjectId = rasProjectId?.count ?? 0 > 0 ? rasProjectId  : nil
@@ -125,5 +128,6 @@ public class MiniAppSdkConfig {
         self.analyticsConfigList = analyticsConfigList
         self.requireMiniAppSignatureVerification = requireMiniAppSignatureVerification
         self.sslKeyHash = sslKeyHash
+        self.storageMaxSizeInBytes = storageMaxSizeInBytes
     }
 }

--- a/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
@@ -31,9 +31,6 @@ public protocol MiniAppMessageDelegate: MiniAppUserInfoDelegate, MiniAppShareCon
 
     /// Interface that is used to download files
     func downloadFile(fileName: String, url: String, headers: DownloadHeaders, completionHandler: @escaping (Result<String, MASDKDownloadFileError>) -> Void)
-
-    /// Interface that is used to limit the secure storage size in bytes
-    func getSecureStorageSizeLimit(completionHandler: @escaping (Result<UInt64, MASDKError>) -> Void)
 }
 
 public extension MiniAppMessageDelegate {
@@ -76,10 +73,6 @@ public extension MiniAppMessageDelegate {
     }
 
     func downloadFile(fileName: String, url: String, headers: DownloadHeaders, completionHandler: @escaping (Result<String, MASDKError>) -> Void) {
-        completionHandler(.failure(.failedToConformToProtocol))
-    }
-
-    func getSecureStorageSizeLimit(completionHandler: @escaping (Result<UInt64, MASDKError>) -> Void) {
         completionHandler(.failure(.failedToConformToProtocol))
     }
 }

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -20,29 +20,29 @@ internal class RealMiniApp {
         self.init(with: nil)
     }
 
-    init(with settings: MiniAppSdkConfig?, and navigationSettings: MiniAppNavigationConfig? = nil, sslPinningSettings: MiniAppSSLConfig? = nil) {
+    init(with config: MiniAppSdkConfig?, and navigationConfig: MiniAppNavigationConfig? = nil, sslPinningSettings: MiniAppSSLConfig? = nil) {
         miniAppInfoFetcher = MiniAppInfoFetcher()
         metaDataDownloader = MetaDataDownloader()
-        miniAppClient = MiniAppClient(baseUrl: settings?.baseUrl,
-                                      rasProjectId: settings?.rasProjectId,
-                                      subscriptionKey: settings?.subscriptionKey,
-                                      hostAppVersion: settings?.hostAppVersion,
-                                      isPreviewMode: settings?.isPreviewMode)
+        miniAppClient = MiniAppClient(baseUrl: config?.baseUrl,
+                                      rasProjectId: config?.rasProjectId,
+                                      subscriptionKey: config?.subscriptionKey,
+                                      hostAppVersion: config?.hostAppVersion,
+                                      isPreviewMode: config?.isPreviewMode)
         manifestDownloader = ManifestDownloader()
         miniAppStatus = MiniAppStatus()
         miniAppPermissionStorage = MiniAppPermissionsStorage()
         miniAppManifestStorage = MAManifestStorage()
         miniAppDownloader = MiniAppDownloader(apiClient: miniAppClient, manifestDownloader: manifestDownloader, status: miniAppStatus)
-        displayer = Displayer(settings, navigationSettings)
-        miniAppAnalyticsConfig = settings?.analyticsConfigList ?? []
+        displayer = Displayer(config, navigationConfig)
+        miniAppAnalyticsConfig = config?.analyticsConfigList ?? []
         previewMiniAppInfoFetcher = PreviewMiniAppFetcher()
     }
 
-    func update(with settings: MiniAppSdkConfig?, navigationSettings: MiniAppNavigationConfig? = nil) {
-        miniAppClient.updateEnvironment(with: settings)
-        displayer.sdkConfig = settings
-        displayer.navConfig = navigationSettings
-        miniAppAnalyticsConfig = settings?.analyticsConfigList ?? []
+    func update(with config: MiniAppSdkConfig?, navigationConfig: MiniAppNavigationConfig? = nil) {
+        miniAppClient.updateEnvironment(with: config)
+        displayer.sdkConfig = config
+        displayer.navConfig = navigationConfig
+        miniAppAnalyticsConfig = config?.analyticsConfigList ?? []
     }
 
     func listMiniApp(completionHandler: @escaping (Result<[MiniAppInfo], MASDKError>) -> Void) {

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -33,13 +33,14 @@ internal class RealMiniApp {
         miniAppPermissionStorage = MiniAppPermissionsStorage()
         miniAppManifestStorage = MAManifestStorage()
         miniAppDownloader = MiniAppDownloader(apiClient: miniAppClient, manifestDownloader: manifestDownloader, status: miniAppStatus)
-        displayer = Displayer(navigationSettings)
+        displayer = Displayer(settings, navigationSettings)
         miniAppAnalyticsConfig = settings?.analyticsConfigList ?? []
         previewMiniAppInfoFetcher = PreviewMiniAppFetcher()
     }
 
     func update(with settings: MiniAppSdkConfig?, navigationSettings: MiniAppNavigationConfig? = nil) {
         miniAppClient.updateEnvironment(with: settings)
+        displayer.settings = settings
         displayer.navConfig = navigationSettings
         miniAppAnalyticsConfig = settings?.analyticsConfigList ?? []
     }

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -40,7 +40,7 @@ internal class RealMiniApp {
 
     func update(with settings: MiniAppSdkConfig?, navigationSettings: MiniAppNavigationConfig? = nil) {
         miniAppClient.updateEnvironment(with: settings)
-        displayer.settings = settings
+        displayer.sdkConfig = settings
         displayer.navConfig = navigationSettings
         miniAppAnalyticsConfig = settings?.analyticsConfigList ?? []
     }

--- a/Sources/Classes/core/Storage/MiniAppSecureStorage.swift
+++ b/Sources/Classes/core/Storage/MiniAppSecureStorage.swift
@@ -164,6 +164,10 @@ public class MiniAppSecureStorage: MiniAppSecureStorageDelegate {
             guard let strongSelf = self else { return }
             do {
                 try strongSelf.saveStoreToDisk()
+                DispatchQueue.main.async {
+                    strongSelf.isBusy = false
+                    completion?(.success(true))
+                }
             } catch let error {
                 strongSelf.isBusy = false
                 if let error = error as? MiniAppSecureStorageError {
@@ -172,10 +176,6 @@ public class MiniAppSecureStorage: MiniAppSecureStorageDelegate {
                     completion?(.failure(.storageIOError))
                 }
                 return
-            }
-            DispatchQueue.main.async {
-                strongSelf.isBusy = false
-                completion?(.success(true))
             }
         }
     }

--- a/Sources/Classes/core/Storage/MiniAppSecureStorage.swift
+++ b/Sources/Classes/core/Storage/MiniAppSecureStorage.swift
@@ -258,7 +258,7 @@ public class MiniAppSecureStorage: MiniAppSecureStorageDelegate {
             throw MiniAppSecureStorageError.storageFullError
         }
     }
-    
+
     func validateAvailableSpace(for dict: [String: String]) throws {
         guard
             let dictData = try? PropertyListEncoder().encode(dict),

--- a/Sources/Classes/core/Storage/MiniAppSecureStorage.swift
+++ b/Sources/Classes/core/Storage/MiniAppSecureStorage.swift
@@ -91,6 +91,7 @@ public class MiniAppSecureStorage: MiniAppSecureStorageDelegate {
         return storage[key]
     }
 
+    // swiftlint:disable function_body_length
     public func set(dict: [String: String], completion: ((Result<Bool, MiniAppSecureStorageError>) -> Void)? = nil) {
         guard let memorySize = try? getMemoryStorageFileSize() else {
             completion?(.failure(.storageUnvailable))

--- a/Tests/Unit/DisplayerTests.swift
+++ b/Tests/Unit/DisplayerTests.swift
@@ -42,6 +42,20 @@ class DisplayerTests: QuickSpec {
                     expect(miniAppView).to(beAnInstanceOf(RealMiniAppView.self))
                 }
             }
+
+            context("when sdk config with a max storage limit is passed") {
+                it("will equal to the specified storage limit") {
+                    miniAppDisplayer.settings = MiniAppSdkConfig(storageMaxSizeInBytes: 64)
+                    let miniAppView = miniAppDisplayer.getMiniAppView(miniAppId: mockMiniAppInfo.id,
+                                                                      versionId: mockMiniAppInfo.version.versionId,
+                                                                      projectId: "project-id",
+                                                                      miniAppTitle: mockMiniAppInfo.displayName!,
+                                                                      hostAppMessageDelegate: mockMessageInterface)
+                    if let view = miniAppView.getMiniAppView() as? RealMiniAppView {
+                        expect(view.secureStorage.fileSizeLimit).to(equal(64))
+                    }
+                }
+            }
         }
     }
 }

--- a/Tests/Unit/DisplayerTests.swift
+++ b/Tests/Unit/DisplayerTests.swift
@@ -45,7 +45,7 @@ class DisplayerTests: QuickSpec {
 
             context("when sdk config with a max storage limit is passed") {
                 it("will equal to the specified storage limit") {
-                    miniAppDisplayer.settings = MiniAppSdkConfig(storageMaxSizeInBytes: 64)
+                    miniAppDisplayer.sdkConfig = MiniAppSdkConfig(storageMaxSizeInBytes: 64)
                     let miniAppView = miniAppDisplayer.getMiniAppView(miniAppId: mockMiniAppInfo.id,
                                                                       versionId: mockMiniAppInfo.version.versionId,
                                                                       projectId: "project-id",

--- a/Tests/Unit/MiniAppStorageTests.swift
+++ b/Tests/Unit/MiniAppStorageTests.swift
@@ -148,6 +148,28 @@ class MiniAppStorageTests: QuickSpec {
                     let fileSize: UInt64 = storage.storageFileSize
                     expect(fileSize).to(equal(42))
                 }
+
+                it("will exceed storage size and throw an error") {
+                    let storage = MiniAppSecureStorage(appId: miniAppId, storageMaxSizeInBytes: 43)
+                    var resultError: MiniAppSecureStorageError?
+                    storage.loadStorage { success in
+                        let values = [
+                            "test1": "test1Value",
+                            "test2": "test2Value",
+                            "test3": "test3Value",
+                            "test4": "test4Value"
+                        ]
+                        storage.set(dict: values) { result in
+                            switch result {
+                            case .success:
+                                fail("should not exceed")
+                            case .failure(let error):
+                                resultError = error
+                            }
+                        }
+                    }
+                    expect(resultError).toEventually(equal(MiniAppSecureStorageError.storageFullError))
+                }
             }
         }
     }

--- a/Tests/Unit/RealMiniAppTests.swift
+++ b/Tests/Unit/RealMiniAppTests.swift
@@ -129,7 +129,7 @@ class RealMiniAppTests: QuickSpec {
                 config.navigationView = dummyView
 
                 it("will take the new navigation settings in account") {
-                    realMiniApp.update(with: nil, navigationSettings: config)
+                    realMiniApp.update(with: nil, navigationConfig: config)
                     expect(realMiniApp.displayer.navConfig?.navigationBarVisibility) == .always
                     expect(realMiniApp.displayer.navConfig?.navigationDelegate).to(beAKindOf(MiniAppNavigationDelegate.self))
                     expect(realMiniApp.displayer.navConfig?.navigationView).to(beAKindOf(MiniAppNavigationDelegate.self))

--- a/Tests/Unit/RealMiniAppViewTests.swift
+++ b/Tests/Unit/RealMiniAppViewTests.swift
@@ -139,6 +139,31 @@ class RealMiniAppViewTests: QuickSpec {
                     expect(miniAppView.messageBodies.count).toEventually(be(0))
                 }
             }
+
+            context("when host app sets a max storage limit") {
+                it("will equal to the default storage limit") {
+                    let miniAppView = RealMiniAppView(
+                        miniAppId: "abcd",
+                        versionId: "efgh",
+                        projectId: "project-id",
+                        miniAppTitle: "",
+                        hostAppMessageDelegate: mockMessageInterface,
+                        storageMaxSizeInBytes: nil
+                    )
+                    expect(miniAppView.secureStorage.fileSizeLimit).to(equal(2_000_000))
+                }
+                it("will equal to the specified storage limit") {
+                    let miniAppView = RealMiniAppView(
+                        miniAppId: "abcd",
+                        versionId: "efgh",
+                        projectId: "project-id",
+                        miniAppTitle: "",
+                        hostAppMessageDelegate: mockMessageInterface,
+                        storageMaxSizeInBytes: 50
+                    )
+                    expect(miniAppView.secureStorage.fileSizeLimit).to(equal(50))
+                }
+            }
         }
     }
 }

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -566,15 +566,16 @@ It's necessary to allow the `File Download` custom permission to make file downl
 
 Allows MiniApps to store data safely in a key/value store.
 
-Use `MiniAppMessageDelegate` new method `getSecureStorageSizeLimit` to define the maximum file size for the storage in bytes.
-When no maximum storage size is set the default value will be 2_000_000 (2Mb). 
+You can specify the max storage file size in `MiniAppSdkConfig.storageMaxSizeInBytes` when creating a MiniApp.
+When no maximum storage size is set the default value will be 2_000_000 (2Mb). Exceeding the file size limit will
+throw an error `MiniAppSecureStorageError.storageFullError` when setting new values into the storage.
 
 ```swift
-extension ViewController: MiniAppMessageDelegate {
-    func getSecureStorageSizeLimit(completionHandler: @escaping (Result<UInt64, MASDKError>) -> Void) {
-        completion(.success(25_000_000))
-    }
-}
+MiniAppSdkConfig(
+    //...
+    // set the max size to 5 Mb
+    storageMaxSizeInBytes: 5_000_000
+)
 ```
 
 Use `wipeSecureStorages` to delete all secure storages stored on the device.


### PR DESCRIPTION
# Description
- replace message delegate maxStorage delegate with MiniAppSdkConfig.storageMaxSizeInBytes
- check every time a value is set for exceeding size

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
