### PR TITLE
[MINI-5708] Back and forward arrows show's blank white screen.

### DIFF
--- a/Sources/Classes/core/SecureStorage/Database/MiniAppSecureStorageSqliteDatabase.swift
+++ b/Sources/Classes/core/SecureStorage/Database/MiniAppSecureStorageSqliteDatabase.swift
@@ -63,10 +63,6 @@ class MiniAppSecureStorageSqliteDatabase: MiniAppSecureStorageDatabase {
     }
 
     func load(completion: ((MiniAppSecureStorageError?) -> Void)?) {
-        guard doesStoragePathExist else {
-            completion?(.storageUnavailable)
-            return
-        }
         do {
             let queue = try Connection(storagePath)
             self.dbQueue = queue

--- a/Sources/Classes/core/SecureStorage/MiniAppSecureStorage.swift
+++ b/Sources/Classes/core/SecureStorage/MiniAppSecureStorage.swift
@@ -33,20 +33,14 @@ class MiniAppSecureStorage: MiniAppSecureStorageDelegate {
     // MARK: - Load/Unload
     func loadStorage(completion: ((Bool) -> Void)? = nil) {
         isStoreLoading = true
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            self?.database.load(completion: { [weak self] error in
-                self?.isStoreLoading = false
-                guard error == nil else {
-                    DispatchQueue.main.async {
-                        completion?(false)
-                    }
-                    return
-                }
-                DispatchQueue.main.async {
-                    completion?(true)
-                }
-            })
-        }
+        database.load(completion: { [weak self] error in
+            self?.isStoreLoading = false
+            guard error == nil else {
+                completion?(false)
+                return
+            }
+            completion?(true)
+        })
     }
 
     func unloadStorage() {

--- a/Sources/Classes/core/SecureStorage/MiniAppSecureStorage.swift
+++ b/Sources/Classes/core/SecureStorage/MiniAppSecureStorage.swift
@@ -33,14 +33,20 @@ class MiniAppSecureStorage: MiniAppSecureStorageDelegate {
     // MARK: - Load/Unload
     func loadStorage(completion: ((Bool) -> Void)? = nil) {
         isStoreLoading = true
-        database.load(completion: { [weak self] error in
-            self?.isStoreLoading = false
-            guard error == nil else {
-                completion?(false)
-                return
-            }
-            completion?(true)
-        })
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.database.load(completion: { [weak self] error in
+                self?.isStoreLoading = false
+                guard error == nil else {
+                    DispatchQueue.main.async {
+                        completion?(false)
+                    }
+                    return
+                }
+                DispatchQueue.main.async {
+                    completion?(true)
+                }
+            })
+        }
     }
 
     func unloadStorage() {

--- a/Tests/Unit/MiniAppSecureStorageTests.swift
+++ b/Tests/Unit/MiniAppSecureStorageTests.swift
@@ -140,13 +140,9 @@ class MiniAppSecureStorageTests: XCTestCase {
     }
 
     func testSetup_UnloadedStorage_WithoutSetup() {
-        let expectation = XCTestExpectation(description: #function)
         let storage = MiniAppSecureStorage(appId: miniAppId)
-        var didLoadStorage: Bool?
-        storage.loadStorage { success in
-            didLoadStorage = success
-            expectation.fulfill()
-        }
+        let didLoadStorage = storage.database.isStoreAvailable
+
         XCTAssertEqual(didLoadStorage, false)
     }
 


### PR DESCRIPTION
# Description
* Issue: Back and forward arrows show's blank white screen.

* Cause: iOS-SDK returns databaseunavailable error before creating the securestorage.sqlite file, when opening the MiniApps and it will never be able to find securestorage.sqlite file.

* Fix: in MiniAppSecureStorageSqliteDatabase.swift & MiniAppSecureStorage.swift files to remove the guard statement on load.

## Links
[MINI-5708](https://jira.rakuten-it.com/jira/browse/MINI-5708)
[MIINI-5708-fix demo](https://rak.box.com/s/01uulek2cbdc2g53t2bsuqfjk8y6kss3)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
