### PR TITLE
[MINI-6107] Add an option to enter the Hex theme colors in Demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Sample App**
 - **Feature:** Implemented method `getHostAppThemeColors(completionHandler:)` in the sample app to fetch the host app theme colors and pass it to MiniApps.
+- **Feature:** Added qa settings page 'Theme Color' to test sending host app theme primary and secondary colors.
 
 ### 5.2.0 (2023-03-30)
 **SDK**

--- a/Example/Assets/en.lproj/Localizable.strings
+++ b/Example/Assets/en.lproj/Localizable.strings
@@ -81,3 +81,4 @@
 "demo.app.rat.page.name.list.ii"                        =   "List II";
 "demo.app.rat.page.name.securestorage"                  =   "Secure Storage";
 "demo.app.rat.page.name.universalbridge"                =   "Universal Bridge";
+"demo.app.rat.page.name.themeColors"                    =   "Theme Colors";

--- a/Example/Assets/ja.lproj/Localizable.strings
+++ b/Example/Assets/ja.lproj/Localizable.strings
@@ -60,3 +60,4 @@
 "demo.app.rat.page.name.list.ii"                        =   "List II";
 "demo.app.rat.page.name.securestorage"                  =   "Secure Storage";
 "demo.app.rat.page.name.universalbridge"                =   "Universal Bridge";
+"demo.app.rat.page.name.themeColors"                    =   "Theme Colors";

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
@@ -36,13 +36,10 @@ struct HostAppThemeColorsView: View {
                         .multilineTextAlignment(.leading)
                 }
             }
-           
-            
         }
         .onTapGesture {
             dismissKeyboard()
         }
