### PR TITLE
[MINI-5845] Support closing a MiniApp programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.1.0 (xxxx-xx-xx)
 **SDK**
 - **Update:** Added `allEmailList` field in `MAContact` to support multiple emails of a specific contact.
+- **Feature:** New `MiniAppMessageDelegate` interface method `func closeMiniApp(withConfirmation: , completionHandler:)` to handle the close miniapp action from MinApps.
 - **Feature:** Universal Bridge support for receiving the Json or string content from the MiniApp to host app. 
 - **Feature:** Added new public protocol `UniversalBridgeDelegate` which is confirmed by `MiniAppMessageDelegate`, further added public interface `sendJsonToHostApp(info:, completionHandler:) -> Void)` in `UniversalBridgeDelegate` which can be implemented in host app to receive the string content from mini app and use in host app through Universal Bridge.
 <details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 5.1.0 (xxxx-xx-xx)
 **SDK**
 - **Update:** Added `allEmailList` field in `MAContact` to support multiple emails of a specific contact.
-- **Feature:** New `MiniAppMessageDelegate` interface method `func closeMiniApp(withConfirmation: , completionHandler:)` to handle the close miniapp action from MinApps.
+- **Feature:** Added a new optional interface `func closeMiniApp(withConfirmation: , completionHandler:)` in `MiniAppMessageDelegate` to support the close mini-app action from MinApps.
 - **Feature:** Universal Bridge support for receiving the Json or string content from the MiniApp to host app. 
 - **Feature:** Added new public protocol `UniversalBridgeDelegate` which is confirmed by `MiniAppMessageDelegate`, further added public interface `sendJsonToHostApp(info:, completionHandler:) -> Void)` in `UniversalBridgeDelegate` which can be implemented in host app to receive the string content from mini app and use in host app through Universal Bridge.
 <details>

--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -168,6 +168,16 @@ struct MiniAppSingleView: View {
                 sendResumeMiniApp(miniAppId: viewModel.miniAppId, version: viewModel.miniAppVersion)
             }
         })
+        .onChange(of: viewModel.closeWithConfirmation, perform: { withConfirmation in
+            if withConfirmation {
+                closeAlertMessage = MiniAppAlertMessage(
+                    title: "Close Miniapp",
+                    message: "Are you sure, you want to close this MiniApp?"
+                )
+            } else {
+                presentationMode.wrappedValue.dismiss()
+            }
+        })
         .trackPage(pageName: pageName)
     }
 

--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -67,7 +67,9 @@ struct MiniAppSingleView: View {
                         primaryButton: .default(Text("Ok"), action: {
                             presentationMode.wrappedValue.dismiss()
                         }),
-                        secondaryButton: .cancel(Text("Cancel"))
+                        secondaryButton: .cancel(Text("Cancel"), action: {
+                            viewModel.shouldCloseMiniApp.send(false)
+                        })
                     )
                 }
             }
@@ -168,14 +170,16 @@ struct MiniAppSingleView: View {
                 sendResumeMiniApp(miniAppId: viewModel.miniAppId, version: viewModel.miniAppVersion)
             }
         })
