### PR TITLE
[MINI-5873] SampleApp "Close Miniapp" button, there is no action in iOS 14

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -61,18 +61,6 @@ struct MiniAppSingleView: View {
                     }
                 }
                 .accessibilityIdentifier(AccessibilityIdentifiers.miniappHeaderClose.identifier)
-                .alert(item: $closeAlertMessage) { errorMessage in
-                    Alert(
-                        title: Text(errorMessage.title),
-                        message: Text(errorMessage.message),
-                        primaryButton: .default(Text("Ok"), action: {
-                            presentationMode.wrappedValue.dismiss()
-                        }),
-                        secondaryButton: .cancel(Text("Cancel"), action: {
-                            viewModel.shouldCloseMiniApp.send(false)
-                        })
-                    )
-                }
             }
 
             ToolbarItem(placement: .navigationBarLeading) {
@@ -124,6 +112,18 @@ struct MiniAppSingleView: View {
             }
 
         })
+        .alert(item: $closeAlertMessage) { errorMessage in
+            Alert(
+                title: Text(errorMessage.title),
+                message: Text(errorMessage.message),
+                primaryButton: .default(Text("Ok"), action: {
+                    presentationMode.wrappedValue.dismiss()
+                }),
+                secondaryButton: .cancel(Text("Cancel"), action: {
+                    viewModel.shouldCloseMiniApp.send(false)
+                })
+            )
+        }
         .sheet(isPresented: $shouldPresentModalView, onDismiss: {shouldPresentModalView = false}, content: {
             NavigationView {
                 if let permissionRequest = permissionRequest {


### PR DESCRIPTION
# Description
* Issue: Once the user taps "Close Miniapp" button or clicks on "x" cancel icon, there is no action .

* Cause: Seen after SwiftUI changes, due to improper implementation if alert{} object in SwiftUI view.

* Fix: Moved the alert component on the view to correct hierarchy of view.

## Links
[MINI-5873](https://jira.rakuten-it.com/jira/browse/MINI-5873) 
[Fix-Demo](https://rak.box.com/s/x0b4izisqvvw6z3gtp75zhb7ln102ik1)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
