### PR TITLE
Mini App Close confirmation alert feature integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Feature:** Added file download error type for HTTP errors: `MASDKDownloadFileError.downloadHttpError`.
 - **Fix:** Updated error type names for `MASDKDownloadFileError` so that they are correctly parsed by JS SDK.
 - **Feature:** Added `MiniAppSecureStorage` for MiniApps to store data safely. `MiniAppSdkConfig` was extended by `storageMaxSizeInBytes` to set the maximum available space in bytes for secure storage.
+- **Feature:** Added `miniAppShouldClose` interface in `MiniAppNavigationBarDelegate` which would help the host app to check if any alert need to displayed before closing the MiniApp
 
 **Sample app**
 - **Enhancement:** Added `GET MESSAGING UNIQUE ID` and `GET MAUID` for retrieving the ID's. (Messaging Unique ID for now will return the same as Unique ID)

--- a/Example/Controllers/DisplayController.swift
+++ b/Example/Controllers/DisplayController.swift
@@ -36,7 +36,14 @@ class DisplayController: RATViewController {
     }
 
     @IBAction func done(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true, completion: nil)
+        if let alertInfo = navBarDelegate?.miniAppShouldClose(), alertInfo.shouldDisplay ?? false {
+            let alertController = UIAlertController(title: alertInfo.title, message: alertInfo.description, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: MASDKLocale.localize(.ok), style: .default, handler: { (_) in
+                self.dismiss(animated: true, completion: nil)
+            }))
+            alertController.addAction(UIAlertAction(title: MASDKLocale.localize(.cancel), style: .cancel, handler: nil))
+            self.present(alertController, animated: true, completion: nil)
+        }
     }
 
     func refreshNavigationBarButtons(backButtonEnabled: Bool, forwardButtonEnabled: Bool) {

--- a/Sources/Classes/core/Display/MiniAppNavigationConfig.swift
+++ b/Sources/Classes/core/Display/MiniAppNavigationConfig.swift
@@ -123,6 +123,12 @@ public protocol MiniAppNavigationBarDelegate: AnyObject {
     /// Returns if action has been triggered or not
     @discardableResult
     func miniAppNavigationBar(didTriggerAction action: MiniAppNavigationAction) -> Bool
+
+    /// Method to check before closing the miniapp. This makes sure whether we need to display alert to the user before closing the mini-app
+    /// - Returns: CloseAlertInfo:
+    /// @discardableResult
+    func miniAppShouldClose() -> CloseAlertInfo?
+
 }
 
 // MARK: - Enums

--- a/Sources/Classes/core/Display/RealMiniAppView.swift
+++ b/Sources/Classes/core/Display/RealMiniAppView.swift
@@ -21,6 +21,7 @@ internal class RealMiniAppView: UIView {
     internal var messageBodies: [String] = []
     internal var onExternalWebviewResponse: ((URL) -> Void)?
     internal var onExternalWebviewClose: ((URL) -> Void)?
+    internal var closeAlertInfo: CloseAlertInfo?
 
     internal weak var hostAppMessageDelegate: MiniAppMessageDelegate?
     internal weak var navigationDelegate: MiniAppNavigationDelegate?
@@ -135,7 +136,8 @@ internal class RealMiniAppView: UIView {
                                                                                    adsDisplayer: adsDisplayer,
                                                                                    secureStorageDelegate: self,
                                                                                    miniAppId: miniAppId,
-                                                                                   miniAppTitle: self.miniAppTitle)
+                                                                                   miniAppTitle: self.miniAppTitle,
+                                                                                   miniAppManageDelegate: self)
         webView.configuration.userContentController.addBridgingJavaScript()
         webView.uiDelegate = self
         self.navigationDelegate = navigationDelegate
@@ -372,6 +374,10 @@ extension RealMiniAppView: MiniAppCallbackDelegate {
 }
 
 extension RealMiniAppView: MiniAppNavigationBarDelegate {
+    func miniAppShouldClose() -> CloseAlertInfo? {
+        return self.closeAlertInfo
+    }
+
     func miniAppNavigationBar(didTriggerAction action: MiniAppNavigationAction) -> Bool {
         let canDo: Bool
         switch action {
@@ -432,5 +438,11 @@ extension RealMiniAppView: MiniAppSecureStorageDelegate {
 
     func clearSecureStorage() throws {
         try secureStorage.clearSecureStorage()
+    }
+}
+
+extension RealMiniAppView: MiniAppManageDelegate {
+    func setMiniAppCloseAlertInfo(alertInfo: CloseAlertInfo?) {
+        self.closeAlertInfo = alertInfo
     }
 }

--- a/Sources/Classes/core/Extensions/Date+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/Date+MiniApp.swift
@@ -5,4 +5,9 @@ extension Date {
         let currentDate = Date()
         return String(Int(currentDate.timeIntervalSince1970 * 1000))
     }
+
+    func dateToNumber() -> Int {
+        let timeSince1970 = self.timeIntervalSince1970
+        return Int(timeSince1970 * 1000)
+    }
 }

--- a/Sources/Classes/core/Extensions/WKUserContentController+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/WKUserContentController+MiniApp.swift
@@ -16,7 +16,8 @@ extension WKUserContentController {
         adsDisplayer: MiniAppAdDisplayer?,
         secureStorageDelegate: MiniAppSecureStorageDelegate,
         miniAppId: String,
-        miniAppTitle: String
+        miniAppTitle: String,
+        miniAppManageDelegate: MiniAppManageDelegate
     ) {
         [Constants.JavaScript.interfaceName,
          Constants.JavaScript.logHandler].forEach { (name) in
@@ -25,6 +26,7 @@ extension WKUserContentController {
                     hostAppMessageDelegate: hostAppMessageDelegate,
                     adsDisplayer: adsDisplayer,
                     secureStorageDelegate: secureStorageDelegate,
+                    miniAppManageDelegate: miniAppManageDelegate,
                     miniAppId: miniAppId,
                     miniAppTitle: miniAppTitle
             ), name: name)

--- a/Sources/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -26,6 +26,7 @@ enum MiniAppJSActionCommand: String {
     case removeSecureStorageItems
     case clearSecureStorage
     case getSecureStorageSize
+    case setCloseAlert
 }
 
 enum JavaScriptExecResult: String {

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -707,7 +707,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             miniAppManageDelegate?.setMiniAppCloseAlertInfo(alertInfo: alertInfo)
             executeJavaScriptCallback(responseStatus: .onSuccess, messageId: callbackId, response: "SUCCESS")
         } else {
-            executeJavaScriptCallback(responseStatus: .onError, messageId: callBackId, response: prepareMAJavascriptError(MiniAppJavaScriptError.unexpectedMessageFormat))
+            executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMAJavascriptError(MiniAppJavaScriptError.unexpectedMessageFormat))
         }
     }
 

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -705,6 +705,9 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     func setMiniAppCloseAlert(with callbackId: String, parameters: RequestParameters?) {
         if let alertInfo = parameters?.closeAlertInfo {
             miniAppManageDelegate?.setMiniAppCloseAlertInfo(alertInfo: alertInfo)
+            executeJavaScriptCallback(responseStatus: .onSuccess, messageId: callbackId, response: "SUCCESS")
+        } else {
+            executeJavaScriptCallback(responseStatus: .onError, messageId: callBackId, response: prepareMAJavascriptError(MiniAppJavaScriptError.unexpectedMessageFormat))
         }
     }
 

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -17,6 +17,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     weak var hostAppMessageDelegate: MiniAppMessageDelegate?
     weak var adsDelegate: MiniAppAdDisplayDelegate?
     weak var secureStorageDelegate: MiniAppSecureStorageDelegate?
+    weak var miniAppManageDelegate: MiniAppManageDelegate?
     var miniAppId: String
     var miniAppTitle: String
     var userAlreadyRespondedRequestList = [MASDKCustomPermissionModel]()
@@ -28,6 +29,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         hostAppMessageDelegate: MiniAppMessageDelegate,
         adsDisplayer: MiniAppAdDisplayer?,
         secureStorageDelegate: MiniAppSecureStorageDelegate,
+        miniAppManageDelegate: MiniAppManageDelegate?,
         miniAppId: String,
         miniAppTitle: String
     ) {
@@ -37,6 +39,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         self.miniAppTitle = miniAppTitle
         self.adsDelegate = adsDisplayer
         self.secureStorageDelegate = secureStorageDelegate
+        self.miniAppManageDelegate = miniAppManageDelegate
         super.init()
     }
 
@@ -115,6 +118,8 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             clearSecureStorage(with: callbackId, parameters: requestParam)
         case .getSecureStorageSize:
             getSecureStorageSize(with: callbackId, parameters: requestParam)
+        case .setCloseAlert:
+            setMiniAppCloseAlert(with: callbackId, parameters: requestParam)
         }
     }
 
