### PR TITLE
[MINI-5762] [iOS-Fix] Set auth token by default

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsViewModel.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsViewModel.swift
@@ -77,6 +77,9 @@ class MiniAppSettingsViewModel: ObservableObject {
                     }
                 }
             }
+            if self.saveTokenDetails(accessToken: "ACCESS_TOKEN", date: Date()) {
+                print("AccessToken is now set to default value \"ACCESS_TOKEN\"")
+            }
         }
     }
 


### PR DESCRIPTION
# Description
Issue: AuthToken was not set and error was shown on authentication in JS sample app.
Cause: Default auth token was not saved on saving the configurations in settings page.
Fix: Saving the Auth token with default value "ACCESS_TOKEN", on saving the configurations in settings viewmodel.

## Links
[MINI-5762](https://jira.rakuten-it.com/jira/browse/MINI-5762)
[Fix-Demo video](https://rak.box.com/s/9ujv7vxdf0bib5hrc9qy3riuepb34gdt)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