-        .onChange(of: viewModel.closeWithConfirmation, perform: { withConfirmation in
-            if withConfirmation {
-                closeAlertMessage = MiniAppAlertMessage(
-                    title: "Close Miniapp",
-                    message: "Are you sure, you want to close this MiniApp?"
-                )
-            } else {
-                presentationMode.wrappedValue.dismiss()
+        .onChange(of: viewModel.shouldCloseMiniApp.value, perform: { newValue in
+            if newValue {
+                if viewModel.closeWithConfirmation {
+                    closeAlertMessage = MiniAppAlertMessage(
+                        title: "Close Miniapp",
+                        message: "Are you sure, you want to close this MiniApp?"
+                    )
+                } else {
+                    presentationMode.wrappedValue.dismiss()
+                }
             }
         })
         .trackPage(pageName: pageName)

--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -173,10 +173,14 @@ struct MiniAppSingleView: View {
         .onChange(of: viewModel.shouldCloseMiniApp.value, perform: { newValue in
             if newValue {
                 if viewModel.closeWithConfirmation {
-                    closeAlertMessage = MiniAppAlertMessage(
-                        title: "Close Miniapp",
-                        message: "Are you sure, you want to close this MiniApp?"
-                    )
+                    if let closeInfo = handler.closeAlertInfo?(), closeInfo.shouldDisplay ?? true {
+                        closeAlertMessage = MiniAppAlertMessage(
+                            title: closeInfo.title ?? "",
+                            message: closeInfo.description ?? ""
+                        )
+                    } else {
+                        presentationMode.wrappedValue.dismiss()
+                    }
                 } else {
                     presentationMode.wrappedValue.dismiss()
                 }

--- a/Example/Controllers/SwiftUI/Features/Terms/MiniAppWithTermsViewModel.swift
+++ b/Example/Controllers/SwiftUI/Features/Terms/MiniAppWithTermsViewModel.swift
@@ -20,6 +20,8 @@ class MiniAppWithTermsViewModel: ObservableObject {
     var showMessageAlert: CurrentValueSubject<Bool, Never> = .init(false)
     var showJsonString: String?
 
+    @Published var closeWithConfirmation: Bool = false
+
     @Published var canGoBack: Bool = false
     @Published var canGoForward: Bool = false
 
@@ -57,6 +59,9 @@ class MiniAppWithTermsViewModel: ObservableObject {
             delegator.onSendJsonToHostApp = { string in
                 self.showMessageAlert.send(true)
                 self.showJsonString = string
+            }
+            delegator.onShoudCloseMiniApp = { confirmation in
+                self.closeWithConfirmation = confirmation
             }
         }
 

--- a/Example/Controllers/SwiftUI/Features/Terms/MiniAppWithTermsViewModel.swift
+++ b/Example/Controllers/SwiftUI/Features/Terms/MiniAppWithTermsViewModel.swift
@@ -20,6 +20,8 @@ class MiniAppWithTermsViewModel: ObservableObject {
     var showMessageAlert: CurrentValueSubject<Bool, Never> = .init(false)
     var showJsonString: String?
 
+    var shouldCloseMiniApp: CurrentValueSubject<Bool, Never> = .init(false)
+
     @Published var closeWithConfirmation: Bool = false
 
     @Published var canGoBack: Bool = false
@@ -62,6 +64,7 @@ class MiniAppWithTermsViewModel: ObservableObject {
             }
             delegator.onShoudCloseMiniApp = { confirmation in
                 self.closeWithConfirmation = confirmation
+                self.shouldCloseMiniApp.send(true)
             }
         }
 

--- a/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
+++ b/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
@@ -16,6 +16,7 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
     var onSendMessage: (() -> Void)?
 
     var onSendJsonToHostApp: ((String) -> Void)?
+    var onShoudCloseMiniApp: ((Bool) -> Void)?
 
     init(miniAppId: String = "", miniAppVersion: String? = nil) {
         self.miniAppId = miniAppId
@@ -177,6 +178,10 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
     func sendJsonToHostApp(info: String, completionHandler: @escaping (Result<MASDKProtocolResponse, UniversalBridgeError>) -> Void) {
         onSendJsonToHostApp?(info)
         completionHandler(.success(.success))
+    }
+
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool,MASDKError>) -> Void) {
+        onShoudCloseMiniApp?(withConfirmation)
     }
 }
 

--- a/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
+++ b/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
@@ -180,7 +180,7 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
         completionHandler(.success(.success))
     }
 
-    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool,MASDKError>) -> Void) {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
         onShoudCloseMiniApp?(withConfirmation)
     }
 }

--- a/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
+++ b/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
@@ -180,7 +180,7 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
         completionHandler(.success(.success))
     }
 
-    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MiniAppJavaScriptError>) -> Void) {
         onShoudCloseMiniApp?(withConfirmation)
     }
 }

--- a/Sources/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -28,6 +28,7 @@ enum MiniAppJSActionCommand: String {
     case getSecureStorageSize
     case setCloseAlert
     case sendJsonToHostapp
+    case miniAppShouldClose
 }
 
 enum JavaScriptExecResult: String {

--- a/Sources/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppJavaScriptEnumerations.swift
@@ -28,7 +28,7 @@ enum MiniAppJSActionCommand: String {
     case getSecureStorageSize
     case setCloseAlert
     case sendJsonToHostapp
-    case miniAppShouldClose
+    case closeMiniApp
 }
 
 enum JavaScriptExecResult: String {

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -124,6 +124,8 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             setMiniAppCloseAlert(with: callbackId, parameters: requestParam)
         case .sendJsonToHostapp:
             sendJsonToHostApp(requestParam: requestParam, callbackId: callbackId)
+        case .miniAppShouldClose:
+            shouldMiniAppClose(requestParam: requestParam, callbackId: callbackId)
         }
     }
 