@@ -695,6 +700,12 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             messageId: callbackId,
             response: encodedSize
         )
+    }
+
+    func setMiniAppCloseAlert(with callbackId: String, parameters: RequestParameters?) {
+        if let alertInfo = parameters?.closeAlertInfo {
+            miniAppManageDelegate?.setMiniAppCloseAlertInfo(alertInfo: alertInfo)
+        }
     }
 
     private func sendScopeError(callbackId: String, type: MASDKAccessTokenError) {

--- a/Sources/Classes/core/MiniAppAnalytics.swift
+++ b/Sources/Classes/core/MiniAppAnalytics.swift
@@ -36,6 +36,7 @@ internal enum MiniAppRATEvent: String, CaseIterable {
     case removeSecureStorageItems = "mini_app_secure_storage_remove_items"
     case clearSecureStorage = "mini_app_secure_storage_clear"
     case getSecureStorageSize = "mini_app_secure_storage_size"
+    case setCloseAlertInfo = "mini_app_close_alert_info"
 
     func name() -> String {
         "mini_app_\(rawValue)"
@@ -73,7 +74,8 @@ internal enum MiniAppRATEvent: String, CaseIterable {
              .setSecureStorageItems,
              .removeSecureStorageItems,
              .clearSecureStorage,
-             .getSecureStorageSize:
+             .getSecureStorageSize,
+             .setCloseAlertInfo:
             return .click
         }
     }
@@ -200,6 +202,8 @@ public class MiniAppAnalytics {
             return .clearSecureStorage
         case .getSecureStorageSize:
             return .getSecureStorageSize
+        case .setCloseAlert:
+            return .setCloseAlertInfo
         }
     }
 }

