### PR TITLE
[MINI-5833] [Universal Bridge] Keyboard overlapping with the "Send Data to Mini App" button in QA settings

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Settings/Features/UniversalBridgeView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/UniversalBridgeView.swift
@@ -10,7 +10,7 @@ struct UniversalBridgeView: View {
         VStack {
             TextEditor(text: $textToSend)
                 .padding()
-                .frame(width : 300.0, height : 200)
+                .frame(width: 300.0, height: 200)
                 .overlay(
                     RoundedRectangle(cornerRadius: 5)
                         .stroke(Color.red, lineWidth: 1)

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/UniversalBridgeView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/UniversalBridgeView.swift
@@ -9,9 +9,15 @@ struct UniversalBridgeView: View {
     var body: some View {
         VStack {
             TextEditor(text: $textToSend)
-                .lineLimit(15)
-                .frame(width: 300, height: 400, alignment: .top)
+                .padding()
+                .frame(width : 300.0, height : 200)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color.red, lineWidth: 1)
+                ).keyboardType(.alphabet)
+                .padding()
             Button {
+                dismissKeyboard()
                 sendDataStringToMiniApp(textString: $textToSend.wrappedValue)
             } label: {
                 Text("Send Data to MiniApp")
@@ -19,6 +25,9 @@ struct UniversalBridgeView: View {
         }
         .navigationTitle(pageName)
         .trackPage(pageName: pageName)
+        .onTapGesture {
+            dismissKeyboard()
+        }
     }
 
     func sendDataStringToMiniApp(textString str: String) {


### PR DESCRIPTION
# Description
* Issue: "Send Data to MiniApp" button is not visible.

* Cause: The keyboard overlaps the send button, hence we cannot send the edited text to the MiniApp.

* Fix: "Send Data to MiniApp" button should be visible in order to send the edited text message. Also on tapping the text field the keyboard will be dismissed now.

## Links
[MINI-5833](https://jira.rakuten-it.com/jira/browse/MINI-5833)
[Fix Demo](https://rak.box.com/s/2dizf8pvdawhkth40ksz4rxj0x5qir8u)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
