### PR TITLE
[MINI-6072] Closer Alert PopUp labels should be same across iOS/Android

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Repository checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Run SwiftLint
       run: swiftlint --strict

--- a/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
@@ -295,3 +295,4 @@ struct MiniAppFeatureConfigView_Previews: PreviewProvider {
         MiniAppSettingsView(showFullProgress: .constant(false))
     }
 }
+// swiftlint:enable line_length

--- a/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
+++ b/Example/Controllers/SwiftUI/Features/Single/MiniAppSingleView.swift
@@ -116,7 +116,7 @@ struct MiniAppSingleView: View {
             Alert(
                 title: Text(errorMessage.title),
                 message: Text(errorMessage.message),
-                primaryButton: .default(Text("Ok"), action: {
+                primaryButton: .default(Text("Yes"), action: {
                     presentationMode.wrappedValue.dismiss()
                 }),
                 secondaryButton: .cancel(Text("No"), action: {

--- a/Example/Controllers/SwiftUI/Helper/Binding+Optional.swift
+++ b/Example/Controllers/SwiftUI/Helper/Binding+Optional.swift
@@ -9,3 +9,4 @@ func ??<T>(lhs: Binding<Optional<T>>, rhs: T) -> Binding<T> {
         set: { lhs.wrappedValue = $0 }
     )
 }
+// swiftlint:enable operator_whitespace syntactic_sugar

--- a/Example/Controllers/SwiftUI/Helper/TextFieldStyle+MiniApp.swift
+++ b/Example/Controllers/SwiftUI/Helper/TextFieldStyle+MiniApp.swift
@@ -73,3 +73,4 @@ extension View {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }
+// swiftlint:enable identifier_name

--- a/Sources/Classes/core/Display/RealMiniAppView.swift
+++ b/Sources/Classes/core/Display/RealMiniAppView.swift
@@ -469,4 +469,3 @@ extension RealMiniAppView {
         didReceiveEvent(MiniAppEvent.miniappReceiveJsonString, message: jsonString)
     }
 }
-// swiftlint:enable file_length function_body_length

--- a/Sources/Classes/core/Display/RealMiniAppView.swift
+++ b/Sources/Classes/core/Display/RealMiniAppView.swift
@@ -469,3 +469,4 @@ extension RealMiniAppView {
         didReceiveEvent(MiniAppEvent.miniappReceiveJsonString, message: jsonString)
     }
 }
+// swiftlint:enable file_length function_body_length

--- a/Sources/Classes/core/Extensions/NSError+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/NSError+MiniApp.swift
@@ -127,4 +127,3 @@ enum MiniAppSDKErrorCode: Int {
          failedToConformToProtocol,
          invalidSignature
 }
-// swiftlint:enable identifier_name

--- a/Sources/Classes/core/Extensions/NSError+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/NSError+MiniApp.swift
@@ -127,3 +127,4 @@ enum MiniAppSDKErrorCode: Int {
          failedToConformToProtocol,
          invalidSignature
 }
+// swiftlint:enable identifier_name

--- a/Sources/Classes/core/Extensions/WKUserContentController+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/WKUserContentController+MiniApp.swift
@@ -58,4 +58,5 @@ extension WKUserContentController {
         let userScript = WKUserScript(source: javascriptSource, injectionTime: .atDocumentStart, forMainFrameOnly: true)
          addUserScript(userScript)
     }
+    // swiftlint:enable function_parameter_count
 }

--- a/Sources/Classes/core/Extensions/WKUserContentController+MiniApp.swift
+++ b/Sources/Classes/core/Extensions/WKUserContentController+MiniApp.swift
@@ -58,5 +58,4 @@ extension WKUserContentController {
         let userScript = WKUserScript(source: javascriptSource, injectionTime: .atDocumentStart, forMainFrameOnly: true)
          addUserScript(userScript)
     }
-    // swiftlint:enable function_parameter_count
 }

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -128,6 +128,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             closeMiniApp(requestParam: requestParam, callbackId: callbackId)
         }
     }
+    // swiftlint:enable function_body_length cyclomatic_complexity
 
     private func sendMessageToContact(with callBackId: String, parameters: RequestParameters?) {
         if let message = parameters?.messageToContact {
@@ -773,6 +774,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         )
     }
 }
+// swiftlint:enable type_body_length file_length
 
 //MARK: Universal Bridge support
 extension MiniAppScriptMessageHandler {

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -128,7 +128,6 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
             closeMiniApp(requestParam: requestParam, callbackId: callbackId)
         }
     }