--- a/Sources/Classes/core/Models/MAPoints.swift
+++ b/Sources/Classes/core/Models/MAPoints.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public class MAPoints: Codable {
+    let standard: Int
+    let term: Int
+    let cash: Int
+
+    public init(standard: Int, term: Int, cash: Int) {
+        self.standard = standard
+        self.term = term
+        self.cash = cash
+    }
+}

--- a/Sources/Classes/core/Models/MATokenInfo.swift
+++ b/Sources/Classes/core/Models/MATokenInfo.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public class MATokenInfo: Codable {
+    let token: String
+    let validUntil: Int
+    let scopes: MASDKAccessTokenScopes
+
+    public init(accessToken: String, expirationDate: Date, scopes: MASDKAccessTokenScopes?) {
+        self.token = accessToken
+        self.validUntil = expirationDate.dateToNumber()
+        self.scopes = scopes ?? MASDKAccessTokenScopes(audience: "UNDEFINED", scopes: [])!
+    }
+}

--- a/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
@@ -22,6 +22,7 @@ struct RequestParameters: Decodable {
     let secureStorageKey: String?
     let secureStorageItems: [String: String]?
     let secureStorageKeyList: [String]?
+    let closeAlertInfo: CloseAlertInfo?
 }
 
 struct LocationOptions: Decodable {
@@ -43,4 +44,10 @@ struct MiniAppCustomPermissionsResponse: Codable {
 
 struct MiniAppCustomPermissionsListResponse: Codable {
     let name, status: String
+}
+
+public struct CloseAlertInfo: Codable {
+    public let shouldDisplay: Bool?
+    public let title: String?
+    public let description: String?
 }

--- a/Sources/Classes/core/Protocols/MiniAppManageDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppManageDelegate.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/**
+ * Protocol for the Managing Mini Apps
+ */
+internal protocol MiniAppManageDelegate: AnyObject {
+
+    func setMiniAppCloseAlertInfo(alertInfo: CloseAlertInfo?)
+}

--- a/Sources/Classes/core/Protocols/MiniAppUserInfoDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppUserInfoDelegate.swift
@@ -72,18 +72,6 @@ public extension MiniAppUserInfoDelegate {
     }
 }
 
-public class MATokenInfo: Codable {
-    let token: String
-    let validUntil: Int
-    let scopes: MASDKAccessTokenScopes
-
-    public init(accessToken: String, expirationDate: Date, scopes: MASDKAccessTokenScopes?) {
-        self.token = accessToken
-        self.validUntil = expirationDate.dateToNumber()
-        self.scopes = scopes ?? MASDKAccessTokenScopes(audience: "UNDEFINED", scopes: [])!
-    }
-}
-
 /// Contact Object of a User
 public class MAContact: Codable, Equatable, Hashable {
     /// Contact ID
@@ -107,24 +95,5 @@ public class MAContact: Codable, Equatable, Hashable {
         hasher.combine(id)
         hasher.combine(name)
         hasher.combine(email)
-    }
-}
-
-extension Date {
-    func dateToNumber() -> Int {
-        let timeSince1970 = self.timeIntervalSince1970
-        return Int(timeSince1970 * 1000)
-    }
-}
-
-public class MAPoints: Codable {
-    let standard: Int
-    let term: Int
-    let cash: Int
-
-    public init(standard: Int, term: Int, cash: Int) {
-        self.standard = standard
-        self.term = term
-        self.cash = cash
     }
 }

--- a/Sources/Classes/ui/MiniAppViewController.swift
+++ b/Sources/Classes/ui/MiniAppViewController.swift
@@ -291,13 +291,25 @@ public class MiniAppViewController: UIViewController {
     @objc
     /// Method that is called when mini app is closed
     public func closePressed() {
+        if let alertInfo = navBarDelegate?.miniAppShouldClose(), alertInfo.shouldDisplay ?? false {
+            let alertController = UIAlertController(title: alertInfo.title, message: alertInfo.description, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: MASDKLocale.localize(.ok), style: .default, handler: { (_) in
+                self.closeMiniApp()
+            }))
+            alertController.addAction(UIAlertAction(title: MASDKLocale.localize(.cancel), style: .cancel, handler: nil))
+            UIApplication.topViewController()?.present(alertController, animated: true, completion: nil)
+        } else {
+            self.closeMiniApp()
+        }
+    }
+
+    func closeMiniApp() {
         if miniAppUiDelegate == nil {
             dismiss(animated: true, completion: nil)
         } else {
             miniAppUiDelegate?.onClose()
         }
     }
-
     /// Method that is called when navigation buttons need to be refreshed
     public func refreshNavigationBarButtons(backButtonEnabled: Bool, forwardButtonEnabled: Bool) {
         backButton.isEnabled = backButtonEnabled

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -527,6 +527,10 @@ class MockMessageInterface: MiniAppMessageDelegate {
     }
 }
 
+class MockManageDelegateInterface: MiniAppManageDelegate {
+    func setMiniAppCloseAlertInfo(alertInfo: CloseAlertInfo?) { }
+}
+
 var mockMiniAppInfo: MiniAppInfo {
     let mockVersion = Version(versionTag: "Dev", versionId: "ver-id-test")
     let info = MiniAppInfo.init(id: "app-id-test", displayName: "Mini App Title", icon: URL(string: "\(mockHost)/icon.png")!, version: mockVersion)

--- a/Tests/Unit/MiniAppAdDisplayerTests.swift
+++ b/Tests/Unit/MiniAppAdDisplayerTests.swift
@@ -28,6 +28,7 @@ class MiniAppAdDisplayerTests: QuickSpec {
                     hostAppMessageDelegate: MockMessageInterface(),
                     adsDisplayer: adsDisplayer,
                     secureStorageDelegate: MockMiniAppSecureStorage(),
+                    miniAppManageDelegate: nil,
                     miniAppId: "mockMiniAppID",
                     miniAppTitle: "mockMiniAppTitle"
             )

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -909,226 +909,286 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
                     expect(mockCallbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue), timeout: .seconds(5))
                 }
