### PR TITLE
[MINI-5871]Mask Project ID & Subscription Key in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 **SDK**
 - **Fix:** Fix Secure storage ready notification
 
+**Sample App**
+- **Bugfix:** Mask Project ID & Subscription Key in Settings
 ---
 
 ### 5.1.0 (2023-01-30)

--- a/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
@@ -135,7 +135,6 @@ struct MiniAppSettingsView: View {
                     .onAppear {
                         self.tmpSubscriptionKey = maskedString(of: viewModel.listConfig.subscriptionKey ?? "")
                     }
-                    
             }
 
             Section {
@@ -235,15 +234,15 @@ struct MiniAppSettingsView: View {
         }
         .onChange(of: viewModel.listConfig.environmentMode, perform: { _ in
             self.dismissKeyboard()
-            switch(viewModel.listConfig.environmentMode) {
+            switch viewModel.listConfig.environmentMode {
             case .production:
                 viewModel.listConfig.projectId = viewModel.listConfig.projectIdProd
                 viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyProd
-                break
+
             case .staging:
                 viewModel.listConfig.projectId = viewModel.listConfig.projectIdStaging
                 viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyStaging
-                break
+
             }
             self.tmpProjectKey = maskedString(of: viewModel.listConfig.projectId ?? "")
             self.tmpSubscriptionKey = maskedString(of: viewModel.listConfig.subscriptionKey ?? "")
@@ -263,14 +262,14 @@ struct MiniAppSettingsView: View {
         return viewModel.listConfigII.error != nil
     }
 
-    func maskedString(of keyString:String) -> String {
-        if (keyString.count > 5) {
-            let iS = keyString.index(keyString.startIndex, offsetBy: 5)
-            let iE = keyString.endIndex
+    func maskedString(of keyString: String) -> String {
+        if keyString.count > 5 {
+            let startIndex = keyString.index(keyString.startIndex, offsetBy: 5)
+            let endIndex = keyString.endIndex
             var str = keyString
             do {
                 let regex = try NSRegularExpression(pattern: "([a-zA-Z0-9-])", options: .caseInsensitive)
-                let range: Range<String.Index> = iS..<iE
+                let range: Range<String.Index> = startIndex..<endIndex
                 str = regex.stringByReplacingMatches(in: str, options: [], range: NSRange(range, in: str), withTemplate: "*")
             } catch { return str}
             return str

--- a/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
@@ -14,6 +14,9 @@ struct MiniAppSettingsView: View {
     @State private var alertMessage: MiniAppAlertMessage?
     @State private var selectedListConfig: ListType = .listI
 
+    @State private var tmpSubscriptionKey: String = ""
+    @State private var tmpProjectKey: String = ""
+
     var body: some View {
         Form {
 
@@ -95,22 +98,44 @@ struct MiniAppSettingsView: View {
 
                 TextField(
                     viewModel.listConfig.placeholderProjectId,
-                    text: Binding<String>(
-                        get: { viewModel.listConfig.projectId ?? "" },
-                        set: { newValue in viewModel.listConfig.projectId = newValue }
-                    )
+                    text: $tmpProjectKey,
+                    onEditingChanged: { isEditing in
+                        if isEditing {
+                            tmpProjectKey = viewModel.listConfig.projectId ?? ""
+                        } else {
+                            self.tmpProjectKey = maskedString(of: tmpProjectKey)
+                        }
+                    },
+                    onCommit: {
+                        viewModel.listConfig.projectId = tmpProjectKey
+                        self.tmpProjectKey = maskedString(of: tmpProjectKey)
+                    }
                 )
                     .padding(.vertical, 15)
                     .accessibilityIdentifier(AccessibilityIdentifiers.settingsHostId.identifier)
+                    .onAppear {
+                        self.tmpProjectKey = maskedString(of: viewModel.listConfig.projectId ?? "")
+                    }
                 TextField(
                     viewModel.listConfig.placeholderSubscriptionKey,
-                    text: Binding<String>(
-                        get: { viewModel.listConfig.subscriptionKey ?? "" },
-                        set: { newValue in viewModel.listConfig.subscriptionKey = newValue }
-                    )
+                    text: $tmpSubscriptionKey,
+                    onEditingChanged: { isEditing in
+                        if isEditing {
+                            tmpSubscriptionKey = viewModel.listConfig.subscriptionKey ?? ""
+                        } else {
+                            self.tmpSubscriptionKey = maskedString(of: tmpSubscriptionKey)
+                        }
+                    }, onCommit: {
+                        viewModel.listConfig.subscriptionKey = tmpSubscriptionKey
+                        self.tmpSubscriptionKey = maskedString(of: tmpSubscriptionKey)
+                    }
                 )
                     .padding(.vertical, 15)
                     .accessibilityIdentifier(AccessibilityIdentifiers.settingsSubscriptionKey.identifier)
+                    .onAppear {
+                        self.tmpSubscriptionKey = maskedString(of: viewModel.listConfig.subscriptionKey ?? "")
+                    }
+                    
             }
 
             Section {
@@ -208,6 +233,21 @@ struct MiniAppSettingsView: View {
                 ()
             }
         }
+        .onChange(of: viewModel.listConfig.environmentMode, perform: { _ in
+            self.dismissKeyboard()
+            switch(viewModel.listConfig.environmentMode) {
+            case .production:
+                viewModel.listConfig.projectId = viewModel.listConfig.projectIdProd
+                viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyProd
+                break
+            case .staging:
+                viewModel.listConfig.projectId = viewModel.listConfig.projectIdStaging
+                viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyStaging
+                break
+            }
+            self.tmpProjectKey = maskedString(of: viewModel.listConfig.projectId ?? "")
+            self.tmpSubscriptionKey = maskedString(of: viewModel.listConfig.subscriptionKey ?? "")
+        })
         .trackPage(pageName: pageName)
     }
 
@@ -221,6 +261,21 @@ struct MiniAppSettingsView: View {
 
     var hasListIIErrors: Bool {
         return viewModel.listConfigII.error != nil
+    }
+
+    func maskedString(of keyString:String) -> String {
+        if (keyString.count > 5) {
+            let iS = keyString.index(keyString.startIndex, offsetBy: 5)
+            let iE = keyString.endIndex
+            var str = keyString
+            do {
+                let regex = try NSRegularExpression(pattern: "([a-zA-Z0-9-])", options: .caseInsensitive)
+                let range: Range<String.Index> = iS..<iE
+                str = regex.stringByReplacingMatches(in: str, options: [], range: NSRange(range, in: str), withTemplate: "*")
+            } catch { return str}
+            return str
+        }
+        return keyString
     }
 }
 


### PR DESCRIPTION
# Description
Mask Project ID & Subscription Key in Settings
* Issue:  Project ID & Subscription Key in Settings are shown as plain text
* Cause: Not masked
* Fix: Will be masked when not editing and un-masked when editing.

## Links
[MINI-5871](https://jira.rakuten-it.com/jira/browse/MINI-5871) 
[Demo Video Link](https://rak.box.com/s/h97sjvynohib8ylr0np4ogpucx7m9p4a)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
