### PR TITLE
[MINI-5895] - Changes to align with Android Error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.2.0 (2023-xx-xx)
 **SDK**
 - **Fix:** Fix Secure storage ready notification
+- **Refactor:** Update the Custom permissions error messages format
 
 **Sample App**
 - **Bugfix:** Mask Project ID & Subscription Key in Settings

--- a/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
+++ b/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
@@ -74,10 +74,6 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
         }
     }
 
-    func requestCustomPermissions(permissions: [MASDKCustomPermissionModel], miniAppTitle: String, completionHandler: @escaping (Result<[MASDKCustomPermissionModel], MASDKCustomPermissionError>) -> Void) {
-        completionHandler(.failure(.userDenied))
-    }
-
     func requestDevicePermission(permissionType: MiniAppDevicePermissionType, completionHandler: @escaping (Result<MASDKPermissionResponse, MASDKPermissionError>) -> Void) {
         switch permissionType {
         case .location:

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -507,7 +507,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         } else {
             executeJavaScriptCallback(responseStatus: .onError,
                                       messageId: callbackId,
-                                      response: prepareMAJavascriptError(MASDKCustomPermissionError.userDenied))
+                                      response: prepareMAJavascriptError(MASDKCustomPermissionError.contactsPermissionError))
         }
     }
 

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -146,7 +146,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     private func sendMessageToContactId(with callBackId: String, parameters: RequestParameters?) {
-        if isUserAllowedPermission(customPermissionType: .sendMessage, callbackId: callBackId) {
+        if isUserAllowedPermission(customPermissionType: .sendMessage) {
             if let message = parameters?.messageToContact {
                 if let contactId = parameters?.contactId {
                     hostAppMessageDelegate?.sendMessageToContactId(contactId, message: message) { result in
@@ -164,6 +164,10 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             } else {
                 executeJavaScriptCallback(responseStatus: .onError, messageId: callBackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.unexpectedMessageFormat))
             }
+        } else {
+            executeJavaScriptCallback(responseStatus: .onError,
+                                      messageId: callBackId,
+                                      response: getMiniAppErrorMessage(MASDKCustomPermissionError.contactsPermissionError))
         }
     }
 
@@ -295,8 +299,12 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     func getCurrentPosition(callbackId: String, location: CLLocation?) {
-        if isUserAllowedPermission(customPermissionType: .deviceLocation, callbackId: callbackId) {
+        if isUserAllowedPermission(customPermissionType: .deviceLocation) {
             executeJavaScriptCallback(responseStatus: .onSuccess, messageId: callbackId, response: getLocationInfo(location: location))
+        } else {
+            executeJavaScriptCallback(responseStatus: .onError,
+                                      messageId: callbackId,
+                                      response: prepareMAJavascriptError(MASDKCustomPermissionError.locationPermissionError))
         }
     }
 
@@ -441,7 +449,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     func fetchUserName(callbackId: String) {
-        if isUserAllowedPermission(customPermissionType: .userName, callbackId: callbackId) {
+        if isUserAllowedPermission(customPermissionType: .userName) {
             hostAppMessageDelegate?.getUserName { (result) in
                 switch result {
                 case .success(let response):
@@ -454,11 +462,15 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     self.handleMASDKError(error: error, callbackId: callbackId)
                 }
             }
+        } else {
+            executeJavaScriptCallback(responseStatus: .onError,
+                                      messageId: callbackId,
+                                      response: prepareMAJavascriptError(MASDKCustomPermissionError.userNamePermissionError))
         }
     }
 
     func fetchProfilePhoto(callbackId: String) {
-        if isUserAllowedPermission(customPermissionType: .profilePhoto, callbackId: callbackId) {
+        if isUserAllowedPermission(customPermissionType: .profilePhoto) {
             hostAppMessageDelegate?.getProfilePhoto { (result) in
                 switch result {
                 case .success(let response):
@@ -471,11 +483,15 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     self.handleMASDKError(error: error, callbackId: callbackId)
                 }
             }
+        } else {
+            executeJavaScriptCallback(responseStatus: .onError,
+                                      messageId: callbackId,
+                                      response: prepareMAJavascriptError(MASDKCustomPermissionError.profilePhotoPermissionError))
         }
     }
 
     func fetchContacts(callbackId: String) {
-        if isUserAllowedPermission(customPermissionType: .contactsList, callbackId: callbackId) {
+        if isUserAllowedPermission(customPermissionType: .contactsList) {
             hostAppMessageDelegate?.getContacts { [self] result in
                 switch result {
                 case .success(let contactsList):
@@ -488,18 +504,15 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: getMiniAppErrorMessage(MiniAppJavaScriptError.internalError))
                 }
             }
-        }
-    }
-
-    func isUserAllowedPermission(customPermissionType: MiniAppCustomPermissionType, callbackId: String) -> Bool {
-        if isPermissionAllowedAlready(customPermissionType: customPermissionType) {
-            return true
         } else {
             executeJavaScriptCallback(responseStatus: .onError,
                                       messageId: callbackId,
-                                      response: getMiniAppErrorMessage(MASDKCustomPermissionError.userDenied))
-            return false
+                                      response: prepareMAJavascriptError(MASDKCustomPermissionError.userDenied))
         }
+    }
+
+    func isUserAllowedPermission(customPermissionType: MiniAppCustomPermissionType) -> Bool {
+        return isPermissionAllowedAlready(customPermissionType: customPermissionType)
     }
 
     private func isPermissionAllowedAlready(customPermissionType: MiniAppCustomPermissionType) -> Bool {
@@ -530,7 +543,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     func fetchTokenDetails(callbackId: String, for requestParam: RequestParameters?) {
-        if isUserAllowedPermission(customPermissionType: .accessToken, callbackId: callbackId) {
+        if isUserAllowedPermission(customPermissionType: .accessToken) {
             guard var accessTokenPermission = MASDKAccessTokenScopes(audience: requestParam?.audience, scopes: []),
                   let accessTokenPermissions = MiniApp.shared().getDownloadedManifest(miniAppId: miniAppId)?.accessTokenPermissions,
                   accessTokenPermission.isPartOf(accessTokenPermissions) // we check that the Mini App manages scopes and that these scopes are included in the Manifest
@@ -554,11 +567,15 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMAJavascriptError(error))
                 }
             }
+        } else {
+            executeJavaScriptCallback(responseStatus: .onError,
+                                      messageId: callbackId,
+                                      response: prepareMAJavascriptError(MASDKCustomPermissionError.accessTokenPermissionError))
         }
     }
 
     func fetchPoints(with callbackId: String) {
-         if isUserAllowedPermission(customPermissionType: .points, callbackId: callbackId) {
+         if isUserAllowedPermission(customPermissionType: .points) {
             hostAppMessageDelegate?.getPoints { (result) in
                 switch result {
                 case .success(let response):
@@ -571,7 +588,11 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     self.executeJavaScriptCallback(responseStatus: .onError, messageId: callbackId, response: prepareMAJavascriptError(error))
                 }
             }
-        }
+         } else {
+             executeJavaScriptCallback(responseStatus: .onError,
+                                       messageId: callbackId,
+                                       response: prepareMAJavascriptError(MASDKCustomPermissionError.pointsPermissionError))
+         }
     }
 
     func getEnvironmentInfo(with callbackId: String) {
@@ -595,7 +616,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
 
     func downloadFile(with callbackId: String, parameters: RequestParameters?) {
          if
-            isUserAllowedPermission(customPermissionType: .fileDownload, callbackId: callbackId),
+            isUserAllowedPermission(customPermissionType: .fileDownload),
             let fileName = parameters?.filename,
             let url = parameters?.url,
             let headers = parameters?.headers
@@ -616,7 +637,11 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     )
                 }
             }
-        }
+         } else {
+             executeJavaScriptCallback(responseStatus: .onError,
+                                       messageId: callbackId,
+                                       response: prepareMAJavascriptError(MASDKCustomPermissionError.userDenied))
+         }
     }
 
     func getSecureStorageItem(with callbackId: String, parameters: RequestParameters?) {

--- a/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
@@ -102,7 +102,7 @@ public enum MASDKPermissionError: String, MiniAppErrorProtocol {
 
 /// Enumeration that is used to differentiate the Custom permission errors
 public enum MASDKCustomPermissionError: String, MiniAppErrorProtocol {
-    
+
     /// Unknown Error
     case unknownError = "UKNOWN_ERROR"
 
@@ -138,7 +138,7 @@ public enum MASDKCustomPermissionError: String, MiniAppErrorProtocol {
 
     /// Location Customer permission denied error
     case locationPermissionError
-    
+
     public var name: String {
         return self.rawValue
     }

--- a/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavascriptErrorInfo.swift
@@ -102,7 +102,7 @@ public enum MASDKPermissionError: String, MiniAppErrorProtocol {
 
 /// Enumeration that is used to differentiate the Custom permission errors
 public enum MASDKCustomPermissionError: String, MiniAppErrorProtocol {
-
+    
     /// Unknown Error
     case unknownError = "UKNOWN_ERROR"
 
@@ -121,7 +121,25 @@ public enum MASDKCustomPermissionError: String, MiniAppErrorProtocol {
     /// Invalid scope request for the Custom Permission
     case outOfScope
 
-    var name: String {
+    /// User name Customer permission denied error
+    case userNamePermissionError
+
+    /// Profile Photo Customer permission denied error
+    case profilePhotoPermissionError
+
+    /// Access Token Customer permission denied error
+    case accessTokenPermissionError
+
+    /// Contacts Customer permission denied error
+    case contactsPermissionError
+
+    /// Points Customer permission denied error
+    case pointsPermissionError
+
+    /// Location Customer permission denied error
+    case locationPermissionError
+    
+    public var name: String {
         return self.rawValue
     }
 
@@ -140,6 +158,18 @@ public enum MASDKCustomPermissionError: String, MiniAppErrorProtocol {
             return "User denied to share the detail"
         case .outOfScope:
             return "Invalid scope request for the Custom Permission"
+        case .userNamePermissionError:
+            return "Cannot get user name: Permission has not been accepted yet for getting user name."
+        case .profilePhotoPermissionError:
+            return "Cannot get profile photo: Permission has not been accepted yet for getting profile photo."
+        case .accessTokenPermissionError:
+            return "Cannot get access token: Permission has not been accepted yet for getting access token."
+        case .contactsPermissionError:
+            return "Cannot get contacts: Permission has not been accepted yet for getting contacts."
+        case .pointsPermissionError:
+            return "Cannot get points: Permission has not been accepted yet for getting points."
+        case .locationPermissionError:
+            return "Cannot get location: Permission has not been accepted yet for getting location."
         }
     }
 }

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -658,6 +658,23 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
                     expect(mockCallbackProtocol.errorMessage).toEventually(contain("Unable to return Access Token"), timeout: .seconds(2))
                 }
+                it("will return Error if User didn't allow Access Token permission") {
+                    let mockCallbackProtocol = MockMiniAppCallbackProtocol()
+                    let scriptMessageHandler = MiniAppScriptMessageHandler(
+                        delegate: mockCallbackProtocol,
+                        hostAppMessageDelegate: mockMessageInterface,
+                        adsDisplayer: mockAdsDelegate,
+                        secureStorageDelegate: mockSecureStorageDelegate,
+                        miniAppManageDelegate: mockMiniAppManageInterface,
+                        miniAppId: mockMiniAppInfo.id, miniAppTitle: mockMiniAppTitle
+                    )
+                    mockMessageInterface.mockAccessToken = ""
+                    updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .accessToken, status: .denied)
+                    let mockMessage = MockWKScriptMessage(
+                        name: "", body: "{\"action\": \"getAccessToken\", \"param\":{\"audience\": \"AUDIENCE_TEST\", \"scopes\":[\"scope_test\"]}, \"id\":\"12345\"}" as AnyObject)
+                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.accessTokenPermissionError.rawValue), timeout: .seconds(10))
+                }
             }
             context("when MiniApp manifest contained no scopes") {
                 it("will return error") {

--- a/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
+++ b/Tests/Unit/MiniAppScriptMessageHandlerTests.swift
@@ -454,7 +454,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     let mockMessage = MockWKScriptMessage(
                         name: "", body: "{\"action\": \"getUserName\", \"param\":null, \"id\":\"12345\"}" as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userDenied.rawValue), timeout: .seconds(10))
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userNamePermissionError.rawValue), timeout: .seconds(10))
                 }
             }
             context("when MiniAppScriptMessageHandler receives valid getProfilePhoto command") {
@@ -506,7 +506,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     let mockMessage = MockWKScriptMessage(
                         name: "", body: "{\"action\": \"getProfilePhoto\", \"param\":null, \"id\":\"12345\"}" as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userDenied.rawValue), timeout: .seconds(10))
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.profilePhotoPermissionError.rawValue), timeout: .seconds(10))
                 }
             }
             context("when MiniAppScriptMessageHandler receives valid getContacts command") {
@@ -538,7 +538,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     )
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .contactsList, status: .denied)
                    scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userDenied.rawValue), timeout: .seconds(10))
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.contactsPermissionError.rawValue), timeout: .seconds(10))
                 }
                 it("will return Error if contacts are nil") {
                     let mockCallbackProtocol = MockMiniAppCallbackProtocol()
@@ -1000,7 +1000,7 @@ class MiniAppScriptMessageHandlerTests: QuickSpec {
                     updateCustomPermissionStatus(miniAppId: mockMiniAppInfo.id, permissionType: .points, status: .denied)
                     let mockMessage = MockWKScriptMessage(name: "", body: command as AnyObject)
                     scriptMessageHandler.userContentController(WKUserContentController(), didReceive: mockMessage)
-                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.userDenied.rawValue), timeout: .seconds(10))
+                    expect(mockCallbackProtocol.errorMessage).toEventually(contain(MASDKCustomPermissionError.pointsPermissionError.rawValue), timeout: .seconds(10))
 
                 }
             }

--- a/Tests/Unit/Signature/FetcherTests.swift
+++ b/Tests/Unit/Signature/FetcherTests.swift
@@ -54,7 +54,7 @@ class FetcherSpec: QuickSpec {
 
                 fetcher.fetchKey(with: "key", completionHandler: { (_) in
                 })
-                expect(apiClientMock.request?.allHTTPHeaderFields!["apiKey"]).toEventually(equal("ras-my-subkey"))
+                expect(apiClientMock.request?.allHTTPHeaderFields!["apiKey"]).toEventually(equal("ras-my-subkey"), timeout: .seconds(5))
             }
 
             context("when valid key model is received as the result from the api client") {


### PR DESCRIPTION
# Description
Error message sent to MiniApp is not in Proper format. This will send error message in the same format as Android

## Links
[MINI-5895](https://jira.rakuten-it.com/jira/browse/MINI-5895)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