-                context("when MiniAppScriptMessageHandler receives sendMessageToContactId command") {
-                    it("will return contact Id") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
-                        )
-                        mockMessageInterface.messageContentAllowed = false
-                        let command = """
-                        {
-                            "action" : "sendMessageToContactId",
-                            "id" : "4.1141101534045745",
-                            "param" : {
-                                "contactId" : "\(mockMiniAppInfo.id)",
-                                "messageToContact" : null
-                            }
+            }
+            context("when MiniAppScriptMessageHandler receives sendMessageToContactId command") {
+                it("will return contact Id") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    mockMessageInterface.messageContentAllowed = false
+                    let command = """
+                    {
+                        "action" : "sendMessageToContactId",
+                        "id" : "4.1141101534045745",
+                        "param" : {
+                            "contactId" : "\(mockMiniAppInfo.id)",
+                            "messageToContact" : null
                         }
-                        """
-                        updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .sendMessage, status: .allowed)
-                        updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .contactsList, status: .allowed)
+                    }
+                    """
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .sendMessage, status: .allowed)
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .contactsList, status: .allowed)
 
-                        let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
-                        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                        expect(mockCallbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue), timeout: .seconds(5))
-                    }
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue), timeout: .seconds(5))
                 }
-                context("when MiniAppScriptMessageHandler receives sendMessageToMultipleContacts command") {
-                    it("will return list of contact Ids") {
-                        mockMessageInterface.messageContentAllowed = false
-                        let command = """
-                        {
-                            "action" : "sendMessageToMultipleContacts",
-                            "id" : "5.1141101534045745",
-                            "param" : {
-                                "messageToContact" : null
-                        }
-                        """
-                        updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .sendMessage, status: .allowed)
-                        updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .contactsList, status: .allowed)
-                        let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
-                        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                        expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue), timeout: .seconds(5))
+            }
+            context("when MiniAppScriptMessageHandler receives sendMessageToMultipleContacts command") {
+                it("will return list of contact Ids") {
+                    mockMessageInterface.messageContentAllowed = false
+                    let command = """
+                    {
+                        "action" : "sendMessageToMultipleContacts",
+                        "id" : "5.1141101534045745",
+                        "param" : {
+                            "messageToContact" : null
                     }
+                    """
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .sendMessage, status: .allowed)
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .contactsList, status: .allowed)
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue), timeout: .seconds(5))
                 }
