### PR TITLE
Replace `print` with MiniAppLogger

### DIFF
--- a/Sources/Classes/core/Extensions/URL+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/URL+MiniApp.swift
@@ -42,7 +42,7 @@ extension URL {
         do {
             return try FileManager.default.attributesOfItem(atPath: path)
         } catch let error as NSError {
-            print("FileAttribute error: \(error)")
+            MiniAppLogger.d("FileAttribute error: \(error)")
         }
         return nil
     }

--- a/Sources/Classes/core/Extensions/URL+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/URL+MiniApp.swift
@@ -42,7 +42,7 @@ extension URL {
         do {
             return try FileManager.default.attributesOfItem(atPath: path)
         } catch let error as NSError {
-            MiniAppLogger.d("FileAttribute error: \(error)")
+            MiniAppLogger.e("FileAttribute error", error)
         }
         return nil
     }


### PR DESCRIPTION
# Description
Missed a print in the SDK replacing it with MiniAppLogger
(throws a warning in link)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
