### PR TITLE
[MINI-5952] Fix for sendJsonToMiniapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Fix:** Fix Secure storage ready notification
 - **Refactor:** Update the Custom permissions error messages format
 - **SPM:** Moved Admob dependency to the official SPM repo
+- **Fix:** Updated `sendJsonToMiniApp` to `MiniAppManageDelegate` that will help the old architecture to use it.
 
 **Sample App**
 - **Bugfix:** Mask Project ID & Subscription Key in Settings

--- a/Sources/Classes/core/Display/RealMiniAppView.swift
+++ b/Sources/Classes/core/Display/RealMiniAppView.swift
@@ -464,7 +464,7 @@ extension RealMiniAppView: MiniAppManageDelegate {
 
 // MARK: - Universal Bridge
 extension RealMiniAppView {
-    func sendJsonToMiniApp(string jsonString: String) {
+    public func sendJsonToMiniApp(string jsonString: String) {
         // Post custom event to send the string content to mini app.
         didReceiveEvent(MiniAppEvent.miniappReceiveJsonString, message: jsonString)
     }

--- a/Sources/Classes/core/Protocols/MiniAppDisplayProtocol.swift
+++ b/Sources/Classes/core/Protocols/MiniAppDisplayProtocol.swift
@@ -9,7 +9,7 @@ public protocol MiniAppDisplayDelegate: AnyObject {
 
     /// Get the view of the Mini app
     func getMiniAppView() -> UIView
-    
+
     /// Interface  that will be used by the Host app to send Json
     func sendJsonToMiniApp(string jsonString: String)
 

--- a/Sources/Classes/core/Protocols/MiniAppDisplayProtocol.swift
+++ b/Sources/Classes/core/Protocols/MiniAppDisplayProtocol.swift
@@ -9,5 +9,8 @@ public protocol MiniAppDisplayDelegate: AnyObject {
 
     /// Get the view of the Mini app
     func getMiniAppView() -> UIView
+    
+    /// Interface  that will be used by the Host app to send Json
+    func sendJsonToMiniApp(string jsonString: String)
 
 }


### PR DESCRIPTION
# Description
* Supporting `sendJsonToMiniApp` for old architecture

## Links
[MINI-5952](https://jira.rakuten-it.com/jira/browse/MINI-5952)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