@@ -774,6 +776,24 @@ extension MiniAppScriptMessageHandler {
             }
             self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMAJavascriptError(MiniAppErrorType.unknownError))
         }
+    }
+}
+
+//MARK: MiniApp ShouldClose Handler
+extension MiniAppScriptMessageHandler {
+    func shouldMiniAppClose(requestParam: RequestParameters?, callbackId: String) {
+        guard let requestParamValue = requestParam?.miniAppShouldClose else {
+            executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMAJavascriptError(MiniAppJavaScriptError.unexpectedMessageFormat))
+            return
+        }
+
+        self.hostAppMessageDelegate?.closeMiniApp(withConfirmation: requestParamValue.withConfirmation ?? false, completionHandler: { result in
+            switch result {
+            case .success: ()
+            case .failure(let error):
+                self.handleMASDKError(error: error, callbackId: callbackId)
+            }
+        })
     }
 }
 

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -791,7 +791,7 @@ extension MiniAppScriptMessageHandler {
             switch result {
             case .success: ()
             case .failure(let error):
-                self.handleMASDKError(error: error, callbackId: callbackId)
+                self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMAJavascriptError(error))
             }
         })
     }

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -124,8 +124,8 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             setMiniAppCloseAlert(with: callbackId, parameters: requestParam)
         case .sendJsonToHostapp:
             sendJsonToHostApp(requestParam: requestParam, callbackId: callbackId)
-        case .miniAppShouldClose:
-            shouldMiniAppClose(requestParam: requestParam, callbackId: callbackId)
+        case .closeMiniApp:
+            closeMiniApp(requestParam: requestParam, callbackId: callbackId)
         }
     }
 
