### PR TITLE
[MALI-1042] Save Image Activity Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Enhancement:** Added a `Wipe Secure Storages` button to Settings/QA to remove all secure storages
 - **Enhancement:** Added `GET MESSAGING UNIQUE ID` and `GET MAUID` for retrieving the ID's. (Messaging Unique ID for now will return the same as Unique ID)
 - **Feature:** Added support for Mini Apps to download Base64 `data:` URIs with the `MiniApp.downloadFile` feature.
+- **Bugfix:** Replaced UIActivityController with a custom one that overrides the `dimiss` function so only the activity will be closed.
 
 ### 4.1.0 (2022-04-11)
 

--- a/Example/Controllers/Extensions/ViewController+Activity.swift
+++ b/Example/Controllers/Extensions/ViewController+Activity.swift
@@ -1,0 +1,6 @@
+import Foundation
+import UIKit
+
+public class MiniAppActivityController: UIActivityViewController {
+    public override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {}
+}

--- a/Example/Controllers/Extensions/ViewController+MiniApp.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniApp.swift
@@ -39,7 +39,7 @@ extension ViewController: MiniAppNavigationDelegate {
             activityItem = base64Data
         }
         guard let wrappedActivityItem = activityItem else { return }
-        let activityViewController = UIActivityViewController(activityItems: [wrappedActivityItem], applicationActivities: nil)
+        let activityViewController = MiniAppActivityController(activityItems: [wrappedActivityItem], applicationActivities: nil)
         activityViewController.completionWithItemsHandler = { [weak self] (_, completed, _, _) in
             guard completed else { return }
             let controller = UIAlertController(title: "Nice", message: "Successfully shared!", preferredStyle: .alert)

--- a/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
+++ b/Example/Controllers/Extensions/ViewController+MiniAppUserInfoProtocol.swift
@@ -76,7 +76,7 @@ extension ViewController: MiniAppUserInfoDelegate {
                         completionHandler(.failure(MASDKDownloadFileError.saveTemporarilyFailed))
                         return
                     }
-                    let activityVc = UIActivityViewController(activityItems: [savedUrl], applicationActivities: nil)
+                    let activityVc = MiniAppActivityController(activityItems: [savedUrl], applicationActivities: nil)
                     self.presentedViewController?.present(activityVc, animated: true, completion: nil)
                     completionHandler(.success(fileName))
                 case .failure(let error):

--- a/MiniAppSPM/Sample SPM.xcodeproj/project.pbxproj
+++ b/MiniAppSPM/Sample SPM.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		F74AA10D283C651400087718 /* AdMobDisplayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74AA0DC283C651300087718 /* AdMobDisplayerTests.swift */; };
 		F74AA112283C65AB00087718 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = F74AA111283C65AB00087718 /* Nimble */; };
 		F74AA115283C65E300087718 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = F74AA114283C65E300087718 /* Quick */; };
+		F781DC1C284F0B010096A21A /* ViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F781DC1B284F0B010096A21A /* ViewController+Activity.swift */; };
 		F7FD91F1283B68C400F105C1 /* Base64UriHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FD91F0283B68C400F105C1 /* Base64UriHelper.swift */; };
 /* End PBXBuildFile section */
 
@@ -246,6 +247,7 @@
 		F74AA0D9283C651300087718 /* MiniAppSdkConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiniAppSdkConfigTests.swift; sourceTree = "<group>"; };
 		F74AA0DA283C651300087718 /* MiniAppKeyChainTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiniAppKeyChainTests.swift; sourceTree = "<group>"; };
 		F74AA0DC283C651300087718 /* AdMobDisplayerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdMobDisplayerTests.swift; sourceTree = "<group>"; };
+		F781DC1B284F0B010096A21A /* ViewController+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Activity.swift"; sourceTree = "<group>"; };
 		F7FD91F0283B68C400F105C1 /* Base64UriHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Base64UriHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -398,6 +400,7 @@
 				3105759F27EE213400D93B06 /* ViewController+MiniAppUserInfoProtocol.swift */,
 				310575A027EE213400D93B06 /* ViewController+MiniApp.swift */,
 				310575A127EE213400D93B06 /* ViewController+ChatDelegate.swift */,
+				F781DC1B284F0B010096A21A /* ViewController+Activity.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -759,6 +762,7 @@
 				310575ED27EE213400D93B06 /* RATNotificationCenter.swift in Sources */,
 				310575C327EE213400D93B06 /* Progress+UIViewController.swift in Sources */,
 				310575C227EE213400D93B06 /* UITextField.swift in Sources */,
