### PR TITLE
[MINI-5615] Set max storage limit keyboard to number pad and dismiss button for iOS 15

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsQAView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsQAView.swift
@@ -54,6 +54,7 @@ struct MiniAppSettingsQAView: View {
                             trackButtonTap(pageName: pageName, buttonTitle: "Save Max Storage Limit")
                             switch viewModel.setSecureStorageLimit(maxSize: miniAppMaxStorageSize) {
                             case let .success(formattedString):
+                                dismissKeyboard()
                                 miniAppMaxStorageSize = formattedString
                                 alertMessage = MiniAppAlertMessage(title: "Success", message: "Saved Max Storage Size Limit to \(formattedString) bytes.")
                             case let .failure(error):

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsQAView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsQAView.swift
@@ -49,6 +49,7 @@ struct MiniAppSettingsQAView: View {
                             .frame(height: 50)
                             .textFieldStyle(MiniAppTextFieldStyle())
                             .font(.system(size: 13))
+                            .keyboardWithCustomNumberPad()
                         Button {
                             trackButtonTap(pageName: pageName, buttonTitle: "Save Max Storage Limit")
                             switch viewModel.setSecureStorageLimit(maxSize: miniAppMaxStorageSize) {

--- a/Example/Controllers/SwiftUI/Helper/TextFieldStyle+MiniApp.swift
+++ b/Example/Controllers/SwiftUI/Helper/TextFieldStyle+MiniApp.swift
@@ -14,3 +14,37 @@ struct MiniAppTextFieldStyle: TextFieldStyle {
         )
     }
 }
+
+struct NumberPadKeyboardViewModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 15.0, *) {
+            content
+            .keyboardType(.numberPad)
+            .toolbar {
+                ToolbarItem(placement: .keyboard) {
+                    HStack {
+                        Spacer()
+                        Button("Done") {
+                            dismissKeyboard()
+                        }
+                        .foregroundColor(.blue)
+                    }
+                }
+            }
+        } else {
+            // keep default layout for iOS 14 to dismiss the keyboard
+            // can be removed after min target upgrade to iOS 15
+            content
+        }
+    }
+
+    func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+
+extension View {
+    func keyboardWithCustomNumberPad() -> some View {
+        modifier(NumberPadKeyboardViewModifier())
+    }
+}

--- a/Example/Controllers/SwiftUI/Helper/TextFieldStyle+MiniApp.swift
+++ b/Example/Controllers/SwiftUI/Helper/TextFieldStyle+MiniApp.swift
@@ -47,4 +47,8 @@ extension View {
     func keyboardWithCustomNumberPad() -> some View {
         modifier(NumberPadKeyboardViewModifier())
     }
+
+    func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
 }


### PR DESCRIPTION
# Description
Max storage limit keyboard to number pad +
Add max storage limit keyboard dismiss button for iOS 15
- keep default for iOS 14 (hence the support)

**Video**
https://rak.box.com/s/g3ry28h1n69jg4whdrkvkgxs9o3qnpet

## Links
https://jira.rakuten-it.com/jira/browse/MINI-5614

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