@@ -781,13 +781,13 @@ extension MiniAppScriptMessageHandler {
 
 //MARK: MiniApp ShouldClose Handler
 extension MiniAppScriptMessageHandler {
-    func shouldMiniAppClose(requestParam: RequestParameters?, callbackId: String) {
-        guard let requestParamValue = requestParam?.miniAppShouldClose else {
+    func closeMiniApp(requestParam: RequestParameters?, callbackId: String) {
+        guard let requestParamValue = requestParam?.withConfirmationAlert else {
             executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMAJavascriptError(MiniAppJavaScriptError.unexpectedMessageFormat))
             return
         }
 
-        self.hostAppMessageDelegate?.closeMiniApp(withConfirmation: requestParamValue.withConfirmation ?? false, completionHandler: { result in
+        self.hostAppMessageDelegate?.closeMiniApp(withConfirmation: requestParamValue, completionHandler: { result in
             switch result {
             case .success: ()
             case .failure(let error):

--- a/Sources/Classes/core/MiniAppAnalytics.swift
+++ b/Sources/Classes/core/MiniAppAnalytics.swift
@@ -38,7 +38,7 @@ internal enum MiniAppRATEvent: String, CaseIterable {
     case getSecureStorageSize = "mini_app_secure_storage_size"
     case setCloseAlertInfo = "mini_app_close_alert_info"
     case sendJsonToHostapp = "mini_app_send_json_to_host_app"
-    case miniAppShouldClose = "mini_app_should_close_with_confirmation"
+    case closeMiniApp = "close_mini_app_with_confirmation_alert"
 
     func name() -> String {
         "mini_app_\(rawValue)"
@@ -79,7 +79,7 @@ internal enum MiniAppRATEvent: String, CaseIterable {
              .getSecureStorageSize,
              .setCloseAlertInfo,
              .sendJsonToHostapp,
-             .miniAppShouldClose:
+             .closeMiniApp:
             return .click
         }
     }
@@ -210,8 +210,8 @@ public class MiniAppAnalytics {
             return .setCloseAlertInfo
         case .sendJsonToHostapp:
             return .sendJsonToHostapp
-        case .miniAppShouldClose:
-            return .miniAppShouldClose
+        case .closeMiniApp:
+            return .closeMiniApp
         }
     }
 }

--- a/Sources/Classes/core/MiniAppAnalytics.swift
+++ b/Sources/Classes/core/MiniAppAnalytics.swift
@@ -38,6 +38,7 @@ internal enum MiniAppRATEvent: String, CaseIterable {
     case getSecureStorageSize = "mini_app_secure_storage_size"
     case setCloseAlertInfo = "mini_app_close_alert_info"
     case sendJsonToHostapp = "mini_app_send_json_to_host_app"
+    case sendJsonToMiniApp = "mini_app_send_json_to_mini_app"
     case closeMiniApp = "close_mini_app_with_confirmation_alert"
 
     func name() -> String {
@@ -79,6 +80,7 @@ internal enum MiniAppRATEvent: String, CaseIterable {
              .getSecureStorageSize,
              .setCloseAlertInfo,
              .sendJsonToHostapp,
+             .sendJsonToMiniApp,
              .closeMiniApp:
             return .click
         }

--- a/Sources/Classes/core/MiniAppAnalytics.swift
+++ b/Sources/Classes/core/MiniAppAnalytics.swift
@@ -38,6 +38,7 @@ internal enum MiniAppRATEvent: String, CaseIterable {
     case getSecureStorageSize = "mini_app_secure_storage_size"
     case setCloseAlertInfo = "mini_app_close_alert_info"
     case sendJsonToHostapp = "mini_app_send_json_to_host_app"
+    case miniAppShouldClose = "mini_app_should_close_with_confirmation"
 
     func name() -> String {
         "mini_app_\(rawValue)"
@@ -77,7 +78,8 @@ internal enum MiniAppRATEvent: String, CaseIterable {
              .clearSecureStorage,
              .getSecureStorageSize,
              .setCloseAlertInfo,
-             .sendJsonToHostapp:
+             .sendJsonToHostapp,
+             .miniAppShouldClose:
             return .click
         }
     }
@@ -208,6 +210,8 @@ public class MiniAppAnalytics {
             return .setCloseAlertInfo
         case .sendJsonToHostapp:
             return .sendJsonToHostapp
+        case .miniAppShouldClose:
+            return .miniAppShouldClose
         }
     }
 }

--- a/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
@@ -24,7 +24,7 @@ struct RequestParameters: Decodable {
     let secureStorageKeyList: [String]?
     let closeAlertInfo: CloseAlertInfo?
     let jsonInfo: JsonStringInfoParameters?
-    let miniAppShouldClose: MiniAppShouldClose?
+    let withConfirmationAlert: Bool?
 }
 
 struct LocationOptions: Decodable {
@@ -51,10 +51,6 @@ struct MiniAppCustomPermissionsResponse: Codable {
 struct MiniAppCustomPermissionsListResponse: Codable {
     let name: String
     let status: String
-}
-
-struct MiniAppShouldClose: Decodable {
-    let withConfirmation: Bool?
 }
 
 public struct CloseAlertInfo: Codable {

--- a/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
@@ -24,6 +24,7 @@ struct RequestParameters: Decodable {
     let secureStorageKeyList: [String]?
     let closeAlertInfo: CloseAlertInfo?
     let jsonInfo: JsonStringInfoParameters?
+    let miniAppShouldClose: MiniAppShouldClose?
 }
 
 struct LocationOptions: Decodable {
@@ -50,6 +51,10 @@ struct MiniAppCustomPermissionsResponse: Codable {
 struct MiniAppCustomPermissionsListResponse: Codable {
     let name: String
     let status: String
+}
+
+struct MiniAppShouldClose: Decodable {
+    let withConfirmation: Bool?
 }
 
 public struct CloseAlertInfo: Codable {

--- a/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
@@ -37,13 +37,14 @@ struct MAJavascriptErrorModel: Codable {
     var message: String?
 }
 
-enum MiniAppJavaScriptError: String, Codable, MiniAppErrorProtocol {
+public enum MiniAppJavaScriptError: String, Codable, MiniAppErrorProtocol {
     case internalError
     case unexpectedMessageFormat
     case invalidPermissionType
     case valueIsEmpty
     case scopeError
     case audienceError
+    case failedToConformToProtocol = "FAILED_TO_CONFORM_PROTOCOL"
 
     var name: String {
         self.rawValue
@@ -63,6 +64,8 @@ enum MiniAppJavaScriptError: String, Codable, MiniAppErrorProtocol {
         return "No scopes provided for the audience requested"
         case .audienceError:
         return "Audience with scopes requested not allowed on this MiniApp"
+        case .failedToConformToProtocol:
+            return MASDKLocale.localize(.failedToConformToProtocol)
         }
     }
 }
@@ -311,7 +314,7 @@ public enum UniversalBridgeError: Error, MiniAppErrorProtocol {
     public var name: String {
         switch self {
         case .failedToConformToProtocol:
-            return "FailedToConformToProtocol"
+            return "FAILED_TO_CONFORM_PROTOCOL"
         case .error(let name):
             return name
         }

--- a/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
@@ -31,6 +31,9 @@ public protocol MiniAppMessageDelegate: MiniAppUserInfoDelegate, MiniAppShareCon
 
     /// Interface that is used to download files
     func downloadFile(fileName: String, url: String, headers: DownloadHeaders, completionHandler: @escaping (Result<String, MASDKDownloadFileError>) -> Void)
+
+    /// Interface to recieve the close command from the MiniApp
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void)
 }
 
 public extension MiniAppMessageDelegate {

--- a/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
@@ -82,6 +82,10 @@ public extension MiniAppMessageDelegate {
     func sendJsonToHostApp(info: String, completionHandler: @escaping (Result<MASDKProtocolResponse, UniversalBridgeError>) -> Void) {
         completionHandler(.failure(.failedToConformToProtocol))
     }
+
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MiniAppJavaScriptError>) -> Void) {
+        completionHandler(.failure(.failedToConformToProtocol))
+    }
 }
 
 public enum MASDKProtocolResponse: String {

--- a/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
@@ -33,7 +33,7 @@ public protocol MiniAppMessageDelegate: MiniAppUserInfoDelegate, MiniAppShareCon
     func downloadFile(fileName: String, url: String, headers: DownloadHeaders, completionHandler: @escaping (Result<String, MASDKDownloadFileError>) -> Void)
 
     /// Interface to recieve the close command from the MiniApp
-    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void)
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MiniAppJavaScriptError>) -> Void)
 }
 
 public extension MiniAppMessageDelegate {
@@ -76,6 +76,10 @@ public extension MiniAppMessageDelegate {
     }
 
     func downloadFile(fileName: String, url: String, headers: DownloadHeaders, completionHandler: @escaping (Result<String, MASDKError>) -> Void) {
+        completionHandler(.failure(.failedToConformToProtocol))
+    }
+
+    func sendJsonToHostApp(info: String, completionHandler: @escaping (Result<MASDKProtocolResponse, UniversalBridgeError>) -> Void) {
         completionHandler(.failure(.failedToConformToProtocol))
     }
 }

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -476,7 +476,7 @@ extension RealMiniApp: MiniAppMessageDelegate {
         completionHandler(.failure(.failedToConformToProtocol))
     }
 
-    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MiniAppJavaScriptError>) -> Void) {
         completionHandler(.failure(.failedToConformToProtocol))
     }
 }

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -475,6 +475,10 @@ extension RealMiniApp: MiniAppMessageDelegate {
     func sendJsonToHostApp(info: String, completionHandler: @escaping (Result<MASDKProtocolResponse, UniversalBridgeError>) -> Void) {
         completionHandler(.failure(.failedToConformToProtocol))
     }
+
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+        completionHandler(.failure(.failedToConformToProtocol))
+    }
 }
 
 extension RealMiniApp {

--- a/Sources/Classes/ui/MiniAppViewController.swift
+++ b/Sources/Classes/ui/MiniAppViewController.swift
@@ -368,7 +368,7 @@ public class MiniAppViewController: UIViewController {
         present(nvc, animated: true, completion: nil)
     }
 
-    public func closeMiniApp(withConfirmation confirmation:Bool) {
+    public func closeMiniApp(withConfirmation confirmation: Bool) {
         if confirmation {
             self.closePressed()
         } else {

--- a/Sources/Classes/ui/MiniAppViewController.swift
+++ b/Sources/Classes/ui/MiniAppViewController.swift
@@ -367,6 +367,14 @@ public class MiniAppViewController: UIViewController {
         nvc.navigationBar.barTintColor = .systemBackground
         present(nvc, animated: true, completion: nil)
     }
+
+    public func closeMiniApp(withConfirmation confirmation:Bool) {
+        if confirmation {
+            self.closePressed()
+        } else {
+            self.closeMiniApp()
+        }
+    }
 }
 
 // MARK: - MiniAppNavigationDelegate

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -374,7 +374,7 @@ class MockFile {
 }
 
 class MockMessageInterfaceExtension: MiniAppMessageDelegate {
-    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MiniAppJavaScriptError>) -> Void) {
         let mockMessageInterface = MockMessageInterface()
         return mockMessageInterface.closeMiniApp(withConfirmation: withConfirmation, completionHandler: completionHandler)
     }
@@ -561,7 +561,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
         }
     }
 
-    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MiniAppJavaScriptError>) -> Void) {
         if mockInterfaceImplemented {
             completionHandler(.success(true))
         } else {

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -374,6 +374,10 @@ class MockFile {
 }
 
 class MockMessageInterfaceExtension: MiniAppMessageDelegate {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+        //TO-DO: implementation pending
+    }
+    
     func sendJsonToHostApp(info: String, completionHandler: @escaping (Result<MASDKProtocolResponse, UniversalBridgeError>) -> Void) {
         let mockMessageInterface = MockMessageInterface()
         return mockMessageInterface.sendJsonToHostApp(info: info, completionHandler: completionHandler)
@@ -553,6 +557,10 @@ class MockMessageInterface: MiniAppMessageDelegate {
         } else {
             completionHandler(.failure(.failedToConformToProtocol))
         }
+    }
+
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+        //TO-DO: implementation pending
     }
 }
 

--- a/Tests/Unit/Helpers.swift
+++ b/Tests/Unit/Helpers.swift
@@ -375,7 +375,8 @@ class MockFile {
 
 class MockMessageInterfaceExtension: MiniAppMessageDelegate {
     func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
-        //TO-DO: implementation pending
+        let mockMessageInterface = MockMessageInterface()
+        return mockMessageInterface.closeMiniApp(withConfirmation: withConfirmation, completionHandler: completionHandler)
     }
     
     func sendJsonToHostApp(info: String, completionHandler: @escaping (Result<MASDKProtocolResponse, UniversalBridgeError>) -> Void) {
@@ -425,6 +426,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
     var mockAccessToken: String? = ""
     var mockEnvironmentInfo: Bool = false
     var mockDownloadFile: Bool = false
+    var mockInterfaceImplemented: Bool = false
 
     func sendMessageToContact(_ message: MessageToContact, completionHandler: @escaping (Result<String?, MASDKError>) -> Void) {
         if messageContentAllowed {
@@ -552,7 +554,7 @@ class MockMessageInterface: MiniAppMessageDelegate {
     }
 
     func sendJsonToHostApp(info: String, completionHandler: @escaping (Result<MASDKProtocolResponse, UniversalBridgeError>) -> Void) {
-        if messageContentAllowed {
+        if mockInterfaceImplemented {
             completionHandler(.success(.success))
         } else {
             completionHandler(.failure(.failedToConformToProtocol))
@@ -560,7 +562,11 @@ class MockMessageInterface: MiniAppMessageDelegate {
     }
 
     func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
-        //TO-DO: implementation pending
+        if mockInterfaceImplemented {
+            completionHandler(.success(true))
+        } else {
+            completionHandler(.failure(.failedToConformToProtocol))
+        }
     }
 }
 

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -94,7 +94,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageItems: nil,
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
-                        jsonInfo: JsonStringInfoParameters(content: "")
+                        jsonInfo: JsonStringInfoParameters(content: ""),
+                        miniAppShouldClose: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "", id: "123", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -122,7 +123,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageItems: nil,
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
-                        jsonInfo: JsonStringInfoParameters(content: "")
+                        jsonInfo: JsonStringInfoParameters(content: ""),
+                        miniAppShouldClose: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -150,7 +152,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageItems: nil,
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
-                        jsonInfo: JsonStringInfoParameters(content: "")
+                        jsonInfo: JsonStringInfoParameters(content: ""),
+                        miniAppShouldClose: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getMessagingUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -178,7 +181,8 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageItems: nil,
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
-                        jsonInfo: JsonStringInfoParameters(content: "")
+                        jsonInfo: JsonStringInfoParameters(content: ""),
+                        miniAppShouldClose: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getMauid", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -95,7 +95,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
                         jsonInfo: JsonStringInfoParameters(content: ""),
-                        miniAppShouldClose: nil
+                        withConfirmationAlert: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "", id: "123", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -124,7 +124,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
                         jsonInfo: JsonStringInfoParameters(content: ""),
-                        miniAppShouldClose: nil
+                        withConfirmationAlert: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -153,7 +153,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
                         jsonInfo: JsonStringInfoParameters(content: ""),
-                        miniAppShouldClose: nil
+                        withConfirmationAlert: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getMessagingUniqueId", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -182,7 +182,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         secureStorageKeyList: nil,
                         closeAlertInfo: nil,
                         jsonInfo: JsonStringInfoParameters(content: ""),
-                        miniAppShouldClose: nil
+                        withConfirmationAlert: nil
                     )
                     let javascriptMessageInfo = MiniAppJavaScriptMessageInfo(action: "getMauid", id: "", param: requestParam)
                     scriptMessageHandler.handleBridgeMessage(responseJson: javascriptMessageInfo)
@@ -1404,7 +1404,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     miniAppTitle: mockMiniAppTitle
                 )
                 it("will return SUCCESS after host app recieves valid content strig") {
-                    mockMessageInterface.messageContentAllowed = true
+                    mockMessageInterface.mockInterfaceImplemented = true
                     let command = "{\"action\":\"sendJsonToHostapp\",\"param\":{\"jsonInfo\":{\"content\":\"{\\\"data\\\":\\\"Thisisasamplejsoninformation\\\"}\"}},\"id\":\"10.050192665128856\"}"
                     let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
@@ -1412,7 +1412,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     expect(callbackProtocol.response).toEventually(equal(MASDKProtocolResponse.success.rawValue), timeout: .seconds(10))
                 }
                 it("will return failedToConformToProtocol Error when message interface is nil") {
-                    mockMessageInterface.messageContentAllowed = false
+                    mockMessageInterface.mockInterfaceImplemented = false
                     let command = "{\"action\":\"sendJsonToHostapp\",\"param\":{\"jsonInfo\":{\"content\":\"{\\\"data\\\":\\\"Thisisasamplejsoninformation\\\"}\"}},\"id\":\"10.050192665128856\"}"
                     let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
@@ -1430,6 +1430,32 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                         name: "", body: command as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
                     expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.name))
+                }
+            }
+            context("when host app recieve the closeMiniApp(withConfirmationAlert:) action") {
+                let scriptMessageHandler = MiniAppScriptMessageHandler(
+                    delegate: callbackProtocol,
+                    hostAppMessageDelegate: mockMessageInterface,
+                    adsDisplayer: mockAdsDelegate,
+                    secureStorageDelegate: mockSecureStorageDelegate,
+                    miniAppManageDelegate: mockMiniAppManageInterface,
+                    miniAppId: mockMiniAppInfo.id,
+                    miniAppTitle: mockMiniAppTitle
+                )
+                it("if protocol implemented the miniapp will be closed and success will be returned") {
+                    mockMessageInterface.mockInterfaceImplemented = true
+                    let command = "{\"action\":\"sendJsonToHostapp\",\"param\":{\"jsonInfo\":{\"content\":\"{\\\"data\\\":\\\"Thisisasamplejsoninformation\\\"}\"}},\"id\":\"10.050192665128856\"}"
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(callbackProtocol.response).toEventuallyNot(beNil(), timeout: .seconds(10))
+                    expect(callbackProtocol.response).toEventually(equal(MASDKProtocolResponse.success.rawValue), timeout: .seconds(10))
+                }
+                it("if protocol delegate not implemented, will throw failed to confirm to protocol error") {
+                    mockMessageInterface.mockInterfaceImplemented = false
+                    let command = "{\"action\":\"sendJsonToHostapp\",\"param\":{\"jsonInfo\":{\"content\":\"{\\\"data\\\":\\\"Thisisasamplejsoninformation\\\"}\"}},\"id\":\"10.050192665128856\"}"
+                    let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(callbackProtocol.errorMessage).toEventually(contain(UniversalBridgeError.failedToConformToProtocol.name))
                 }
             }
         }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -1444,7 +1444,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                 )
                 it("if protocol implemented the miniapp will be closed and success will be returned") {
                     mockMessageInterface.mockInterfaceImplemented = true
-                    let command = "{\"action\":\"sendJsonToHostapp\",\"param\":{\"jsonInfo\":{\"content\":\"{\\\"data\\\":\\\"Thisisasamplejsoninformation\\\"}\"}},\"id\":\"10.050192665128856\"}"
+                    let command = "{\"action\":\"closeMiniApp\",\"param\":{\"withConfirmationAlert\":true},\"id\":\"11.4876229746876\"}"
                     let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
                     expect(callbackProtocol.response).toEventuallyNot(beNil(), timeout: .seconds(10))
@@ -1452,10 +1452,18 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                 }
                 it("if protocol delegate not implemented, will throw failed to confirm to protocol error") {
                     mockMessageInterface.mockInterfaceImplemented = false
-                    let command = "{\"action\":\"sendJsonToHostapp\",\"param\":{\"jsonInfo\":{\"content\":\"{\\\"data\\\":\\\"Thisisasamplejsoninformation\\\"}\"}},\"id\":\"10.050192665128856\"}"
+                    let command = "{\"action\":\"closeMiniApp\",\"param\":{\"withConfirmationAlert\":true},\"id\":\"11.4876229746876\"}"
                     let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                    expect(callbackProtocol.errorMessage).toEventually(contain(UniversalBridgeError.failedToConformToProtocol.name))
+                    expect(callbackProtocol.errorMessage).toEventually(contain(MASDKError.failedToConformToProtocol.errorDescription ??  ""))
+                }
+                it("will return Error unexpected message format when jsonInfo parameter is empty") {
+                    mockMessageInterface.mockInterfaceImplemented = true
+                    let command = "{\"action\":\"closeMiniApp\",\"param\":{\"wrongKeyName\":true},\"id\":\"11.4876229746876\"}"
+                    let mockMessage = MockWKScriptMessage(
+                        name: "", body: command as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(callbackProtocol.errorMessage).toEventually(contain(MiniAppJavaScriptError.unexpectedMessageFormat.name))
                 }
             }
         }

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1074,16 +1074,16 @@ window.addEventListener(MiniAppKeyboardEvents.KEYBOARDHIDDEN, function (e) {
 }
 ```
 
-<a id="miniapp-close-event-listner></a>
+<a id="miniapp-close"></a>
 
 ### MiniApp Close
 
 MiniApp can request the host app to close itself through the javascript bridge event trigger.
-MiniApp-SDK provides the `MiniAppMessageDelegate` interface method `func closeMiniApp(withConfirmation: , completionHandler:)` which must be implemented in the host app.
+MiniApp iOS provides the `MiniAppMessageDelegate` interface method `func closeMiniApp(withConfirmation: , completionHandler:)` which can be implemented in the host app. This delegate method is an optional.
 
 ```swift
 extension ViewController: MiniAppMessageDelegate {
-    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MiniAppJavaScriptError>) -> Void) {
         if withConfirmation {
             // You can handle the close action with confirmation alert.
         } else {

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1074,6 +1074,25 @@ window.addEventListener(MiniAppKeyboardEvents.KEYBOARDHIDDEN, function (e) {
 }
 ```
 
+<a id="miniapp-close-event-listner></a>
+
+### MiniApp Close
+
+MiniApp can request the host app to close itself through the javascript bridge event trigger.
+MiniApp-SDK provides the `MiniAppMessageDelegate` interface method `func closeMiniApp(withConfirmation: , completionHandler:)` which must be implemented in the host app.
+
+```swift
+extension ViewController: MiniAppMessageDelegate {
+    func closeMiniApp(withConfirmation: Bool, completionHandler: @escaping (Result<Bool, MASDKError>) -> Void) {
+        if withConfirmation {
+            // You can handle the close action with confirmation alert.
+        } else {
+            // you can directly  close the MiniApp without the confirmation alert.
+        }
+    }
+}
+```
+
 <a id="faqs-and-troubleshooting"></a>
 
 ## FAQs and Troubleshooting


### PR DESCRIPTION
# Description
Mini App should be able to close mini-app by calling the JS Interface and JS interface would call the native interface.

## Links
[MINI-5845](https://jira.rakuten-it.com/jira/browse/MINI-5845)
[Demo Video on BOX](https://rak.box.com/s/lupcyfphg9fod3qroz3xoha09y90s155)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
