### PR TITLE
[MALI- 1161] - Fix Preview-codes backslash issue

### DIFF
--- a/Sources/Classes/core/API/PreviewMiniappAPI.swift
+++ b/Sources/Classes/core/API/PreviewMiniappAPI.swift
@@ -16,7 +16,7 @@ internal class PreviewMiniappAPI {
 
     private func getMiniAppInfo(using token: String) -> URL? {
         let previewToken = token.replacingOccurrences(of: "\\\\/", with: "", options: .regularExpression, range: nil)
-        guard var baseURL = environment.baseUrl else {
+        guard let baseURL = environment.baseUrl else {
             return nil
         }
         return baseURL.appendingPathComponent("host/\(environment.projectId)/preview-codes/\(previewToken)")

--- a/Sources/Classes/core/API/PreviewMiniappAPI.swift
+++ b/Sources/Classes/core/API/PreviewMiniappAPI.swift
@@ -15,9 +15,10 @@ internal class PreviewMiniappAPI {
     }
 
     private func getMiniAppInfo(using token: String) -> URL? {
-        guard let baseURL = environment.baseUrl else {
+        let previewToken = token.replacingOccurrences(of: "\\\\/", with: "", options: .regularExpression, range: nil)
+        guard var baseURL = environment.baseUrl else {
             return nil
         }
-        return baseURL.appendingPathComponent("host/\(environment.projectId)/preview-codes/\(token)")
+        return baseURL.appendingPathComponent("host/\(environment.projectId)/preview-codes/\(previewToken)")
     }
 }


### PR DESCRIPTION
# Description
QR Code feature is not working in PROD and testflight builds. Pretty strange that it happens only in Prod builds.
Removing any backslash and \\ in preview token that could break the preview feature in the PROD. We suspect that this could be the reason for the issue.
Preview tokens adds a extra / sometimes, this could help avoid the situation.

## Links
[MALI-1161](https://jira.rakuten-it.com/jira/browse/MALI-1161)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
