### PR TITLE
[MINI-5895] Fix to show Request Custom permissions

### DIFF
--- a/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
+++ b/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
@@ -74,10 +74,6 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
         }
     }
 
-    func requestCustomPermissions(permissions: [MASDKCustomPermissionModel], miniAppTitle: String, completionHandler: @escaping (Result<[MASDKCustomPermissionModel], MASDKCustomPermissionError>) -> Void) {
-        completionHandler(.failure(.userDenied))
-    }
-
     func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
         switch permissionType {
         case .location:


### PR DESCRIPTION
# Description
* This fix will show the Permissions request UI again. We shouldn't override it in Demo app unless the Host app wants to show its own UI for request permissions

## Links
[MINI-5895](https://jira.rakuten-it.com/jira/browse/MINI-5895)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
