### PR TITLE
[MINI-5710] MiniApp resumed count update on closing web-view

### DIFF
--- a/Sources/Classes/core/Display/MiniAppExternalWebViewController.swift
+++ b/Sources/Classes/core/Display/MiniAppExternalWebViewController.swift
@@ -80,7 +80,7 @@ public class MiniAppExternalWebViewController: UIViewController {
     }
 
     deinit {
-        if let wView = webView, let url = wView.url {
+        if let url = currentURL {
             miniAppExternalUrlClose?(url)
         }
     }

--- a/Sources/Classes/core/Downloader/MiniAppClient.swift
+++ b/Sources/Classes/core/Downloader/MiniAppClient.swift
@@ -110,14 +110,14 @@ internal class MiniAppClient: NSObject, MiniAppClientProtocol, URLSessionDownloa
         }
         return requestDataFromServer(urlRequest: urlRequest) { [weak self] result in
             switch result {
-            case .success(let data) :
+            case .success(let data):
                 if let signature = data.httpResponse.value(forHTTPHeaderField: "Signature"), let signatureId = ResponseDecoder.decode(decodeType: ManifestResponse.self, data: data.data)?.publicKeyId {
                     MiniAppLogger.d(signature, "🖊️")
                     self?.signatures[versionId] = (signatureId, signature)
                 } else {
                     fallthrough
                 }
-            case .failure :
+            case .failure:
                 self?.signatures.removeValue(forKey: versionId)
             }
             completionHandler(result)


### PR DESCRIPTION

# Description
Issue: When External web-view is closed the MiniApp resumed count was not recorded when in flight mode.
Cause: The url parameter used to be sent in the close action call back was not available and web-view was nil.
Fix: Make use of the parameter currentURL set during the initializing of the ViewController.

## Links
https://jira.rakuten-it.com/jira/browse/MINI-5710

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
