### PR TITLE
[MINI-6150] [Demo App] Color-Hex not displayed in QA settings after saving

### DIFF
--- a/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/Features/HostAppThemeColorsView.swift
@@ -37,6 +37,10 @@ struct HostAppThemeColorsView: View {
                 }
             }
         }
+        .onAppear {
+            primaryColor = viewModel.store.hostAppThemeColors.primaryColor
+            secondaryColor = viewModel.store.hostAppThemeColors.secondaryColor
+        }
         .onTapGesture {
             dismissKeyboard()
         }

--- a/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
+++ b/Sources/Classes/core/Protocols/MiniAppMessageDelegate.swift
@@ -140,8 +140,8 @@ public typealias DownloadHeaders = [String: String]
 
 // Model class used for sending the Host App theme colors to miniapp
 public class HostAppThemeColors: Codable {
-    let primaryColor: String
-    let secondaryColor: String
+    public let primaryColor: String
+    public let secondaryColor: String
 
     public init(primaryColor: String, secondaryColor: String) {
         self.primaryColor = primaryColor


### PR DESCRIPTION
# Description
Fixing issue in QA>Theme Colors: The value fields are empty. The Color-Hex Values saved earlier should be displayed.

## Links
[MINI-6150](https://jira.rakuten-it.com/jira/browse/MINI-6150)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
