### PR TITLE
[NO-TICKET] - Send keyboard events when MiniApp is loaded from URL

### DIFF
--- a/Example/Controllers/DisplayController.swift
+++ b/Example/Controllers/DisplayController.swift
@@ -11,6 +11,12 @@ class DisplayController: RATViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.pageName = MASDKLocale.localize("demo.app.rat.page.name.display.miniapp")
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardShown), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardHidden), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -47,5 +53,21 @@ class DisplayController: RATViewController {
         default:
             break
         }
+    }
+
+    @objc
+    func keyboardShown(notification: Notification) {
+        guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let keyboardScreenEndFrame = keyboardValue.cgRectValue
+        let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
+        let navigationBarHeight = (navigationController?.navigationBar.bounds.height ?? 0) + (view.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0)
+        let screenHeight = view.bounds.height - navigationBarHeight
+        let keyboardHeight = keyboardViewEndFrame.height
+        MiniApp.shared(with: Config.current()).keyboardShown(navigationBarHeight: navigationBarHeight, screenHeight: screenHeight, keyboardheight: keyboardHeight)
+    }
+
+    @objc
+    func keyboardHidden(notification: Notification) {
+        MiniApp.shared(with: Config.current()).keyboardHidden(navigationBarHeight: 0, screenHeight: 0, keyboardheight: 0)
     }
 }


### PR DESCRIPTION
# Description
Keyboard events are not sent for the miniapps that is loaded via URL. This should fix it.

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
