### PR TITLE
[MINI-5866] - T&C issue fix in Demo app

### DIFF
--- a/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
+++ b/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
@@ -23,6 +23,10 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
         self.miniAppVersion = miniAppVersion
     }
 
+    func getMessagingUniqueId(completionHandler: @escaping (Result<String?, MASDKError>) -> Void) {
+        completionHandler(.success("MESSAGINGID-\(miniAppId.prefix(8))-\((miniAppVersion ?? "").prefix(8))"))
+    }
+
     func getUniqueId(completionHandler: @escaping (Result<String?, MASDKError>) -> Void) {
         completionHandler(.success("UNIQUE-\(miniAppId.prefix(8))-\((miniAppVersion ?? "").prefix(8))"))
     }

--- a/Example/Controllers/SwiftUI/Store/MiniAppPermissionService.swift
+++ b/Example/Controllers/SwiftUI/Store/MiniAppPermissionService.swift
@@ -54,12 +54,12 @@ final class MiniAppPermissionService {
             compareMiniAppManifest(info: miniAppInfo, manifest: cachedManifest) { result in
                 DispatchQueue.main.async {
                     switch result {
-                    case .success(let isManifestSame):
-                        if isManifestSame {
+                    case .success(let manifestData):
+                        guard let fetchedManifest = manifestData else {
                             completion(.success(.permissionGranted))
-                        } else {
-                            completion(.success(.permissionRequested(info: miniAppInfo, manifest: cachedManifest)))
+                            return
                         }
+                        completion(.success(.permissionRequested(info: miniAppInfo, manifest: fetchedManifest)))
                     case .failure(let error):
                         completion(.failure(error))
                     }
@@ -83,7 +83,7 @@ final class MiniAppPermissionService {
     func compareMiniAppManifest(
         info: MiniAppInfo,
         manifest: MiniAppManifest,
-        completion: @escaping ((Result<Bool, Error>) -> Void)
+        completion: @escaping ((Result<MiniAppManifest?, Error>) -> Void)
     ) {
         MiniApp
             .shared(with: config)
@@ -95,9 +95,9 @@ final class MiniAppPermissionService {
                 switch result {
                 case .success(let manifestData):
                     if manifest == manifestData {
-                        completion(.success(true))
+                        completion(.success(nil))
                     } else {
-                        completion(.success(false))
+                        completion(.success(manifestData))
                     }
                 case .failure(let error):
                     if error.isQPSLimitError() {


### PR DESCRIPTION
# Description
* Demo app is not fetching the latest miniapp manifest, this PR will fix it
* Updated Demo app to implement getMessagingUniqueId()

## Links
[MINI-5866](https://jira.rakuten-it.com/jira/browse/MINI-5866)
[MINI-5872](https://jira.rakuten-it.com/jira/browse/MINI-5872)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
