### PR TITLE
[MINI-5485, MINI-5695] Missing events for open / close permission settings

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -147,6 +147,20 @@ struct MiniAppSingleView: View {
                 ()
             }
         }
+        .onChange(of: permissionRequest, perform: { request in
+            if let request = request {
+                sendPauseMiniApp(miniAppId: request.info.id, version: request.info.version.versionId)
+            } else {
+                sendResumeMiniApp(miniAppId: viewModel.miniAppId, version: viewModel.miniAppVersion)
+            }
+        })
+        .onChange(of: isSharePreviewPresented, perform: { isPresented in
+            if isPresented {
+                sendPauseMiniApp(miniAppId: viewModel.miniAppId, version: viewModel.miniAppVersion)
+            } else {
+                sendResumeMiniApp(miniAppId: viewModel.miniAppId, version: viewModel.miniAppVersion)
+            }
+        })
         .trackPage(pageName: pageName)
     }
 
@@ -179,9 +193,13 @@ struct MiniAppSingleView_Previews: PreviewProvider {
     }
 }
 
-struct MiniAppPermissionRequest: Identifiable {
+struct MiniAppPermissionRequest: Identifiable, Equatable {
     let id = UUID()
     let sdkConfig: MiniAppSdkConfig
     let info: MiniAppInfo
     let manifest: MiniAppManifest
+
+    static func == (lhs: MiniAppPermissionRequest, rhs: MiniAppPermissionRequest) -> Bool {
+        return lhs.id == rhs.id
+    }
 }

--- a/Example/Controllers/SwiftUI/Helper/View+Events.swift
+++ b/Example/Controllers/SwiftUI/Helper/View+Events.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftUI
+import MiniApp
+
+extension View {
+    func sendPauseMiniApp(miniAppId: String, version: String? = nil) {
+        NotificationCenter.default.sendCustomEvent(
+            MiniAppEvent.Event(
+                miniAppId: miniAppId,
+                miniAppVersion: version ?? "",
+                type: .pause,
+                comment: "MiniApp view will disappear"
+            )
+        )
+    }
+    func sendResumeMiniApp(miniAppId: String, version: String? = nil) {
+        NotificationCenter.default.sendCustomEvent(
+            MiniAppEvent.Event(
+                miniAppId: miniAppId,
+                miniAppVersion: version ?? "",
+                type: .resume,
+                comment: "MiniApp view will appear"
+            )
+        )
+    }
+}

--- a/MiniAppSPM/Sample SPM.xcodeproj/project.pbxproj
+++ b/MiniAppSPM/Sample SPM.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		3105761627EE387800D93B06 /* Config-test-debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3105761127EE387800D93B06 /* Config-test-debug.xcconfig */; };
 		31A7169B27EF0800003770E9 /* MiniApp in Frameworks */ = {isa = PBXBuildFile; productRef = 31A7169A27EF0800003770E9 /* MiniApp */; };
 		31A7169D27EF0800003770E9 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 31A7169C27EF0800003770E9 /* AppCenterCrashes */; };
+		A13198032918A67E00B839E8 /* View+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13198022918A67E00B839E8 /* View+Events.swift */; };
+		A13198052918A69500B839E8 /* AccessabilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13198042918A69500B839E8 /* AccessabilityIdentifiers.swift */; };
 		A1B4E6E428E6C7E7009ED66F /* SampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B4E6E328E6C7E7009ED66F /* SampleApp.swift */; };
 		F7370A8A287BD21C00090032 /* MiniAppSecureStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7370A89287BD21C00090032 /* MiniAppSecureStorageTests.swift */; };
 		F73D0E9328D41205002437DC /* MiniAppFeatureListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73D0E9228D41205002437DC /* MiniAppFeatureListCell.swift */; };
@@ -173,6 +175,8 @@
 		3105761027EE387800D93B06 /* Config-common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Config-common.xcconfig"; sourceTree = "<group>"; };
 		3105761127EE387800D93B06 /* Config-test-debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Config-test-debug.xcconfig"; sourceTree = "<group>"; };
 		31A7169827EF0428003770E9 /* MiniApp */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MiniApp; path = ..; sourceTree = "<group>"; };
