### PR TITLE
[MINI-5519] Include version in getMiniAppInfo

### DIFF
--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -189,7 +189,7 @@ class MiniAppViewHandler: NSObject {
             return
         }
 
-        getMiniAppInfo(miniAppId: appId) { [weak self] result in
+        getMiniAppInfo(miniAppId: appId, miniAppVersion: version ?? "") { [weak self] result in
             guard let self = self else {
                 completion(.failure(.unknownError(domain: "", code: 0, description: "miniapp download failed")))
                 return


### PR DESCRIPTION
# Description
`MiniAppViewHandler` did not include the version when getting `MiniAppInfo`

## Links
https://jira.rakuten-it.com/jira/browse/MINI-5519

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