-        
         Button {
             trackButtonTap(pageName: pageName, buttonTitle: "Save Theme Colors")
             dismissKeyboard()
@@ -61,7 +58,6 @@ struct HostAppThemeColorsView: View {
             Alert(title: Text(alert.title), message: Text(alert.message), dismissButton: .default(Text("Ok")))
         }
         .trackPage(pageName: pageName)
-        
     }
 
     func storeHostAppThemeColors() {

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import MiniApp
+
+struct HostAppThemeColorsView: View {
+    @ObservedObject var viewModel: MiniAppSettingsViewModel
+    @State var primaryColor: String = ""
+    @State var secondaryColor: String = ""
+    @State private var pColor = Color.red
+    @State private var sColor = Color.blue
+    @State private var alertMessage: MiniAppAlertMessage?
+
+    var body: some View {
+        Form {
+            Section(header: Text("Enter color as Hex values")) {
+                VStack {
+                    Text("Primary Color")
+                    TextField("Primary Color as(#FFFFFF)", text: $primaryColor)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(Color("Crimson"), lineWidth: 1)
+                        ).keyboardType(.alphabet)
+                        .padding()
+                    Text("Secondary Color")
+                    TextField("Secondary Color(#FFFFFF)", text: $secondaryColor)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(Color("Crimson"), lineWidth: 1)
+                        ).keyboardType(.alphabet)
+                        .padding()
+                    Text("Note - Please enter only Hex color string including #")
+                        .padding()
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+           
+            
+        }
+        .onTapGesture {
+            dismissKeyboard()
+        }
+        
+        Button {
+            trackButtonTap(pageName: pageName, buttonTitle: "Save Theme Colors")
+            dismissKeyboard()
+            storeHostAppThemeColors()
+        } label: {
+            Text("Save")
+                .font(.system(size: 15, weight: .bold))
+                .frame(height: 50)
+                .frame(maxWidth: 300)
+        }
+        .navigationTitle(pageName)
+        .foregroundColor(.white)
+        .background(Color("Crimson").cornerRadius(10))
+        .padding(.all)
+        .alert(item: $alertMessage) { alert in
+            Alert(title: Text(alert.title), message: Text(alert.message), dismissButton: .default(Text("Ok")))
+        }
+        .trackPage(pageName: pageName)
+        
+    }
+
+    func storeHostAppThemeColors() {
+        if $primaryColor.wrappedValue != "" {
+            viewModel.store.hostAppThemeColors = HostAppThemeColors(primaryColor: $primaryColor.wrappedValue,
+                                                                    secondaryColor: $secondaryColor.wrappedValue == "" ? "#FFFFFF" : $secondaryColor.wrappedValue)
+            alertMessage = MiniAppAlertMessage(title: "Success", message: "Theme colors have been stored.")
+        } else {
+            viewModel.store.hostAppThemeColors = HostAppThemeColors(
+                primaryColor: $primaryColor.wrappedValue == "" ? "#FFFFFF" : $primaryColor.wrappedValue,
+                secondaryColor: $secondaryColor.wrappedValue == "" ? "#FFFFFF" : $secondaryColor.wrappedValue
+            )
+            alertMessage = MiniAppAlertMessage(title: "Failure", message: "Theme primary color must not be empty. Default value #FFFFFF will be set.")
+        }
+    }
+}
+
+extension HostAppThemeColorsView: ViewTrackable {
+    var pageName: String {
+        return NSLocalizedString("demo.app.rat.page.name.themeColors", comment: "")
+    }
+}
+
+struct HostAppThemeColorsView_Previews: PreviewProvider {
+    static var previews: some View {
+        HostAppThemeColorsView(viewModel: MiniAppSettingsViewModel())
+    }
+}

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
@@ -11,7 +11,7 @@ struct HostAppThemeColorsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Enter color as Hex values")) {
+            Section(header: Text("")) {
                 VStack {
                     Text("Primary Color")
                     TextField("Primary Color as(#FFFFFF)", text: $primaryColor)
@@ -62,15 +62,17 @@ struct HostAppThemeColorsView: View {
 
     func storeHostAppThemeColors() {
         if $primaryColor.wrappedValue != "" {
-            viewModel.store.hostAppThemeColors = HostAppThemeColors(primaryColor: $primaryColor.wrappedValue,
-                                                                    secondaryColor: $secondaryColor.wrappedValue == "" ? "#FFFFFF" : $secondaryColor.wrappedValue)
-            alertMessage = MiniAppAlertMessage(title: "Success", message: "Theme colors have been stored.")
+            viewModel.store.hostAppThemeColors = HostAppThemeColors(
+                primaryColor: $primaryColor.wrappedValue,
+                secondaryColor: $secondaryColor.wrappedValue
+            )
+            alertMessage = MiniAppAlertMessage(title: "Success", message: "Theme colors have been stored. Go to miniapp Color Theme page to check.")
         } else {
             viewModel.store.hostAppThemeColors = HostAppThemeColors(
-                primaryColor: $primaryColor.wrappedValue == "" ? "#FFFFFF" : $primaryColor.wrappedValue,
-                secondaryColor: $secondaryColor.wrappedValue == "" ? "#FFFFFF" : $secondaryColor.wrappedValue
+                primaryColor: $primaryColor.wrappedValue,
+                secondaryColor: $secondaryColor.wrappedValue
             )
-            alertMessage = MiniAppAlertMessage(title: "Failure", message: "Theme primary color must not be empty. Default value #FFFFFF will be set.")
+            alertMessage = MiniAppAlertMessage(title: "Error", message: "Primary color should not be empty.")
         }
     }
 }

--- a/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsQAView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/MiniAppSettingsQAView.swift
@@ -16,6 +16,11 @@ struct MiniAppSettingsQAView: View {
             } label: {
                 Label("Universal Bridge", systemImage: "link")
             }
+            NavigationLink {
+                HostAppThemeColorsView(viewModel: viewModel)
+            } label: {
+                Label("Theme Colors", systemImage: "paintpalette")
+            }
         }
         .navigationTitle(pageName)
         .trackPage(pageName: pageName)

--- a/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
+++ b/Example/Controllers/SwiftUI/Helper/MiniAppViewMessageDelegator.swift
@@ -187,9 +187,7 @@ class MiniAppViewMessageDelegator: NSObject, MiniAppMessageDelegate {
     func getHostAppThemeColors(completionHandler: @escaping (Result<HostAppThemeColors?, MiniAppJavaScriptError>) -> Void) {
         completionHandler(
             .success(
-                HostAppThemeColors(
-                    primaryColor: "#FF008C",
-                    secondaryColor: "#7D64BE")
+                MiniAppStore.shared.hostAppThemeColors
             )
         )
     }

--- a/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
+++ b/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
@@ -31,7 +31,7 @@ class MiniAppStore: ObservableObject {
     @Published var miniAppInfoList2Error: Error?
 
     var handlersListDict: [String: MiniAppSUIViewHandler] = [:]
-    var hostAppThemeColors: HostAppThemeColors = HostAppThemeColors(primaryColor: "#FFFFFF", secondaryColor: "#FFFFFF")
+    var hostAppThemeColors: HostAppThemeColors = HostAppThemeColors(primaryColor: "", secondaryColor: "")
 
     private init() {
         if !miniAppFirstLaunch {

--- a/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
+++ b/Example/Controllers/SwiftUI/Store/MiniAppStore.swift
@@ -31,6 +31,7 @@ class MiniAppStore: ObservableObject {
     @Published var miniAppInfoList2Error: Error?
 
     var handlersListDict: [String: MiniAppSUIViewHandler] = [:]
+    var hostAppThemeColors: HostAppThemeColors = HostAppThemeColors(primaryColor: "#FFFFFF", secondaryColor: "#FFFFFF")
 
     private init() {
         if !miniAppFirstLaunch {

--- a/Sample.xcodeproj/project.pbxproj
+++ b/Sample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		189A69D12566479800DCE2B1 /* RealMiniAppTests+Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189A69D02566479800DCE2B1 /* RealMiniAppTests+Permissions.swift */; };
 		1C0A785B29C3417500433A38 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C0A785929C3417500433A38 /* AdSupport.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		1C0A785C29C3417500433A38 /* AppTrackingTransparency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C0A785A29C3417500433A38 /* AppTrackingTransparency.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		1C0C5C892A0C973300CB1F63 /* HostAppThemeColorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0C5C882A0C973300CB1F63 /* HostAppThemeColorsView.swift */; };
 		1C2E06AE293A6A99003C6380 /* MiniAppSecureStorageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2E06AD293A6A99003C6380 /* MiniAppSecureStorageView.swift */; };
 		1CD1591829421FDF001E0E21 /* UniversalBridgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CD1591729421FDF001E0E21 /* UniversalBridgeView.swift */; };
 		2AB1B0A226A6CDEF004CAC1B /* MASDKLocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB1B0A126A6CDEF004CAC1B /* MASDKLocaleTests.swift */; };
@@ -148,6 +149,7 @@
 		189A69D02566479800DCE2B1 /* RealMiniAppTests+Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealMiniAppTests+Permissions.swift"; sourceTree = "<group>"; };
 		1C0A785929C3417500433A38 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		1C0A785A29C3417500433A38 /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
+		1C0C5C882A0C973300CB1F63 /* HostAppThemeColorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostAppThemeColorsView.swift; sourceTree = "<group>"; };
 		1C2E06AD293A6A99003C6380 /* MiniAppSecureStorageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniAppSecureStorageView.swift; sourceTree = "<group>"; };
 		1CD1591729421FDF001E0E21 /* UniversalBridgeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalBridgeView.swift; sourceTree = "<group>"; };
 		2AB1B0A126A6CDEF004CAC1B /* MASDKLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MASDKLocaleTests.swift; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 				F70DD8C428D417C3003EF1F1 /* MiniAppSettingsGeneralView.swift */,
 				F70DD8C528D417C3003EF1F1 /* MiniAppSettingsSignatureView.swift */,
 				1C2E06AD293A6A99003C6380 /* MiniAppSecureStorageView.swift */,
+				1C0C5C882A0C973300CB1F63 /* HostAppThemeColorsView.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -861,6 +864,7 @@
 				A15CC6CE28FE4E90009B328D /* View+Tracking.swift in Sources */,
 				38920AF7251D9C57004C5DDD /* Config.swift in Sources */,
 				F70DD90128D417C4003EF1F1 /* TextFieldStyle+MiniApp.swift in Sources */,
+				1C0C5C892A0C973300CB1F63 /* HostAppThemeColorsView.swift in Sources */,
 				3857ED7E25DEE0690083F3E1 /* Bundle+MiniApp.swift in Sources */,
 				38920AF2251D9C57004C5DDD /* ImageCache.swift in Sources */,
 				F70DD8EF28D417C4003EF1F1 /* MiniAppSettingsGeneralView.swift in Sources */,


### PR DESCRIPTION
# Description
Add an option in Settings>QA>Theme Colors
Add Two text fields (Primary Color & Secondary Color) Please add the description below the text field "Please mention only Hex color string including #" Add a Save button in Bottom that would persist the Primary & Secondary color in Demo app store. There is no validation required except empty value while saving

## Links
[MINI-6107](https://jira.rakuten-it.com/jira/browse/MINI-6107)
[Demo Link](https://rak.box.com/s/t2d16aqlvezn76of1dbe5xxg6iuhm5r9)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