-                context("when MiniAppScriptMessageHandler receives getPoints command and permission is denied") {
-                    it("will error") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
-                        )
-                        let command = """
-                        {
-                            "action" : "getPoints",
-                            "id" : "5.1141101534045745",
-                            "param" : null
-                        }
-                        """
-                        updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .points, status: .denied)
-                        let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
-                        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                        expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userDenied.rawValue), timeout: .seconds(10))
+            }
+            context("when MiniAppScriptMessageHandler receives getPoints command and permission is denied") {
+                it("will error") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    let command = """
+                    {
+                        "action" : "getPoints",
+                        "id" : "5.1141101534045745",
+                        "param" : null
+                    }
+                    """
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .points, status: .denied)
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userDenied.rawValue), timeout: .seconds(10))
 
-                    }
                 }
-                context("when MiniAppScriptMessageHandler receives getPoints command and permission is allowed") {
-                    it("will return list of contact Ids") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
-                        )
-                        let command = """
-                        {
-                            "action" : "getPoints",
-                            "id" : "5.1141101534045745",
-                            "param" : null
-                        }
-                        """
-                        updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .points, status: .allowed)
-                        mockMessageInterface.mockPointsInterface = false
-                        let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
-                        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                        expect(mockCallbackProtocol.errorMessage).toEventually(contain("Failed to retrieve Points details"), timeout: .seconds(10))
+            }
+            context("when MiniAppScriptMessageHandler receives getPoints command and permission is allowed") {
+                it("will return list of contact Ids") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    let command = """
+                    {
+                        "action" : "getPoints",
+                        "id" : "5.1141101534045745",
+                        "param" : null
+                    }
+                    """
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .points, status: .allowed)
+                    mockMessageInterface.mockPointsInterface = false
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain("Failed to retrieve Points details"), timeout: .seconds(10))
 
-                    }
                 }
-                context("when MiniAppScriptMessageHandler receives getPoints command and permission is allowed") {
-                    it("will return list of contact Ids") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
-                        )
-                        let command = """
-                        {
-                            "action" : "getPoints",
-                            "id" : "5.1141101534045745",
-                            "param" : null
-                        }
-                        """
-                        updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .points, status: .allowed)
-                        mockMessageInterface.mockPointsInterface = true
-                        let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
-                        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                        expect(mockCallbackProtocol.response).toEventually(contain("standard"), timeout: .seconds(10))
+            }
+            context("when MiniAppScriptMessageHandler receives getPoints command and permission is allowed") {
+                it("will return list of contact Ids") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    let command = """
+                    {
+                        "action" : "getPoints",
+                        "id" : "5.1141101534045745",
+                        "param" : null
                     }
+                    """
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .points, status: .allowed)
+                    mockMessageInterface.mockPointsInterface = true
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.response).toEventually(contain("standard"), timeout: .seconds(10))
                 }