+				F781DC1C284F0B010096A21A /* ViewController+Activity.swift in Sources */,
 				310575C427EE213400D93B06 /* Print+MiniApp.swift in Sources */,
 				310575CB27EE213400D93B06 /* AppDelegate.swift in Sources */,
 				310575E427EE213400D93B06 /* ViewController+ChatDelegate.swift in Sources */,

--- a/Sample.xcodeproj/project.pbxproj
+++ b/Sample.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		A1FDEAC026A141CC00E48831 /* PointsSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FDEABF26A141CC00E48831 /* PointsSettingsTableViewController.swift */; };
 		D07452312567B72A00B6E842 /* MASDKErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07452302567B72A00B6E842 /* MASDKErrorTests.swift */; };
 		D0CACE26281A68D700E39920 /* Base64UriHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CACE25281A68D700E39920 /* Base64UriHelper.swift */; };
+		F781DC21284F3F600096A21A /* ViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F781DC20284F3F600096A21A /* ViewController+Activity.swift */; };
 		F7C8804626D8974800B828C6 /* UITableView+EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7C8804526D8974800B828C6 /* UITableView+EmptyView.swift */; };
 /* End PBXBuildFile section */
 
@@ -246,6 +247,7 @@
 		A78AF8E4D879DF8FC03A7E9F /* MiniApp.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = MiniApp.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		D07452302567B72A00B6E842 /* MASDKErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MASDKErrorTests.swift; sourceTree = "<group>"; };
 		D0CACE25281A68D700E39920 /* Base64UriHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64UriHelper.swift; sourceTree = "<group>"; };
+		F781DC20284F3F600096A21A /* ViewController+Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ViewController+Activity.swift"; sourceTree = "<group>"; };
 		F7C8804526D8974800B828C6 /* UITableView+EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+EmptyView.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -465,6 +467,7 @@
 		38920AED251D9C57004C5DDD /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				F781DC20284F3F600096A21A /* ViewController+Activity.swift */,
 				38920AEF251D9C57004C5DDD /* ViewController+MiniApp.swift */,
 				38920AEE251D9C57004C5DDD /* ViewController+MiniAppMessageProtocol.swift */,
 				38D04803252CAA4400133E1D /* ViewController+MiniAppUserInfoProtocol.swift */,
@@ -753,6 +756,7 @@
 				2AE218D7269CAB1400F9D1E7 /* DeeplinkErrorViewController.swift in Sources */,
 				38480100251DB4E00079D6EB /* CustomPermissionsListViewController.swift in Sources */,
 				38920B07251D9C57004C5DDD /* DisplayController.swift in Sources */,
+				F781DC21284F3F600096A21A /* ViewController+Activity.swift in Sources */,
 				38480101251DB4E00079D6EB /* ManageCustomPermissionsViewController.swift in Sources */,
 				38920B09251D9C57004C5DDD /* FirstLaunchViewController.swift in Sources */,
 				2AE218F0269D46DA00F9D1E7 /* UITextView+MiniApp.swift in Sources */,

--- a/Sources/Classes/ui/MiniAppUI.swift
+++ b/Sources/Classes/ui/MiniAppUI.swift
@@ -111,18 +111,3 @@ internal class RealMiniAppUI {
     }
 
 }
-//
-extension UINavigationController {
-    /// When UIDocumentPicker or UIActivityController is dismissed, parent view is also getting dismissed. This seem like a bug in SDK so we are making sure
-    /// here to dismiss only once.
-    open override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        if let controller = self.presentedViewController,
-           controller.isKind(of: UIDocumentPickerViewController.self) || controller.isKind(of: UIActivityViewController.self) {
-            if !controller.isBeingDismissed {
-                super.dismiss(animated: flag, completion: completion)
-            }
-        } else {
-            super.dismiss(animated: flag, completion: completion)
-        }
-    }
-}


### PR DESCRIPTION
# Description
Saving an image results in the presented vc also to dismiss.
Replace UIActivityController with MiniAppActivityController which replaces the `dismiss` function

https://user-images.githubusercontent.com/17570451/172297520-747010de-12ba-457d-873c-c2c6010d6f96.MP4

## Links
https://jira.rakuten-it.com/jira/browse/MALI-1042

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
