### PR TITLE
[MINI-5781] Test cases not reported properly for Xcode 13.4 and above

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -33,7 +33,7 @@ target sdk_name + '_Example' do
   target sdk_name + '_Tests' do
     inherit! :search_paths
     pod 'Nimble', '~>9.2.1'
-    pod 'Quick', '~>4.0.0'
+    pod 'Quick', '~>5.0.0'
   end
 end
 


### PR DESCRIPTION
# Description
* Issue: We are using the Quick framework 4.x

* Cause: Quick framework 4.x is not able to detect all the unit test cases.

* Fix: Upgrade Quick framework to version 5.0.0 in podfile for test target.

## Links
[MINI-5781](https://jira.rakuten-it.com/jira/browse/MINI-5781)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
