### PR TITLE
[MINI-5826] Update Demo app Settings to support multiple emails for contacts

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
@@ -30,7 +30,7 @@ struct MiniAppSettingsContactsView: View {
                 ContactFormView(
                     contactData: Binding<MAContact>(get: { contact }, set: {new in editContact = new }),
                     isEditing: Binding<Bool>(get: { index(for: contact) != nil }, set: { _ in }),
-                    allEmailList: Binding<[String]>(get: {contact.allEmailList!}, set: {new in editContact?.allEmailList = new}),
+                    allEmailList: Binding<[String]>(get: { contact.allEmailList ?? [""] }, set: {new in editContact?.allEmailList = new}),
                     onSave: {
                         if let index = index(for: contact) {
                             contacts[index] = contact
@@ -101,8 +101,8 @@ extension MiniAppSettingsContactsView {
                     Text("Contact ID: \(contactId)")
                         .lineLimit(1)
                     Text("E-Mail address: \(email)")
-                    ForEach(allEmails.indices, id: \.self) { index in
-                        Text("Email \(index + 1): \(allEmails[index])")
+                    if !allEmails.isEmpty && allEmails.first != "" {
+                        Text("Email List: \(allEmails.map { String($0) }.joined(separator: ", "))")
                     }
                 }
                 .font(.system(size: 13))
@@ -130,7 +130,7 @@ extension MiniAppSettingsContactsView {
                     .keyboardType(.emailAddress)
                 ForEach(allEmailList.indices, id: \.self) { index in
                     HStack {
-                        TextField("Email \(index + 1)", text: $allEmailList[index])
+                        TextField("Email Address (Optional) \(index + 1)", text: $allEmailList[index])
                             .keyboardType(.emailAddress)
                         Button {
                             allEmailList.remove(at: index)
@@ -138,7 +138,6 @@ extension MiniAppSettingsContactsView {
                             Image(systemName: "at.badge.minus")
                                 .foregroundColor(Color.red)
                         }
-
                     }
                 }
                 HStack {

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
@@ -16,7 +16,7 @@ struct MiniAppSettingsContactsView: View {
                         name: contact.name ?? "",
                         contactId: contact.id,
                         email: contact.email ?? "",
-                        allEmails: contact.allEmailList ?? [""]
+                        allEmails: contact.allEmailList ?? []
                     )
                     .onTapGesture {
                         guard let index = index(for: contact.wrappedValue) else { return }
@@ -30,7 +30,7 @@ struct MiniAppSettingsContactsView: View {
                 ContactFormView(
                     contactData: Binding<MAContact>(get: { contact }, set: {new in editContact = new }),
                     isEditing: Binding<Bool>(get: { index(for: contact) != nil }, set: { _ in }),
-                    allEmails: Binding<[String]>(get: { contact.allEmailList ?? [""] }, set: {new in editContact?.allEmailList = new}),
+                    allEmails: Binding<[String]>(get: { contact.allEmailList ?? [] }, set: {new in editContact?.allEmailList = new}),
                     onSave: {
                         if let index = index(for: contact) {
                             contacts[index] = removeEmptyEmailStrings(for: contact)
@@ -71,11 +71,7 @@ struct MiniAppSettingsContactsView: View {
     func removeEmptyEmailStrings(for contact: MAContact) -> MAContact {
         var newContact = contact
         if newContact.allEmailList != nil {
-            if newContact.allEmailList?.first ?? "" == "" {
-                newContact.allEmailList = nil
-            } else {
-                newContact.allEmailList = newContact.allEmailList?.filter { $0 != "" }
-            }
+            newContact.allEmailList = newContact.allEmailList?.filter { $0 != "" }
             return newContact
         } else {
             return newContact

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
@@ -232,12 +232,8 @@ extension MiniAppSettingsContactsView {
 
         func validateContactinfo() -> Bool {
             var isEmailListValid = true
-            for emailStr in allEmails {
-                if emailStr == "" {
-                    isEmailListValid = true
-                } else {
-                    isEmailListValid = emailStr.isValidEmail()
-                }
+            for emailStr in allEmails where !emailStr.isValueEmpty() {
+                isEmailListValid = emailStr.isValidEmail()
             }
             return (!(contactData.name ?? "").isValueEmpty() && !contactData.id.isValueEmpty() && (contactData.email ?? "").isValidEmail() && isEmailListValid)
         }

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsContactsView.swift
@@ -116,7 +116,7 @@ extension MiniAppSettingsContactsView {
         @Binding var contactData: MAContact
         @Binding var isEditing: Bool
         @State private var isContactInfoValid: Bool = false
-        @Binding var allEmailList:[String]
+        @Binding var allEmailList: [String]
 
         var onSave: () -> Void
 
@@ -128,23 +128,24 @@ extension MiniAppSettingsContactsView {
                 TextField("Contact Id", text: $contactData.id)
                 TextField("Email", text: $contactData.email ?? "")
                     .keyboardType(.emailAddress)
-                ForEach(allEmailList.indices, id: \.self){ index in
-                    HStack{
+                ForEach(allEmailList.indices, id: \.self) { index in
+                    HStack {
                         TextField("Email \(index + 1)", text: $allEmailList[index])
                             .keyboardType(.emailAddress)
-                        Button(action: {
+                        Button {
                             allEmailList.remove(at: index)
-                        }) {
+                        } label: {
                             Image(systemName: "at.badge.minus")
                                 .foregroundColor(Color.red)
                         }
+
                     }
                 }
-                HStack{
+                HStack {
                     Spacer()
-                    Button(action: {
+                    Button {
                         allEmailList.append("")
-                    }) {
+                    } label: {
                         Image(systemName: "at.badge.plus")
                             .foregroundColor(Color.red)
                     }
@@ -203,7 +204,7 @@ extension MiniAppSettingsContactsView {
                 return errorMessage
             }
 
-            for (idx,emailId) in allEmails.enumerated() {
+            for (idx, emailId) in allEmails.enumerated() {
                 if !emailId.isValueEmpty() {
                     if !emailId.isValidEmail() {
                         errorMessage += "Email \(idx + 1) is invalid.\n"
@@ -219,10 +220,11 @@ extension MiniAppSettingsContactsView {
 
         func validateContactinfo() -> Bool {
             var isEmailListValid = true
-            for (_,emailId) in contactData.allEmailList!.enumerated() {
-                if !emailId.isValidEmail() {
-                    isEmailListValid = false
-                }
+            guard let emailList = contactData.allEmailList else {
+                return (!(contactData.name ?? "").isValueEmpty() && !contactData.id.isValueEmpty() && (contactData.email ?? "").isValidEmail() && isEmailListValid)
+            }
+            for emailId in emailList where !emailId.isValidEmail() {
+                isEmailListValid = false
             }
             return (!(contactData.name ?? "").isValueEmpty() && !contactData.id.isValueEmpty() && (contactData.email ?? "").isValidEmail() && isEmailListValid)
         }

--- a/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsViewModel.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsViewModel.swift
@@ -153,7 +153,7 @@ class MiniAppSettingsViewModel: ObservableObject {
 
     func createRandomContact() -> MAContact {
         let fakeName = MiniAppStore.randomFakeName()
-        return MAContact(id: UUID().uuidString, name: fakeName, email: MiniAppStore.fakeMail(with: fakeName), allEmailList: MiniAppStore.fakeMailList(with: fakeName))
+        return MAContact(id: UUID().uuidString, name: fakeName, email: MiniAppStore.fakeMail(with: fakeName))
     }
 
     // MARK: - Access Token

--- a/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
+++ b/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
@@ -46,7 +46,7 @@ class MiniAppStore: ObservableObject {
         // contacts
         let randomList: [MAContact] = (0..<10).map({ _ in
             let fakeName = Self.randomFakeName()
-            return MAContact(id: UUID().uuidString, name: fakeName, email: Self.fakeMail(with: fakeName), allEmailList: Self.fakeMailList(with: fakeName))
+            return MAContact(id: UUID().uuidString, name: fakeName, email: Self.fakeMail(with: fakeName))
         })
         updateContactList(list: randomList)
 
@@ -159,15 +159,9 @@ class MiniAppStore: ObservableObject {
         return lastNameList.randomElement()!
     }
 
-    class func fakeMailList(with name: String?) -> [String] {
-        var allEmails: [String] = []
-        allEmails.append(name != nil ? name!.replacingOccurrences(of: " ", with: ".", options: .literal, range: nil).lowercased() + "@example1.com" : "")
-        return allEmails
-    }
-
     func createRandomContact() -> MAContact {
         let fakeName = Self.randomFakeName()
-        return MAContact(id: UUID().uuidString, name: fakeName, email: Self.fakeMail(with: fakeName), allEmailList: Self.fakeMailList(with: fakeName))
+        return MAContact(id: UUID().uuidString, name: fakeName, email: Self.fakeMail(with: fakeName))
     }
 
     func getMiniAppPreviewInfo(previewToken: String) async throws -> MiniAppInfo? {

--- a/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
+++ b/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
@@ -161,9 +161,7 @@ class MiniAppStore: ObservableObject {
 
     class func fakeMailList(with name: String?) -> [String] {
         var allEmails: [String] = []
-        for index in 1...3 {
-            allEmails.append(name != nil ? name!.replacingOccurrences(of: " ", with: ".", options: .literal, range: nil).lowercased() + "@example\(index).com" : "")
-        }
+        allEmails.append(name != nil ? name!.replacingOccurrences(of: " ", with: ".", options: .literal, range: nil).lowercased() + "@example1.com" : "")
         return allEmails
     }
 

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -413,7 +413,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
             id: "contact_id",
             name: MiniAppStore.randomFakeName(),
             email: MiniAppStore.fakeMail(with: MiniAppStore.randomFakeName()),
-            allEmailList: MiniAppStore.fakeMailList(with: MiniAppStore.randomFakeName())
+            allEmailList: ["test@test.com"]
         )
     ]
     var messageContentAllowed: Bool = false

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -413,7 +413,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
             id: "contact_id",
             name: MiniAppStore.randomFakeName(),
             email: MiniAppStore.fakeMail(with: MiniAppStore.randomFakeName()),
-            allEmailList: ["test@test.com"]
+            allEmailList: [MiniAppStore.fakeMail(with: MiniAppStore.randomFakeName()),MiniAppStore.fakeMail(with: MiniAppStore.randomFakeName()),MiniAppStore.fakeMail(with: MiniAppStore.randomFakeName())]
         )
     ]
     var messageContentAllowed: Bool = false


### PR DESCRIPTION
# Description
Update our Demo app to show that we can support multiple emails for contacts.
Settings>Contacts
Now contact list shows the additional email ids.
Now on create new contact will add one additional email id to allEmailList.
User can add the new email id to the allEmailList when creating new contact or editing contact.
User can delete the additional email ids in edit screen.

## Links
[MINI-5826](https://jira.rakuten-it.com/jira/browse/MINI-5826)
[Demo Video on Box](https://rak.box.com/s/jds69cb6xkvsi7eb3t69qbt81pwcgbud)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