+		A13198022918A67E00B839E8 /* View+Events.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+Events.swift"; sourceTree = "<group>"; };
+		A13198042918A69500B839E8 /* AccessabilityIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessabilityIdentifiers.swift; sourceTree = "<group>"; };
 		A1B4E6E328E6C7E7009ED66F /* SampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleApp.swift; sourceTree = "<group>"; };
 		F7370A89287BD21C00090032 /* MiniAppSecureStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniAppSecureStorageTests.swift; sourceTree = "<group>"; };
 		F73D0E9228D41205002437DC /* MiniAppFeatureListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniAppFeatureListCell.swift; sourceTree = "<group>"; };
@@ -613,15 +617,17 @@
 		F75D49D728C5B83A0053F74E /* Helper */ = {
 			isa = PBXGroup;
 			children = (
-				F75D49D828C5B83A0053F74E /* RemoteImageView.swift */,
+				A13198042918A69500B839E8 /* AccessabilityIdentifiers.swift */,
+				F75D4A1028CAF7750053F74E /* Binding+Optional.swift */,
+				F77F61AE28E54D1E00F55818 /* CloseButton.swift */,
+				F75D4A0828C9D3B00053F74E /* ImagePicker.swift */,
+				F75D4A1428CEE2F90053F74E /* KeyboardNotificationHelper.swift */,
+				F75D4A1228CEDE5C0053F74E /* LocationManager.swift */,
 				F7C0BCEF28CEF3AE00C56C2E /* MiniAppViewMessageDelegator.swift */,
 				F7C0BCED28CEF09700C56C2E /* MiniAppViewNavigationDelegator.swift */,
+				F75D49D828C5B83A0053F74E /* RemoteImageView.swift */,
 				F75D4A0A28CAF2A90053F74E /* TextFieldStyle+MiniApp.swift */,
-				F75D4A1028CAF7750053F74E /* Binding+Optional.swift */,
-				F75D4A0828C9D3B00053F74E /* ImagePicker.swift */,
-				F75D4A1228CEDE5C0053F74E /* LocationManager.swift */,
-				F75D4A1428CEE2F90053F74E /* KeyboardNotificationHelper.swift */,
-				F77F61AE28E54D1E00F55818 /* CloseButton.swift */,
+				A13198022918A67E00B839E8 /* View+Events.swift */,
 				F758977028FE789300D04B62 /* View+Tracking.swift */,
 			);
 			path = Helper;
@@ -848,12 +854,14 @@
 				F77F61BB28ED3B9900F55818 /* ContentView.swift in Sources */,
 				F73D0E9328D41205002437DC /* MiniAppFeatureListCell.swift in Sources */,
 				F75D49F228C5B83A0053F74E /* MiniAppStore.swift in Sources */,
+				A13198052918A69500B839E8 /* AccessabilityIdentifiers.swift in Sources */,
 				F75D4A0728C9CADE0053F74E /* MiniAppSettingsView+Config.swift in Sources */,
 				F75D49ED28C5B83A0053F74E /* MiniAppListRowCell.swift in Sources */,
 				F75D49F028C5B83A0053F74E /* RemoteImageView.swift in Sources */,
 				F7C0BCF028CEF3AE00C56C2E /* MiniAppViewMessageDelegator.swift in Sources */,
 				310575CA27EE213400D93B06 /* UserProfileModel.swift in Sources */,
 				F75D4A1128CAF7750053F74E /* Binding+Optional.swift in Sources */,
+				A13198032918A67E00B839E8 /* View+Events.swift in Sources */,
 				F77F61AF28E54D1E00F55818 /* CloseButton.swift in Sources */,
 				F75D49FD28C6F38B0053F74E /* MiniAppSettingsAccessTokenView.swift in Sources */,
 				F75D49DF28C5B83A0053F74E /* MiniAppSettingsView.swift in Sources */,

--- a/Sample.xcodeproj/project.pbxproj
+++ b/Sample.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		38FC4653244628F600BE33E0 /* MiniAppScriptMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FC4652244628F600BE33E0 /* MiniAppScriptMessageHandlerTests.swift */; };
 		6226CB7C290BCC51007DC20D /* AccessabilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6226CB7B290BCC51007DC20D /* AccessabilityIdentifiers.swift */; };
 		750191FB804B88456CA24CA7 /* MiniAppAdDisplayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75019776AEA5AACCC4BD4BF4 /* MiniAppAdDisplayerTests.swift */; };
