### PR TITLE
[MINI-5708] Fix for Secure storage notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+### 5.2.0 (2023-xx-xx)
+**SDK**
+- **Fix:** Fix Secure storage ready notification
+
+---
+
 ### 5.1.0 (2023-01-30)
 **SDK**
 - **Update:** Added `allEmailList` field in `MAContact` to support multiple emails of a specific contact.

--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -649,7 +649,7 @@ extension MiniAppViewHandler: WKNavigationDelegate {
         }
         decisionHandler(.cancel)
     }
-    
+
     private func notifySecureStorageStatus() {
         if shouldAutoLoadSecureStorage {
             secureStorage.loadStorage { success in

--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -336,16 +336,6 @@ class MiniAppViewHandler: NSObject {
         )
         initExternalWebViewClosures()
         observeWebView()
-
-        if shouldAutoLoadSecureStorage {
-            secureStorage.loadStorage { success in
-                if success {
-                    MiniAppSecureStorage.sendLoadStorageReady(miniAppId: self.appId, miniAppVersion: self.version ?? "")
-                } else {
-                    MiniAppSecureStorage.sendLoadStorageError(miniAppId: self.appId, miniAppVersion: self.version ?? "")
-                }
-            }
-        }
     }
 
     func loadWebView(url: URL) {
@@ -598,6 +588,7 @@ extension MiniAppViewHandler: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        notifySecureStorageStatus()
         initialLoadCallback?(true)
         initialLoadCallback = nil
     }
@@ -657,6 +648,18 @@ extension MiniAppViewHandler: WKNavigationDelegate {
             }
         }
         decisionHandler(.cancel)
+    }
+    
+    private func notifySecureStorageStatus() {
+        if shouldAutoLoadSecureStorage {
+            secureStorage.loadStorage { success in
+                if success {
+                    MiniAppSecureStorage.sendLoadStorageReady(miniAppId: self.appId, miniAppVersion: self.version ?? "")
+                } else {
+                    MiniAppSecureStorage.sendLoadStorageError(miniAppId: self.appId, miniAppVersion: self.version ?? "")
+                }
+            }
+        }
     }
 }
 

--- a/Tests/Unit/MiniAppViewHandlerTests.swift
+++ b/Tests/Unit/MiniAppViewHandlerTests.swift
@@ -458,6 +458,94 @@ class MiniAppViewHandlerTests: XCTestCase {
         wait(for: [expectation], timeout: 3.0)
         XCTAssertEqual(eventTypeResult, .resume)
     }
+    
+    func test_keyboard_shown_event() {
+        let messageDelegate = MockMessageInterface()
+        let viewHandler = MiniAppViewHandler(
+            config: .init(
+                config: nil,
+                messageDelegate: messageDelegate
+            ),
+            appId: mockMiniAppInfo.id,
+            version: mockMiniAppInfo.version.versionId
+        )
+
+        let miniAppWebView = MiniAppWebView()
+        do {
+            try viewHandler.loadWebView(
+                webView: miniAppWebView,
+                miniAppId: mockMiniAppInfo.id,
+                versionId: mockMiniAppInfo.version.versionId
+            )
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+        viewHandler.webView = miniAppWebView
+        let expectation = XCTestExpectation(description: #function)
+        var eventTypeResult: MiniAppKeyboardEvent?
+        NotificationCenter.default.addObserver(forName: MiniAppKeyboardEvent.notificationName, object: nil, queue: .main) { notification in
+            if let event = notification.object as? MiniAppKeyboardEvent.Event {
+                eventTypeResult = event.type
+            }
+            expectation.fulfill()
+        }
+        NotificationCenter.default
+            .sendKeyboardEvent(
+                MiniAppKeyboardEvent.Event(
+                    type: .keyboardShown,
+                    comment: "Keyboard was shown",
+                    navigationBarHeight: 100.0,
+                    keyboardHeight: 100.0,
+                    screenHeight: 100.0
+                )
+            )
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertEqual(eventTypeResult, .keyboardShown)
+    }
+
+    func test_keyboard_hide_event() {
+        let messageDelegate = MockMessageInterface()
+        let viewHandler = MiniAppViewHandler(
+            config: .init(
+                config: nil,
+                messageDelegate: messageDelegate
+            ),
+            appId: mockMiniAppInfo.id,
+            version: mockMiniAppInfo.version.versionId
+        )
+
+        let miniAppWebView = MiniAppWebView()
+        do {
+            try viewHandler.loadWebView(
+                webView: miniAppWebView,
+                miniAppId: mockMiniAppInfo.id,
+                versionId: mockMiniAppInfo.version.versionId
+            )
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+        viewHandler.webView = miniAppWebView
+        let expectation = XCTestExpectation(description: #function)
+        var eventTypeResult: MiniAppKeyboardEvent?
+        NotificationCenter.default.addObserver(forName: MiniAppKeyboardEvent.notificationName, object: nil, queue: .main) { notification in
+            if let event = notification.object as? MiniAppKeyboardEvent.Event {
+                eventTypeResult = event.type
+            }
+            expectation.fulfill()
+        }
+        NotificationCenter.default
+            .sendKeyboardEvent(
+                MiniAppKeyboardEvent.Event(
+                    type: .keyboardHidden,
+                    comment: "Keyboard was Hidden",
+                    navigationBarHeight: 100.0,
+                    keyboardHeight: 0,
+                    screenHeight: 100.0
+                )
+            )
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertEqual(eventTypeResult, .keyboardHidden)
+    }
 }
 
 extension MiniAppViewHandlerTests {


### PR DESCRIPTION
# Description
* Secure storage notification is sent even before the Mini app starts listening, this PR will fix the same.

## Links
[MINI-5708](https://jira.rakuten-it.com/jira/browse/MINI-5708)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
