### PR TITLE
[NO TICKET] Update AdMob to use official SPM.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 **SDK**
 - **Fix:** Fix Secure storage ready notification
 - **Refactor:** Update the Custom permissions error messages format
+- **SPM:** Moved Admob dependency to the official SPM repo
 
 **Sample App**
 - **Bugfix:** Mask Project ID & Subscription Key in Settings

--- a/DEV.md
+++ b/DEV.md
@@ -58,7 +58,7 @@ Here are the different environment variables you can set before running `fastlan
 |`RAS_PROJECT_IDENTIFIER_PROD` |Project id key you can find in your Rakuten App Studio project |yes |
 |`RAS_PROJECT_IDENTIFIER_STG` |Project id you can find in your staging Rakuten App Studio project |yes |
 |`RMA_DEMO_APP_BUILD_TYPE` |This is used as a suffix for your demo app version name (for example if demo app is 3.7.0 and you provide `DEV` as value for this variable, your version will be named `3.7.0-DEV`) |no |
-|`RMA_GAD_APPLICATION_IDENTIFIER` |Only required if you intend to work with the Google Ads subspec `MiniApp/Admob` or `MiniApp/Admob8` |no |
+|`RMA_GAD_APPLICATION_IDENTIFIER` |Only required if you intend to work with the Google Ads subspec `MiniApp/Admob`, `MiniApp/Admob7` or `MiniApp/Admob8` |no |
 |`RMA_APP_CENTER_SECRET` |This variable is used to send crash reports to an AppCenter project (the token can be generated in your AppCenter project page). |no |
 
 <a id="test-sample-app"></a>

--- a/MiniApp.podspec
+++ b/MiniApp.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |miniapp|
     signature.dependency 'MiniApp/Core'
   end
 
-  miniapp.subspec 'Admob' do |admob|
+  miniapp.subspec 'Admob7' do |admob|
     admob.source_files = 'Sources/Classes/admob7/**/*.{swift,h,m}'
     admob.dependency 'MiniApp/Core'
     admob.dependency 'Google-Mobile-Ads-SDK', '~> 7.0'
@@ -55,9 +55,18 @@ Pod::Spec.new do |miniapp|
   end
 
   miniapp.subspec 'Admob8' do |admob|
-    admob.source_files = 'Sources/Classes/admob/**/*.{swift,h,m}'
+    admob.source_files = 'Sources/Classes/admob8/**/*.{swift,h,m}'
     admob.dependency 'MiniApp/Core'
     admob.dependency 'Google-Mobile-Ads-SDK', '~> 8.0'
+    admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB -D RMA_SDK_ADMOB8'}
+    admob.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    admob.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  end
+
+  miniapp.subspec 'Admob' do |admob|
+    admob.source_files = 'Sources/Classes/admob/**/*.{swift,h,m}'
+    admob.dependency 'MiniApp/Core'
+    admob.dependency 'Google-Mobile-Ads-SDK', '~> 9.0'
     admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB -D RMA_SDK_ADMOB8'}
     admob.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
     admob.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }

--- a/MiniApp.podspec
+++ b/MiniApp.podspec
@@ -45,6 +45,15 @@ Pod::Spec.new do |miniapp|
     signature.dependency 'MiniApp/Core'
   end
 
+  miniapp.subspec 'Admob' do |admob|
+    admob.source_files = 'Sources/Classes/admob/**/*.{swift,h,m}'
+    admob.dependency 'MiniApp/Core'
+    admob.dependency 'Google-Mobile-Ads-SDK', '~> 9.0'
+    admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB -D RMA_SDK_ADMOB9'}
+    admob.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    admob.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  end
+  
   miniapp.subspec 'Admob7' do |admob|
     admob.source_files = 'Sources/Classes/admob7/**/*.{swift,h,m}'
     admob.dependency 'MiniApp/Core'
@@ -58,15 +67,6 @@ Pod::Spec.new do |miniapp|
     admob.source_files = 'Sources/Classes/admob8/**/*.{swift,h,m}'
     admob.dependency 'MiniApp/Core'
     admob.dependency 'Google-Mobile-Ads-SDK', '~> 8.0'
-    admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB -D RMA_SDK_ADMOB8'}
-    admob.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    admob.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  end
-
-  miniapp.subspec 'Admob' do |admob|
-    admob.source_files = 'Sources/Classes/admob/**/*.{swift,h,m}'
-    admob.dependency 'MiniApp/Core'
-    admob.dependency 'Google-Mobile-Ads-SDK', '~> 9.0'
     admob.xcconfig = { 'OTHER_SWIFT_FLAGS' => '$(inherited) -D RMA_SDK_ADMOB -D RMA_SDK_ADMOB8'}
     admob.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
     admob.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,26 +6,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "ef819db8c58657a6ca367322e73f3b6322afe0a2",
-          "version": "8.15.0"
-        }
-      },
-      {
-        "package": "GoogleMobileAds-SPM",
-        "repositoryURL": "https://github.com/rakutentech/GoogleMobileAds-SPM.git",
-        "state": {
-          "branch": null,
-          "revision": "7d006438585368541fce6f4840d30b682cd9ee0d",
-          "version": "8.13.0"
-        }
-      },
-      {
-        "package": "GoogleUserMessagingPlatform-SPM",
-        "repositoryURL": "https://github.com/rakutentech/GoogleUserMessagingPlatform-SPM.git",
-        "state": {
-          "branch": null,
-          "revision": "cea32e8a4f0665795b065d9aff4a5db1976f4430",
-          "version": "2.0.0"
+          "revision": "04351180d4c757c6c16127cb57b685fff9ef260b",
+          "version": "10.6.0"
         }
       },
       {
@@ -33,8 +15,8 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "6db6edb48bdd9943426562c7f042a5492de5ba3d",
-          "version": "7.10.0"
+          "revision": "0543562f85620b5b7c510c6bcbef75b562a5127b",
+          "version": "7.11.0"
         }
       },
       {
@@ -42,8 +24,8 @@
         "repositoryURL": "https://github.com/firebase/nanopb.git",
         "state": {
           "branch": null,
-          "revision": "7ee9ef9f627d85cbe1b8c4f49a3ed26eed216c77",
-          "version": "2.30908.0"
+          "revision": "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+          "version": "2.30909.0"
         }
       },
       {
@@ -51,8 +33,8 @@
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {
           "branch": null,
-          "revision": "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
-          "version": "2.1.1"
+          "revision": "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
+          "version": "2.2.0"
         }
       },
       {
@@ -62,6 +44,24 @@
           "branch": null,
           "revision": "7a2e3cd27de56f6d396e84f63beefd0267b55ccb",
           "version": "0.14.1"
+        }
+      },
+      {
+        "package": "GoogleMobileAds",
+        "repositoryURL": "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+        "state": {
+          "branch": null,
+          "revision": "78f4c64d0f1900e54529e4c78075d663ca67d6e0",
+          "version": "9.14.0"
+        }
+      },
+      {
+        "package": "GoogleUserMessagingPlatform",
+        "repositoryURL": "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+        "state": {
+          "branch": null,
+          "revision": "3b924ce3313a5fd2fc6a8dc889a8c38f76890fe3",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             name: "GoogleMobileAds-SPM",
-            url: "https://github.com/rakutentech/GoogleMobileAds-SPM.git", .upToNextMajor(from: "8.0.0")
+            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", .upToNextMajor(from: "9.0.0")
         )
     ],
     targets: [

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ secrets = [
 ]
 
 def miniapp_pods
-  pod 'MiniApp/Admob8', :path => './'
+  pod 'MiniApp/Admob', :path => './'
   pod 'MiniApp/UI', :path => './'
   pod 'MiniApp/Signature', :path => './'
 end

--- a/Sources/Classes/admob8/AdMobDisplayer.swift
+++ b/Sources/Classes/admob8/AdMobDisplayer.swift
@@ -1,0 +1,140 @@
+import Foundation
+import UIKit
+import GoogleMobileAds
+
+/// This subclass of [MiniAppAdDisplayer](x-source-tag://MiniAppAdDisplayer) is internally used by Mini App SDK to display Google Ads
+public class AdMobDisplayer: MiniAppAdDisplayer {
+    internal var interstitialAds: [String: GADInterstitialAd] = [:]
+    internal var rewardedAds: [String: GADRewardedAd] = [:]
+    internal var onInterstitialLoaded: [String: (Result<Void, Error>) -> Void] = [:]
+
+    public override init() {
+        super.init()
+        delegate = self
+    }
+
+    override func cleanReward(_ adId: String) {
+        rewardedAds.removeValue(forKey: adId)
+        super.cleanReward(adId)
+    }
+
+    override func cleanInterstitial(_ adId: String) {
+        onInterstitialLoaded.removeValue(forKey: adId)
+        interstitialAds.removeValue(forKey: adId)
+        super.cleanInterstitial(adId)
+    }
+
+    private func onReadyFailCheck(ready: Bool, adId: String, adType: MiniAppAdType) -> Error {
+        if ready {
+            return NSError.miniAppAdNotLoaded(message: createLoadTwiceError(adUnitId: adId))
+        } else {
+            switch adType {
+            case .interstitial:
+                if interstitialAds[adId] != nil {
+                    return NSError.miniAppAdNotLoaded(message: createLoadReqError(adUnitId: adId))
+                }
+            case .rewarded:
+                if rewardedAds[adId] != nil {
+                    return NSError.miniAppAdNotLoaded(message: createLoadReqError(adUnitId: adId))
+                }
+            }
+            return NSError.miniAppAdNotLoaded(message: createNotLoadingReqError(adUnitId: adId))
+        }
+    }
+
+    func createNotLoadingReqError(adUnitId: String) -> String {
+        String(format: MASDKLocale.localize(.adNotLoadedError), adUnitId)
+    }
+
+    func createLoadReqError(adUnitId: String) -> String {
+        String(format: MASDKLocale.localize(.adLoadingError), adUnitId)
+    }
+
+    func createLoadTwiceError(adUnitId: String) -> String {
+        String(format: MASDKLocale.localize(.adLoadedError), adUnitId)
+    }
+
+    public override func loadInterstitial(for adId: String, onLoaded: @escaping (Result<Void, Error>) -> Void) {
+        if interstitialAds[adId] != nil {
+           onLoaded(.failure(onReadyFailCheck(ready: true, adId: adId, adType: .interstitial)))
+        } else {
+            onInterstitialLoaded[adId] = onLoaded
+            let request = GADRequest()
+            GADInterstitialAd.load(withAdUnitID: adId, request: request) { [weak self]  (interstitialAd, error) in
+                if let error = error {
+                    self?.onInterstitialLoaded[adId]?(.failure(error))
+                    self?.cleanInterstitial(adId)
+                } else {
+                    interstitialAd?.fullScreenContentDelegate = self
+                    self?.interstitialAds[adId] = interstitialAd
+                    self?.onInterstitialLoaded[adId]?(.success(()))
+                }
+            }
+        }
+    }
+
+    public override func loadRewarded(for adId: String, onLoaded: @escaping (Result<(), Error>) -> Void) {
+        if rewardedAds[adId] != nil {
+            onLoaded(.failure(onReadyFailCheck(ready: true, adId: adId, adType: .rewarded)))
+        } else {
+            let request = GADRequest()
+            GADRewardedAd.load(withAdUnitID: adId,
+                    request: request, completionHandler: { [weak self] (rewardedAd, error) in
+                if let err = error {
+                    onLoaded(.failure(err))
+                    self?.cleanReward(adId)
+                } else {
+                    rewardedAd?.fullScreenContentDelegate = self
+                    self?.rewardedAds[adId] = rewardedAd
+                    onLoaded(.success(()))
+                }
+            })
+        }
+    }
+
+    public override func showInterstitial(for adId: String, onClosed: @escaping (Result<Void, Error>) -> Void) {
+        if let interstitialAd = interstitialAds[adId] {
+            if let viewController = UIApplication.topViewController() {
+                onInterstitialClosed[adId] = onClosed
+                interstitialAd.present(fromRootViewController: viewController)
+            } else {
+                onClosed(.failure(NSError.miniAppAdNotLoaded(message: MASDKAdsDisplayError.hostUIError.localizedDescription)))
+            }
+        } else {
+            onClosed(.failure(onReadyFailCheck(ready: false, adId: adId, adType: .interstitial)))
+        }
+    }
+
+    public override func showRewarded(for adId: String, onClosed: @escaping (Result<MiniAppReward, Error>) -> Void) {
+        if let rewardedAd = rewardedAds[adId] {
+            if let viewController = UIApplication.topViewController() {
+                onRewardedClosed[adId] = onClosed
+                rewardedAd.present(fromRootViewController: viewController) { [weak self] in
+                    let reward = rewardedAd.adReward
+                    self?.rewards[adId] = MiniAppReward(type: reward.type, amount: Int(truncating: reward.amount))
+                }
+            } else {
+                onClosed(.failure(NSError.miniAppAdNotLoaded(message: MASDKAdsDisplayError.hostUIError.localizedDescription)))
+            }
+        } else {
+            onClosed(.failure(onReadyFailCheck(ready: false, adId: adId, adType: .rewarded)))
+        }
+    }
+}
+
+extension AdMobDisplayer: GADFullScreenContentDelegate {
+    /// Tells the delegate that the ad dismissed full screen content.
+    public func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) { // swiftlint:disable:this identifier_name
+        if let interstitial = ad as? GADInterstitialAd {
+            onInterstitialClosed[interstitial.adUnitID]?(.success(()))
+            cleanInterstitial(interstitial.adUnitID)
+        } else if let rewardedAd = ad as? GADRewardedAd {
+            if let reward = rewards[rewardedAd.adUnitID] {
+                onRewardedClosed[rewardedAd.adUnitID]?(.success(reward))
+            } else {
+                onRewardedClosed[rewardedAd.adUnitID]?(.failure(NSError.miniAppAdNotLoaded(message: MASDKAdsDisplayError.rewardFailure.localizedDescription)))
+            }
+            cleanReward(rewardedAd.adUnitID)
+        }
+    }
+}

--- a/Tests/Unit/UIModule/AdMobDisplayerTests.swift
+++ b/Tests/Unit/UIModule/AdMobDisplayerTests.swift
@@ -17,7 +17,7 @@ class AdMobDisplayerTests: QuickSpec {
                     let adMobDisplayer = AdMobDisplayer()
                     #if RMA_SDK_ADMOB7
                         adMobDisplayer.interstitialAds = [key1: GADInterstitial(adUnitID: adId), key2: GADInterstitial(adUnitID: adId)]
-                    #elseif RMA_SDK_ADMOB8
+                    #elseif RMA_SDK_ADMOB
                         adMobDisplayer.interstitialAds = [key1: GADInterstitialAd(), key2: GADInterstitialAd()]
                     #endif
                     expect(adMobDisplayer.interstitialAds.count).to(equal(2))
@@ -31,7 +31,7 @@ class AdMobDisplayerTests: QuickSpec {
                     let adMobDisplayer = AdMobDisplayer()
                     #if RMA_SDK_ADMOB7
                         adMobDisplayer.rewardedAds = [key1: GADRewardedAd(adUnitID: adId), key2: GADRewardedAd(adUnitID: adId)]
-                    #elseif RMA_SDK_ADMOB8
+                    #elseif RMA_SDK_ADMOB
                         adMobDisplayer.rewardedAds = [key1: GADRewardedAd(), key2: GADRewardedAd()]
                     #endif
                     expect(adMobDisplayer.rewardedAds.count).to(equal(2))

--- a/scripts/build-doc.sh
+++ b/scripts/build-doc.sh
@@ -4,7 +4,8 @@ set -ex
 bundle install
 ### Removing admobs subspec before generating doc is necessary. The following script has to be run (from CI) before
 echo "" >> MiniApp.podspec # add a new line to the podspec file to remove it after awk treatment
-awk '!/Admob'\''/' RS=miniapp.subspec ORS=miniapp.subspec MiniApp.podspec > MiniApp.jazzy.podspec # create the jazzy podspec
+awk '!/Admob[0-9]'\''/' RS=miniapp.subspec ORS=miniapp.subspec MiniApp.podspec > MiniApp.jazzy.podspec # create the jazzy podspec
 sed -i '' -e '$ d' MiniApp.jazzy.podspec # clean the last line which contains an awk artifact
+echo "end" >> MiniApp.jazzy.podspec
 sed -i '' -e '$ d' MiniApp.podspec # remove the last line we added before
 bundle exec jazzy


### PR DESCRIPTION
# Description
Previously, SPM used in the Mini App repo was using Google AdMob which was referencing the https://github.com/rakutentech/GoogleMobileAds-SPM however that is not required now since Google has released their official SPM repo starting from the version 9.0.0 ; this PR is also updating the version of SPM from `8.0.0` to `9.0.0` and also referring to the official [Google SPM repo](https://github.com/googleads/swift-package-manager-google-mobile-ads).

## Links
- https://developers.google.com/admob/ios/quick-start#spm
# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