-                context("when MiniAppScriptMessageHandler receives getHostEnvironmentInfo command") {
-                    it("will return ") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
-                        )
-                        let command = """
-                        {
-                            "action" : "getHostEnvironmentInfo",
-                            "id" : "5.1141101534045745",
-                            "param" : null
-                        }
-                        """
-                        mockMessageInterface.mockEnvironmentInfo = true
-                        let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
-                        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                        guard let responseData: Data = mockCallbackProtocol.response?.data(using: .utf8) else {
-                            fail("MiniAppScriptMessageHandler - getHostEnvironmentInfo failed")
-                            return
-                        }
-                        let environmentInfo = ResponseDecoder.decode(decodeType: MAHostEnvironmentInfo.self, data: responseData)
+            }
+            context("when MiniAppScriptMessageHandler receives getHostEnvironmentInfo command") {
+                it("will return ") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    let command = """
+                    {
+                        "action" : "getHostEnvironmentInfo",
+                        "id" : "5.1141101534045745",
+                        "param" : null
+                    }
+                    """
+                    mockMessageInterface.mockEnvironmentInfo = true
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    guard let responseData: Data = mockCallbackProtocol.response?.data(using: .utf8) else {
+                        fail("MiniAppScriptMessageHandler - getHostEnvironmentInfo failed")
+                        return
+                    }
+                    let environmentInfo = ResponseDecoder.decode(decodeType: MAHostEnvironmentInfo.self, data: responseData)
                         expect(environmentInfo?.sdkVersion).toEventually(equal("4.2.0"))
-                        expect(environmentInfo?.hostVersion).toEventually(equal(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String))
-                        expect(environmentInfo?.hostLocale).toEventually(equal("en-US"))
-                    }
+                    expect(environmentInfo?.hostVersion).toEventually(equal(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String))
+                    expect(environmentInfo?.hostLocale).toEventually(equal("en-US"))
                 }
-                context("when MiniAppScriptMessageHandler receives downloadFile command") {
-                    it("will return ") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id,
-                            miniAppTitle: mockMiniAppTitle
-                        )
-                        let command = """
-                        {
-                            "action" : "downloadFile",
-                            "id" : "5.1141101534045745",
-                            "param": {
-                                "filename" : "sample.jpg",
-                                "url" : "https://rakuten.co.jp/sample.jpg",
-                                "headers" : { "token": "test" }
+            }
+            context("when MiniAppScriptMessageHandler receives downloadFile command") {
+                it("will return ") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id,
+                        miniAppTitle: mockMiniAppTitle
+                    )
+                    let command = """
+                    {
+                        "action" : "downloadFile",
+                        "id" : "5.1141101534045745",
+                        "param": {
+                            "filename" : "sample.jpg",
+                            "url" : "https://rakuten.co.jp/sample.jpg",
+                            "headers" : { "token": "test" }
+                        }
+                    }
+                    """
+                    updateCustomPermissionStatus(
+                        miniAppId: mockMiniAppInfo.id,
+                        permissionType: .fileDownload,
+                        status: .allowed
+                    )
+                    mockMessageInterface.mockDownloadFile = true
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.response).toEventually(equal("sample.jpg"))
+                }
+            }
+            context("when MiniAppScriptMessageHandler executes keyboard events") {
+                it("keyboard shown succeeds") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    scriptMessageHandler.execKeyboardEventsCallback(with: .keyboardShown, message: "keyboard shown", navigationBarHeight: 100, screenHeight: 200, keyboardHeight: 300)
+                    expect(mockCallbackProtocol.navBarHeight).to(equal(100))
+                    expect(mockCallbackProtocol.screenHeight).to(equal(200))
+                    expect(mockCallbackProtocol.keyboardHeight).to(equal(300))
+                }
+                it("keyboard hidden succeeds") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    scriptMessageHandler.execKeyboardEventsCallback(with: .keyboardHidden, message: "keyboard hidden", navigationBarHeight: 100, screenHeight: 200, keyboardHeight: 300)
+                    expect(mockCallbackProtocol.navBarHeight).to(equal(100))
+                    expect(mockCallbackProtocol.screenHeight).to(equal(200))
+                    expect(mockCallbackProtocol.keyboardHeight).to(equal(300))
+                }
+            }
+            context("when MiniAppScriptMessageHandler receives setCloseAlert command") {
+                it("will set the Mini app close alert info in the SDK") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id,
+                        miniAppTitle: mockMiniAppTitle
+                    )
+                    let command = """
+                    {
+                        "action" : "setCloseAlert",
+                        "id" : "5.114110153404574",
+                        "param": {
+                            "closeAlertInfo": {
+                                "shouldDisplay" : true,
+                                "title" : "Info",
+                                "description" : "Would you like to close the mini-app?"
                             }
                         }
-                        """
-                        updateCustomPermissionStatus(
-                            miniAppId: mockMiniAppInfo.id,
-                            permissionType: .fileDownload,
-                            status: .allowed
-                        )
-                        mockMessageInterface.mockDownloadFile = true
-                        let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
-                        scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                        expect(mockCallbackProtocol.response).toEventually(equal("sample.jpg"))
                     }
+                    """
+                    mockMessageInterface.mockDownloadFile = true
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.response).toEventually(equal("SUCCESS"))
                 }
