### PR TITLE
Cancel icon on sample MiniApp share preview popup is not working

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSharePreviewView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSharePreviewView.swift
@@ -26,7 +26,7 @@ struct MiniAppSharePreviewView: View {
                         })
                     } else {
                         RemoteImageView(urlString: url.absoluteString)
-                            .frame(width: 60, height: 40, alignment: .center)
+                            .frame(width: 300, height: 120, alignment: .center)
                     }
                     Spacer()
                 }
@@ -40,14 +40,6 @@ struct MiniAppSharePreviewView: View {
         }
         .navigationTitle(pageName)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(content: {
-            ToolbarItem(placement: .navigationBarLeading) {
-                CloseButton {
-                    trackButtonTap(pageName: pageName, buttonTitle: "Back")
-                    presentationMode.wrappedValue.dismiss()
-                }
-            }
-        })
         .onAppear {
             viewModel.getInfo { result in
                 switch result {

--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -148,7 +148,7 @@ struct MiniAppSingleView: View {
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarLeading) {
-                            CloseButton{
+                            CloseButton {
                                 trackButtonTap(pageName: NSLocalizedString("demo.app.rat.page.name.share.preview", comment: ""), buttonTitle: "Cancel")
                                 isSharePreviewPresented = false
                                 shouldPresentModalView = false

--- a/Example/Controllers/SwiftUI/Helper/AccessabilityIdentifiers.swift
+++ b/Example/Controllers/SwiftUI/Helper/AccessabilityIdentifiers.swift
@@ -18,6 +18,7 @@ enum AccessibilityIdentifiers: String {
     case miniappHeaderBack = "miniapp.header.back"
     case miniappHeaderForward = "miniapp.header.forward"
     case miniappHeaderClose = "miniapp.header.close"
+    case miniappSharePreviewCancel = "miniapp.sharepview.cancel"
 
     var identifier: String {
         return "miniapp.demo." + rawValue


### PR DESCRIPTION
# Description
* Issue:  [iOS 14][DemoApp]: Cancel icon on sample MiniApp share preview popup is not working

* Cause: Issue with the swiftui implementation and the api used to close does not support in iOS 14.

* Fix: Corrected the SwiftUI implementation to support the close action.
## Links
[MINI-5868](https://jira.rakuten-it.com/jira/browse/MINI-5868)
[Fix Demo](https://rak.box.com/s/0sxevmrrch57wgiouncxo5szbn8lmtqb)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
