### PR TITLE
[MINI-5518] MiniApps restart after permission change

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -135,8 +135,8 @@ struct MiniAppSingleView: View {
         })
         .onChange(of: didAcceptSettingsTerms, perform: { accepted in
             if accepted {
-                viewModel.load()
                 didAcceptSettingsTerms = false
+                permissionRequest = nil
             }
         })
         .onChange(of: viewModel.viewState) { state in


### PR DESCRIPTION
# Description
MiniApps restart after permission change. 
Fixing this (simply) by not reloading the MiniApp after permissions are saved.

**Video**
https://rak.box.com/s/syji0aplv1v9vjhyhs24mh98al53cudt

## Links
https://jira.rakuten-it.com/jira/browse/MINI-5518

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