-                context("when MiniAppScriptMessageHandler executes keyboard events") {
-                    it("keyboard shown succeeds") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
-                        )
-                        scriptMessageHandler.execKeyboardEventsCallback(with: .keyboardShown, message: "keyboard shown", navigationBarHeight: 100, screenHeight: 200, keyboardHeight: 300)
-                        expect(mockCallbackProtocol.navBarHeight).to(equal(100))
-                        expect(mockCallbackProtocol.screenHeight).to(equal(200))
-                        expect(mockCallbackProtocol.keyboardHeight).to(equal(300))
+                it("received wrong params then it will throw error") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id,
+                        miniAppTitle: mockMiniAppTitle
+                    )
+                    let command = """
+                    {
+                        "action" : "setCloseAlert",
+                        "id" : "5.114110153404574",
+                        "param": {
+                            "closeAlertInfo": {
+                                "shouldDisplay" : "true",
+                                "title" : "Info",
+                                "description" : "Would you like to close the mini-app?"
+                            }
+                        }
                     }
-                    it("keyboard hidden succeeds") {
-                        let mockCallbackProtocol = MockMiniAppCallbackProtocol()
-                        let scriptMessageHandler = MiniAppScriptMessageHandler(
-                            delegate: mockCallbackProtocol,
-                            hostAppMessageDelegate: mockMessageInterface,
-                            adsDisplayer: mockAdsDelegate,
-                            secureStorageDelegate: mockSecureStorageDelegate,
-                            miniAppManageDelegate: mockMiniAppManageInterface,
-                            miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
-                        )
-                        scriptMessageHandler.execKeyboardEventsCallback(with: .keyboardHidden, message: "keyboard hidden", navigationBarHeight: 100, screenHeight: 200, keyboardHeight: 300)
-                        expect(mockCallbackProtocol.navBarHeight).to(equal(100))
-                        expect(mockCallbackProtocol.screenHeight).to(equal(200))
-                        expect(mockCallbackProtocol.keyboardHeight).to(equal(300))
-                    }
+                    """
+                    mockMessageInterface.mockDownloadFile = true
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.rawValue))
                 }
             }
         }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -15,6 +15,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
             let mockMessageInterface = MockMessageInterface()
             let mockAdsDelegate =  MockAdsDisplayer()
             let mockSecureStorageDelegate =  MockMiniAppSecureStorage()
+            let mockMiniAppManageInterface = MockManageDelegateInterface()
             let mockMiniAppTitle = "Mini App"
 
             let scriptMessageHandler = MiniAppScriptMessageHandler(
@@ -22,6 +23,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                 hostAppMessageDelegate: mockMessageInterface,
                 adsDisplayer: mockAdsDelegate,
                 secureStorageDelegate: mockSecureStorageDelegate,
+                miniAppManageDelegate: mockMiniAppManageInterface,
                 miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
             )
             beforeEach {
@@ -70,6 +72,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     let requestParam = RequestParameters(
@@ -89,7 +92,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         headers: nil,
                         secureStorageKey: nil,
                         secureStorageItems: nil,
-                        secureStorageKeyList: nil
+                        secureStorageKeyList: nil,
+                        closeAlertInfo: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "", id: "123", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -115,7 +119,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         headers: nil,
                         secureStorageKey: nil,
                         secureStorageItems: nil,
-                        secureStorageKeyList: nil
+                        secureStorageKeyList: nil,
+                        closeAlertInfo: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -141,7 +146,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         headers: nil,
                         secureStorageKey: nil,
                         secureStorageItems: nil,
-                        secureStorageKeyList: nil
+                        secureStorageKeyList: nil,
+                        closeAlertInfo: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getMessagingUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -167,7 +173,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         headers: nil,
                         secureStorageKey: nil,
                         secureStorageItems: nil,
-                        secureStorageKeyList: nil
+                        secureStorageKeyList: nil,
+                        closeAlertInfo: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getMauid", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -197,6 +204,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.locationAllowed = false
@@ -213,6 +221,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.locationAllowed = false
@@ -229,6 +238,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.locationAllowed = false
@@ -245,6 +255,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .deviceLocation, status: .allowed)
@@ -333,6 +344,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.customPermissions = true
@@ -351,6 +363,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id,
                         miniAppTitle: mockMiniAppTitle
                     )
