### PR TITLE
[MINI-6213] [iOS Demo app] [Universal bridge] Unable to see alert message when info sent to the host tab

### DIFF
--- a/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
+++ b/Sources/Classes/core/Models/MiniAppJavaScriptMessageInfo.swift
@@ -42,9 +42,9 @@ struct JsonStringInfoParameters: Codable {
 }
 
 public struct UniversalBridgeInfoParameters: Codable {
-    var key: String?
-    var value: String?
-    var description: String?
+    public var key: String?
+    public var value: String?
+    public var description: String?
 }
 
 struct MiniAppCustomPermissionsRequest: Decodable {


### PR DESCRIPTION
# Description
Fixed the issue - Build failing due to compile time errors. Due to the UniversalBridgeInfoParameters model object parameters being internal.

## Links
[MINI-6213](https://jira.rakuten-it.com/jira/browse/MINI-6213)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
