### PR TITLE
[MINI-5697] SampleApp Unable to open any contact from settings

### DIFF
--- a/Example/Assets/en.lproj/Localizable.strings
+++ b/Example/Assets/en.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "demo.app.rat.page.name.profile"                        =   "Profile";
 "demo.app.rat.page.name.contactslist"                   =   "Contacts List";
 "demo.app.rat.page.name.contactsform"                   =   "Add Contact";
+"demo.app.rat.page.name.editcontactsform"               =   "Edit Contact";
 "demo.app.rat.page.name.permissions"                    =   "Permissions";
 "demo.app.rat.page.name.access_token"                   =   "Access Token";
 "demo.app.rat.page.name.deeplinks"                       =  "Deeplinks";

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
@@ -7,7 +7,7 @@ struct MiniAppSettingsContactsView: View {
 
     @State var contacts: [MAContact] = []
     @State var newContact: MAContact?
-    @State var editingIndex: Int? = nil
+    @State var editingIndex: Int?
 
     var body: some View {
         ZStack {
@@ -16,8 +16,8 @@ struct MiniAppSettingsContactsView: View {
                     ContactCellView(name: contact.name ?? "", contactId: contact.id, email: contact.email ?? "")
                         .onTapGesture {
                             newContact = MAContact(
-                                id: contact.id.wrappedValue ,
-                                name: contact.name.wrappedValue ?? "" ,
+                                id: contact.id.wrappedValue,
+                                name: contact.name.wrappedValue ?? "",
                                 email: contact.email.wrappedValue ?? "")
                             editingIndex = contacts.firstIndex(of: contact.wrappedValue)
                         }
@@ -33,7 +33,7 @@ struct MiniAppSettingsContactsView: View {
                     isPresented: Binding<Bool>(get: { newContact != nil }, set: { new in if !new { newContact = nil } }),
                     isEditing: Binding<Bool>(get: {editingIndex != nil}, set: {new in if !new {editingIndex = nil}}),
                     onSave: {
-                        if let contact = newContact{
+                        if let contact = newContact {
                             if editingIndex != nil {
                                 contacts[editingIndex!] = contact
                             } else {
@@ -44,7 +44,6 @@ struct MiniAppSettingsContactsView: View {
                         }
                         viewModel.saveContactList(contacts: contacts)
                     }
-                    
                 )
             }
         })
@@ -143,10 +142,9 @@ extension MiniAppSettingsContactsView {
         }
 
         var pageName: String {
-        
             if isEditing {
                 return (NSLocalizedString("demo.app.rat.page.name.editcontactsform", comment: ""))
-            }else{
+            } else {
                 return (NSLocalizedString("demo.app.rat.page.name.contactsform", comment: ""))
             }
         }

--- a/Sources/Classes/core/Downloader/MiniAppClient.swift
+++ b/Sources/Classes/core/Downloader/MiniAppClient.swift
@@ -110,14 +110,14 @@ internal class MiniAppClient: NSObject, MiniAppClientProtocol, URLSessionDownloa
         }
         return requestDataFromServer(urlRequest: urlRequest) { [weak self] result in
             switch result {
-            case .success(let data) :
+            case .success(let data):
                 if let signature = data.httpResponse.value(forHTTPHeaderField: "Signature"), let signatureId = ResponseDecoder.decode(decodeType: ManifestResponse.self, data: data.data)?.publicKeyId {
                     MiniAppLogger.d(signature, "🖊️")
                     self?.signatures[versionId] = (signatureId, signature)
                 } else {
                     fallthrough
                 }
-            case .failure :
+            case .failure:
                 self?.signatures.removeValue(forKey: versionId)
             }
             completionHandler(result)


### PR DESCRIPTION
# Description
Issue: Unable to open any contact from settings and edit the contact details.
Cause: onTapGesture handler was missing for the List view cells in new SwiftUI implementation
Fix: Added onTapGesture for the Contacts List cell, On tap the edit contact will be presented and can edit the contact and save it.

## Links
https://jira.rakuten-it.com/jira/browse/MINI-5697
Fix Demo: https://rak.box.com/s/b75zt50q5fltqmhxi3edqceykhmwy7zl
PR comments implementation demo : https://rak.box.com/s/bpbqycag0yvefuhr6csdqxrj4vqmhmax

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