@@ -369,6 +382,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id,
                         miniAppTitle: mockMiniAppTitle
                     )
@@ -388,6 +402,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
@@ -406,6 +421,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .allowed)
@@ -423,6 +439,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .userName, status: .denied)
@@ -441,6 +458,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .profilePhoto, status: .allowed)
@@ -457,6 +475,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .profilePhoto, status: .allowed)
@@ -472,6 +491,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .profilePhoto, status: .denied)
@@ -489,6 +509,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: "Mini App"
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .contactsList, status: .allowed)
@@ -504,6 +525,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                        hostAppMessageDelegate: mockMessageInterface,
                        adsDisplayer: mockAdsDelegate,
                        secureStorageDelegate: mockSecureStorageDelegate,
+                       miniAppManageDelegate: mockMiniAppManageInterface,
                        miniAppId: mockMiniAppInfo.id, miniAppTitle: "Mini App"
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .contactsList, status: .denied)
@@ -522,6 +544,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.mockAccessToken = "MOCK_ACCESS_TOKEN"
@@ -542,6 +565,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.mockAccessToken = "MOCK_ACCESS_TOKEN"
@@ -562,6 +586,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.mockAccessToken = "MOCK_ACCESS_TOKEN"
@@ -582,6 +607,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.mockAccessToken = "MOCK_ACCESS_TOKEN"
@@ -601,6 +627,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.mockAccessToken = ""
@@ -620,6 +647,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.mockAccessToken = ""
@@ -639,6 +667,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = false
@@ -656,6 +685,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = false
@@ -673,6 +703,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = true
@@ -703,6 +734,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = false
@@ -733,6 +765,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = true
@@ -766,6 +799,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = false
@@ -824,6 +858,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = false
@@ -857,6 +892,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         hostAppMessageDelegate: mockMessageInterface,
                         adsDisplayer: mockAdsDelegate,
                         secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
                         miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                     )
                     mockMessageInterface.messageContentAllowed = false
@@ -881,6 +917,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                         )
                         mockMessageInterface.messageContentAllowed = false
@@ -928,6 +965,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                         )
                         let command = """
@@ -952,6 +990,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                         )
                         let command = """
@@ -977,6 +1016,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                         )
                         let command = """
@@ -1001,6 +1041,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                         )
                         let command = """
@@ -1031,6 +1072,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id,
                             miniAppTitle: mockMiniAppTitle
                         )
@@ -1064,6 +1106,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                         )
                         scriptMessageHandler.execKeyboardEventsCallback(with: .keyboardShown, message: "keyboard shown", navigationBarHeight: 100, screenHeight: 200, keyboardHeight: 300)
@@ -1078,6 +1121,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                             hostAppMessageDelegate: mockMessageInterface,
                             adsDisplayer: mockAdsDelegate,
                             secureStorageDelegate: mockSecureStorageDelegate,
+                            miniAppManageDelegate: mockMiniAppManageInterface,
                             miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
                         )
                         scriptMessageHandler.execKeyboardEventsCallback(with: .keyboardHidden, message: "keyboard hidden", navigationBarHeight: 100, screenHeight: 200, keyboardHeight: 300)


### PR DESCRIPTION
# Description
* Host app can use `miniAppShouldClose` in `MiniAppNavigationBarDelegate` to retrieve `CloseAlertInfo`
* Sample app changes to display Alert when MiniApp is closed

## Links
[MINI-5047](https://jira.rakuten-it.com/jira/browse/MINI-5047)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
