### PR TITLE
[MINI-5676] Prepare the SDK to handle MAUID v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 5.3.0 (XXXX-XX-XX)
+**SDK**
+- **Deprecated:** `getUniqueId(completionHandler:)` in `MiniAppMessageDelegate` protocol is deprecated. You should use `getMessagingUniqueId(completionHandler:)` instead.
+
 ### 5.2.0 (2023-03-30)
 **SDK**
 - **Fix:** Fix Secure storage ready notification

--- a/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
+++ b/Sources/Classes/core/JavascriptBridge/MiniAppScriptMessageHandler.swift
@@ -226,6 +226,7 @@ internal class MiniAppScriptMessageHandler: NSObject, WKScriptMessageHandler {
         }
     }
 
+    @available(*, deprecated, renamed:"getMessagingUniqueId(completionHandler:)")
     func getUniqueId(callbackId: String) {
         hostAppMessageDelegate?.getUniqueId { (result) in
             switch result {

--- a/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
@@ -8,6 +8,7 @@ Public Protocol that will be used by the Mini App to communicate
 public protocol MiniAppMessageDelegate: MiniAppUserInfoDelegate, MiniAppShareContentDelegate, ChatMessageBridgeDelegate, UniversalBridgeDelegate {
 
     /// Interface that should be implemented to return alphanumeric string that uniquely identifies a device.
+    @available(*, deprecated, renamed:"getMessagingUniqueId(completionHandler:)")
     func getUniqueId(completionHandler: @escaping (Result<String?, MASDKError>) -> Void)
 
     /// Interface that should be implemented to return alphanumeric string that uniquely identifies a device assembled as message unique id
@@ -57,6 +58,7 @@ public extension MiniAppMessageDelegate {
         completionHandler(.failure(.failedToConformToProtocol))
     }
 
+    @available(*, deprecated, renamed:"getMessagingUniqueId(completionHandler:)")
     func getUniqueId(completionHandler: @escaping (Result<String?, MASDKError>) -> Void) {
         completionHandler(.failure(.failedToConformToProtocol))
     }

--- a/Sources/Classes/core/View/MiniAppView+Definitions.swift
+++ b/Sources/Classes/core/View/MiniAppView+Definitions.swift
@@ -29,7 +29,7 @@ public struct MiniAppConfig {
     - Parameters:
         - config: MiniAppSdkConfig that defines the baseUrl and other basic settings
         - adsDisplayer: Ads Displayer for showing ads
-        - messageDelegate: Message delegate to handle getUniqueId etc
+        - messageDelegate: Message delegate to handle getMauid etc
         - navigationDelegate: Handling of webview navigation actions
      */
     public init(

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -215,6 +215,8 @@ Mini App SDK provides default implementation for few interfaces in `MiniAppMessa
 | Method                       | Default  |
 | :----                        | :----:   |
 | getUniqueId                  | 🚫       |
+| getMessagingUniqueId         | 🚫       |
+| getMauid                     | 🚫       |
 | requestDevicePermission      | 🚫       |
 | requestCustomPermissions     | ✅       |
 | shareContent                 | ✅       |
@@ -234,6 +236,36 @@ Mini App SDK provides default implementation for few interfaces in `MiniAppMessa
 extension ViewController: MiniAppMessageDelegate {
     func getUniqueId(completionHandler: @escaping (Result<String, MASDKError>) -> Void) {
         // Implementation to return the Unique ID
+        completionHandler(.success(""))
+    }
+}
+```
+
+<a id="retrieve-unique-id"></a>
+
+##### Retrieving Messaging Unique ID
+---
+**API Docs:** [MiniAppUserInfoDelegate](https://rakutentech.github.io/ios-miniapp/Protocols/MiniAppUserInfoDelegate.html)
+
+```swift
+extension ViewController: MiniAppMessageDelegate {
+    func getMessagingUniqueId(completionHandler: @escaping (Result<String, MASDKError>) -> Void) {
+        // Implementation to return the Messaging Unique ID
+        completionHandler(.success(""))
+    }
+}
+```
+
+<a id="retrieve-unique-id"></a>
+
+##### Retrieving Unique MAUID for v2
+---
+**API Docs:** [MiniAppUserInfoDelegate](https://rakutentech.github.io/ios-miniapp/Protocols/MiniAppUserInfoDelegate.html)
+
+```swift
+extension ViewController: MiniAppMessageDelegate {
+    func getMauid(completionHandler: @escaping (Result<String, MASDKError>) -> Void) {
+        // Implementation to return the Unique MAUID
         completionHandler(.success(""))
     }
 }


### PR DESCRIPTION
# Description
Adding the deprecated with renamed modifier to the method getUniqueId() method.
Updated change log and updated user guide with getMessagingUniqueId() and getMauid() methods.

## Links
[MINI-5676](https://jira.rakuten-it.com/jira/browse/MINI-5676)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