+		A13198012918A45C00B839E8 /* View+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13198002918A45C00B839E8 /* View+Events.swift */; };
 		A13C249826A15048003ADC6D /* UserPointsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13C249726A15048003ADC6D /* UserPointsModel.swift */; };
 		A15CC6B828ED2CB4009B328D /* SampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15CC6B728ED2CB4009B328D /* SampleApp.swift */; };
 		A15CC6BA28ED2CC5009B328D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15CC6B928ED2CC5009B328D /* SceneDelegate.swift */; };
@@ -214,6 +215,7 @@
 		7501901BB0FC97CC8680E785 /* Config-test-debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Config-test-debug.xcconfig"; sourceTree = "<group>"; };
 		7501924AE42A5A88FF5CFB12 /* Config-test-release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Config-test-release.xcconfig"; sourceTree = "<group>"; };
 		75019776AEA5AACCC4BD4BF4 /* MiniAppAdDisplayerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiniAppAdDisplayerTests.swift; sourceTree = "<group>"; };
+		A13198002918A45C00B839E8 /* View+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Events.swift"; sourceTree = "<group>"; };
 		A13C249726A15048003ADC6D /* UserPointsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPointsModel.swift; sourceTree = "<group>"; };
 		A15CC6B728ED2CB4009B328D /* SampleApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleApp.swift; sourceTree = "<group>"; };
 		A15CC6B928ED2CC5009B328D /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -637,17 +639,18 @@
 			isa = PBXGroup;
 			children = (
 				6226CB7B290BCC51007DC20D /* AccessabilityIdentifiers.swift */,
+				F70DD8E128D417C3003EF1F1 /* Binding+Optional.swift */,
+				F77F61B028E54EE400F55818 /* CloseButton.swift */,
+				A15CC6DB29025B2B009B328D /* DemoAppAnalytics.swift */,
+				F70DD8E028D417C3003EF1F1 /* ImagePicker.swift */,
+				F70DD8DE28D417C3003EF1F1 /* KeyboardNotificationHelper.swift */,
+				F70DD8E228D417C3003EF1F1 /* LocationManager.swift */,
+				F70DD8DF28D417C3003EF1F1 /* MiniAppViewMessageDelegator.swift */,
+				F70DD8E328D417C3003EF1F1 /* MiniAppViewNavigationDelegator.swift */,
 				F70DD8DC28D417C3003EF1F1 /* RemoteImageView.swift */,
 				F70DD8DD28D417C3003EF1F1 /* TextFieldStyle+MiniApp.swift */,
-				F70DD8DE28D417C3003EF1F1 /* KeyboardNotificationHelper.swift */,
-				F70DD8DF28D417C3003EF1F1 /* MiniAppViewMessageDelegator.swift */,
-				F70DD8E028D417C3003EF1F1 /* ImagePicker.swift */,
-				F70DD8E128D417C3003EF1F1 /* Binding+Optional.swift */,
-				F70DD8E228D417C3003EF1F1 /* LocationManager.swift */,
-				F70DD8E328D417C3003EF1F1 /* MiniAppViewNavigationDelegator.swift */,
-				F77F61B028E54EE400F55818 /* CloseButton.swift */,
+				A13198002918A45C00B839E8 /* View+Events.swift */,
 				A15CC6CD28FE4E90009B328D /* View+Tracking.swift */,
-				A15CC6DB29025B2B009B328D /* DemoAppAnalytics.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -820,6 +823,7 @@
 				F70DD8EA28D417C4003EF1F1 /* MiniAppSettingsProfileView.swift in Sources */,
 				F70DD8E828D417C4003EF1F1 /* MiniAppSettingsView+Config.swift in Sources */,
 				F70DD8F628D417C4003EF1F1 /* MiniAppWithTermsView.swift in Sources */,
+				A13198012918A45C00B839E8 /* View+Events.swift in Sources */,
 				F70DD8EE28D417C4003EF1F1 /* MiniAppSettingsAccessTokenView.swift in Sources */,
 				F70DD90728D417C4003EF1F1 /* MiniAppViewNavigationDelegator.swift in Sources */,
 				A15CC6BA28ED2CC5009B328D /* SceneDelegate.swift in Sources */,


### PR DESCRIPTION
# Description
Add pause and resume event for permissions and share preview for MiniAppSingleView

**Video**
https://rak.box.com/s/esfpcslakehe4imd7d1j7wnflt312q4v

## Links
https://jira.rakuten-it.com/jira/browse/MINI-5485

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