-    // swiftlint:enable function_body_length cyclomatic_complexity
 
     private func sendMessageToContact(with callBackId: String, parameters: RequestParameters?) {
         if let message = parameters?.messageToContact {
@@ -774,7 +773,6 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         )
     }
 }
-// swiftlint:enable type_body_length file_length
 
 //MARK: Universal Bridge support
 extension MiniAppScriptMessageHandler {

--- a/Sources/Classes/core/MiniAppAnalytics.swift
+++ b/Sources/Classes/core/MiniAppAnalytics.swift
@@ -217,4 +217,3 @@ public class MiniAppAnalytics {
         }
     }
 }
-// swiftlint:enable function_body_length cyclomatic_complexity

--- a/Sources/Classes/core/MiniAppAnalytics.swift
+++ b/Sources/Classes/core/MiniAppAnalytics.swift
@@ -217,3 +217,4 @@ public class MiniAppAnalytics {
         }
     }
 }
+// swiftlint:enable function_body_length cyclomatic_complexity

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -265,7 +265,6 @@ internal class RealMiniApp {
             }
         }
     }
-    // swiftlint:enable function_parameter_count
 
     func retrieveCustomPermissions(forMiniApp id: String) -> [MASDKCustomPermissionModel] {
         let cachedPermissions = miniAppPermissionStorage.getCustomPermissions(forMiniApp: id)
@@ -508,5 +507,3 @@ extension RealMiniApp {
             )
     }
 }
-// swiftlint:enable type_body_length
-// swiftlint:enable file_length

--- a/Sources/Classes/core/RealMiniApp.swift
+++ b/Sources/Classes/core/RealMiniApp.swift
@@ -265,6 +265,7 @@ internal class RealMiniApp {
             }
         }
     }
+    // swiftlint:enable function_parameter_count
 
     func retrieveCustomPermissions(forMiniApp id: String) -> [MASDKCustomPermissionModel] {
         let cachedPermissions = miniAppPermissionStorage.getCustomPermissions(forMiniApp: id)
@@ -507,3 +508,5 @@ extension RealMiniApp {
             )
     }
 }
+// swiftlint:enable type_body_length
+// swiftlint:enable file_length

--- a/Sources/Classes/core/Utilities/MASDKLocale.swift
+++ b/Sources/Classes/core/Utilities/MASDKLocale.swift
@@ -97,3 +97,4 @@ public struct MASDKLocale {
         localize(bundle: path, key.rawValue)
     }
 }
+// swiftlint:enable identifier_name

--- a/Sources/Classes/core/Utilities/MASDKLocale.swift
+++ b/Sources/Classes/core/Utilities/MASDKLocale.swift
@@ -97,4 +97,3 @@ public struct MASDKLocale {
         localize(bundle: path, key.rawValue)
     }
 }
-// swiftlint:enable identifier_name

--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -877,4 +877,3 @@ extension MiniAppViewHandler {
         self.didReceiveEvent(MiniAppEvent.miniappReceiveJsonString, message: jsonString ?? "")
     }
 }
-// swiftlint:enable file_length function_body_length

--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -877,3 +877,4 @@ extension MiniAppViewHandler {
         self.didReceiveEvent(MiniAppEvent.miniappReceiveJsonString, message: jsonString ?? "")
     }
 }
+// swiftlint:enable file_length function_body_length

--- a/Sources/Classes/ui/MiniAppViewController.swift
+++ b/Sources/Classes/ui/MiniAppViewController.swift
@@ -386,4 +386,3 @@ extension MiniAppViewController: MiniAppNavigationDelegate {
     }
 
 }
-// swiftlint:enable function_body_length

--- a/Sources/Classes/ui/MiniAppViewController.swift
+++ b/Sources/Classes/ui/MiniAppViewController.swift
@@ -386,3 +386,4 @@ extension MiniAppViewController: MiniAppNavigationDelegate {
     }
 
 }
+// swiftlint:enable function_body_length


### PR DESCRIPTION
# Description
* Issue: Close alert showing the button titles as "No" and "Ok" in iOS

* Cause: Close alert button was set to "No" and "Ok" in iOS.

* Fix: Updated the button titles in close alert as "No" and "Yes" as per Android.

## Links
[MINI-6072](https://jira.rakuten-it.com/jira/browse/MINI-6072)
![Simulator Screen Shot - iPhone 13 Pro Max - 2023-04-18 at 13 41 59](https://user-images.githubusercontent.com/115203844/232674685-d07128c0-0a31-4a93-9110-b61e7c180b03.png)


# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
