### PR TITLE
[MINI-5899][iOS Sample] Enable deeplink/QR code to save the Project key and subscription key

### DIFF
--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -1,13 +1,15 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject var sharedSettingsVM: MiniAppSettingsViewModel
+    
     var body: some View {
-        MiniAppDashboardView()
+        MiniAppDashboardView(sharedSettingsVM: sharedSettingsVM)
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ContentView(sharedSettingsVM: MiniAppSettingsViewModel())
     }
 }

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject var sharedSettingsVM: MiniAppSettingsViewModel
-    
+
     var body: some View {
         MiniAppDashboardView(sharedSettingsVM: sharedSettingsVM)
     }

--- a/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
@@ -253,24 +253,32 @@ struct MiniAppSettingsView: View {
                 ()
             }
         }
+        .onChange(of: viewModel.listConfig.listType, perform: { _ in
+            self.dismissKeyboard()
+            self.updateKeys()
+        })
         .onChange(of: viewModel.listConfig.environmentMode, perform: { _ in
             self.dismissKeyboard()
-            switch viewModel.listConfig.environmentMode {
-            case .production:
-                viewModel.listConfig.projectId = viewModel.listConfig.projectIdProd
-                viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyProd
-            case .staging:
-                viewModel.listConfig.projectId = viewModel.listConfig.projectIdStaging
-                viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyStaging
-            }
-            self.tmpProjectKey = maskedString(of: viewModel.listConfig.projectId ?? "")
-            self.tmpSubscriptionKey = maskedString(of: viewModel.listConfig.subscriptionKey ?? "")
+            self.updateKeys()
         })
         .trackPage(pageName: pageName)
     }
 
     func dismissKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+
+    func updateKeys() {
+        switch viewModel.listConfig.environmentMode {
+        case .production:
+            viewModel.listConfig.projectId = viewModel.listConfig.projectIdProd
+            viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyProd
+        case .staging:
+            viewModel.listConfig.projectId = viewModel.listConfig.projectIdStaging
+            viewModel.listConfig.subscriptionKey = viewModel.listConfig.subscriptionKeyStaging
+        }
+        self.tmpProjectKey = maskedString(of: viewModel.listConfig.projectId ?? "")
+        self.tmpSubscriptionKey = maskedString(of: viewModel.listConfig.subscriptionKey ?? "")
     }
 
     var hasListIErrors: Bool {

--- a/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
+++ b/Example/Controllers/SwiftUI/Features/Settings/MiniAppSettingsView.swift
@@ -217,7 +217,6 @@ struct MiniAppSettingsView: View {
                 dismissButton: .default(Text("Ok"), action: {
                     self.tmpProjectKey = maskedString(of: viewModel.listConfig.projectId ?? "")
                     self.tmpSubscriptionKey = maskedString(of: viewModel.listConfig.subscriptionKey ?? "")
-                    
                 })
             )
         }

--- a/Example/Controllers/SwiftUI/MiniAppDashboardView.swift
+++ b/Example/Controllers/SwiftUI/MiniAppDashboardView.swift
@@ -9,6 +9,7 @@ class MiniAppDashboardViewModel: ObservableObject {
 struct MiniAppDashboardView: View {
 
     @StateObject var viewModel = MiniAppDashboardViewModel()
+    @StateObject var sharedSettingsVM: MiniAppSettingsViewModel
 
     @State var sampleMiniAppId: String = ""
     @State var sampleMiniAppVersion: String = ""
@@ -51,7 +52,7 @@ struct MiniAppDashboardView: View {
                 .tag(2)
 
                 NavigationView {
-                    MiniAppSettingsView(showFullProgress: $isPresentingFullProgress)
+                    MiniAppSettingsView(viewModel:sharedSettingsVM, showFullProgress: $isPresentingFullProgress)
                 }
                 .navigationViewStyle(.stack)
                 .tabItem {
@@ -95,6 +96,6 @@ struct MiniAppDashboardView: View {
 
 struct MiniAppDashboardView_Previews: PreviewProvider {
     static var previews: some View {
-        MiniAppDashboardView()
+        MiniAppDashboardView(sharedSettingsVM: MiniAppSettingsViewModel())
     }
 }

--- a/Example/Controllers/SwiftUI/MiniAppDashboardView.swift
+++ b/Example/Controllers/SwiftUI/MiniAppDashboardView.swift
@@ -52,7 +52,7 @@ struct MiniAppDashboardView: View {
                 .tag(2)
 
                 NavigationView {
-                    MiniAppSettingsView(viewModel:sharedSettingsVM, showFullProgress: $isPresentingFullProgress)
+                    MiniAppSettingsView(viewModel: sharedSettingsVM, showFullProgress: $isPresentingFullProgress)
                 }
                 .navigationViewStyle(.stack)
                 .tabItem {

--- a/Example/Models/SettingsParams.swift
+++ b/Example/Models/SettingsParams.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct SettingsParams: Equatable {
+    var tab: Int = 1
+    var projectId: String = ""
+    var subscriptionKey: String = ""
+    var isProduction: Bool = false
+    var isPreviewMode: Bool = false
+}

--- a/Example/SampleApp.swift
+++ b/Example/SampleApp.swift
@@ -8,10 +8,9 @@ struct SampleApp: App {
 
     let store = MiniAppStore.shared
     let deepLinkManager = DeeplinkManager()
-    
+
     @StateObject var sharedSettingsViewModel = MiniAppSettingsViewModel()
     @State var deepLink: SampleAppDeeplink?
-    
 
     var body: some Scene {
         WindowGroup {
@@ -70,7 +69,7 @@ struct SampleApp: App {
                 }
         }
     }
-    
+
     func prepareSettingsViewModel(with params: SettingsParams) {
         if params.tab == 1 {
             let list1 = self.setConfigValues(with: params, for: ListConfiguration(listType: .listI))
@@ -86,8 +85,8 @@ struct SampleApp: App {
         sharedSettingsViewModel.listConfig.persist()
         sharedSettingsViewModel.selectedListConfig = params.tab == 1 ? .listI : .listII
     }
-    
-    func setConfigValues(with params: SettingsParams, for listConfig:ListConfiguration) -> ListConfiguration {
+
+    func setConfigValues(with params: SettingsParams, for listConfig: ListConfiguration) -> ListConfiguration {
         var listConfig = listConfig
         if params.isProduction {
             listConfig.environmentMode = .production

--- a/Example/SampleApp.swift
+++ b/Example/SampleApp.swift
@@ -8,12 +8,14 @@ struct SampleApp: App {
 
     let store = MiniAppStore.shared
     let deepLinkManager = DeeplinkManager()
-
+    
+    @StateObject var sharedSettingsViewModel = MiniAppSettingsViewModel()
     @State var deepLink: SampleAppDeeplink?
+    
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(sharedSettingsVM: sharedSettingsViewModel)
                 .accentColor(.red)
                 .onOpenURL { url in
                     let receivedDeepLink = deepLinkManager.manage(url: url)
@@ -40,6 +42,9 @@ struct SampleApp: App {
                                 print(error)
                             }
                         }
+                    case let .settings(settinsInfo):
+                        prepareSettingsViewModel(with: settinsInfo)
+                        deepLink = .settings(viewModel: self.sharedSettingsViewModel)
                     }
                 }
                 .sheet(item: $deepLink) {
@@ -56,19 +61,65 @@ struct SampleApp: App {
                             )
                         }
                         .accentColor(.red)
+                    case .settings(let viewModel):
+                        NavigationView {
+                            MiniAppSettingsView(viewModel: viewModel, showFullProgress: .constant(false))
+                        }
+                        .accentColor(.red)
                     }
                 }
         }
+    }
+    
+    func prepareSettingsViewModel(with params: SettingsParams) {
+        if params.tab == 1 {
+            let list1 = self.setConfigValues(with: params, for: ListConfiguration(listType: .listI))
+            sharedSettingsViewModel.listConfig = list1
+            sharedSettingsViewModel.listConfigI = list1
+            sharedSettingsViewModel.listConfigI.persist()
+        } else {
+            let list2 = self.setConfigValues(with: params, for: ListConfiguration(listType: .listII))
+            sharedSettingsViewModel.listConfig = list2
+            sharedSettingsViewModel.listConfigII = list2
+            sharedSettingsViewModel.listConfigII.persist()
+        }
+        sharedSettingsViewModel.listConfig.persist()
+        sharedSettingsViewModel.selectedListConfig = params.tab == 1 ? .listI : .listII
+    }
+    
+    func setConfigValues(with params: SettingsParams, for listConfig:ListConfiguration) -> ListConfiguration {
+        var listConfig = listConfig
+        if params.isProduction {
+            listConfig.environmentMode = .production
+            listConfig.projectIdProd = params.projectId
+            listConfig.subscriptionKey = params.subscriptionKey
+        } else {
+            listConfig.environmentMode = .staging
+            listConfig.projectIdStaging = params.projectId
+            listConfig.subscriptionKeyStaging = params.subscriptionKey
+        }
+        if params.isPreviewMode {
+            listConfig.previewMode = .previewable
+        } else {
+            listConfig.previewMode = .published
+        }
+        listConfig.projectId = params.projectId
+        listConfig.subscriptionKey = params.subscriptionKey
+        listConfig.persist()
+        return listConfig
     }
 }
 
 enum SampleAppDeeplink: Identifiable {
     case miniapp(info: MiniAppInfo)
+    case settings(viewModel: MiniAppSettingsViewModel)
 
     var id: String {
         switch self {
         case .miniapp(let info):
             return info.id + "_" + info.version.versionId
+        case .settings(let queryParams):
+            return "SettingsConfig"
         }
     }
 }

--- a/Example/SceneDelegate.swift
+++ b/Example/SceneDelegate.swift
@@ -87,9 +87,9 @@ class DeeplinkManager {
             return .settings(settingsParams: settingsParams)
         }
     }
-    
+
     func getQueryItems(_ urlString: String) -> SettingsParams {
-        var queryItems: [String : String] = [:]
+        var queryItems: [String: String] = [:]
         let components: NSURLComponents? = getURLComonents(urlString)
         for item in components?.queryItems ?? [] {
             queryItems[item.name] = item.value?.removingPercentEncoding
@@ -102,9 +102,9 @@ class DeeplinkManager {
         settingsParams.isPreviewMode = Bool(queryItems["isPreviewMode"] ?? "") ?? false
         return settingsParams
     }
-    
+
     func getURLComonents(_ urlString: String?) -> NSURLComponents? {
-        var components: NSURLComponents? = nil
+        var components: NSURLComponents?
         let linkUrl = URL(string: urlString?.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) ?? "")
         if let linkUrl = linkUrl {
             components = NSURLComponents(url: linkUrl, resolvingAgainstBaseURL: true)

--- a/Example/SceneDelegate.swift
+++ b/Example/SceneDelegate.swift
@@ -44,12 +44,14 @@ class DeeplinkManager {
     enum Path: String {
         case qrcode = "preview"
         case deeplink = "dl"
+        case settings = "settings"
     }
 
     enum Target: Equatable, Identifiable {
         case unknown
         case qrcode(code: String)
         case deeplink(id: String)
+        case settings(settingsParams: SettingsParams)
 
         var id: String {
             switch self {
@@ -59,6 +61,8 @@ class DeeplinkManager {
                 return code
             case let .deeplink(id):
                 return id
+            case let .settings(settingsParams):
+                return settingsParams.projectId
             }
         }
     }
@@ -77,6 +81,34 @@ class DeeplinkManager {
         case .deeplink:
             guard url.pathComponents.count > 1 else { return .unknown }
             return .deeplink(id: url.pathComponents[2])
+        case .settings:
+            guard url.pathComponents.count > 1 else { return .unknown }
+            let settingsParams = self.getQueryItems(url.absoluteString)
+            return .settings(settingsParams: settingsParams)
         }
+    }
+    
+    func getQueryItems(_ urlString: String) -> SettingsParams {
+        var queryItems: [String : String] = [:]
+        let components: NSURLComponents? = getURLComonents(urlString)
+        for item in components?.queryItems ?? [] {
+            queryItems[item.name] = item.value?.removingPercentEncoding
+        }
+        var settingsParams = SettingsParams()
+        settingsParams.tab = Int(queryItems["tab"] ?? "") ?? 1
+        settingsParams.projectId = queryItems["projectid"] ?? ""
+        settingsParams.subscriptionKey = queryItems["subscription"] ?? ""
+        settingsParams.isProduction = Bool(queryItems["isProduction"] ?? "") ?? false
+        settingsParams.isPreviewMode = Bool(queryItems["isPreviewMode"] ?? "") ?? false
+        return settingsParams
+    }
+    
+    func getURLComonents(_ urlString: String?) -> NSURLComponents? {
+        var components: NSURLComponents? = nil
+        let linkUrl = URL(string: urlString?.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) ?? "")
+        if let linkUrl = linkUrl {
+            components = NSURLComponents(url: linkUrl, resolvingAgainstBaseURL: true)
+        }
+        return components
     }
 }

--- a/Sample.xcodeproj/project.pbxproj
+++ b/Sample.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1C0A785C29C3417500433A38 /* AppTrackingTransparency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C0A785A29C3417500433A38 /* AppTrackingTransparency.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		1C0C5C892A0C973300CB1F63 /* HostAppThemeColorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0C5C882A0C973300CB1F63 /* HostAppThemeColorsView.swift */; };
 		1C2E06AE293A6A99003C6380 /* MiniAppSecureStorageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2E06AD293A6A99003C6380 /* MiniAppSecureStorageView.swift */; };
+		1C3FCFEB2A666DB3003C7A05 /* SettingsParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3FCFEA2A666DB3003C7A05 /* SettingsParams.swift */; };
 		1C6BAB472A5519340012E800 /* MAAnalyticsInfoLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6BAB462A5519340012E800 /* MAAnalyticsInfoLogger.swift */; };
 		1C6BAB4B2A5522F60012E800 /* MAAnalyticsInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6BAB4A2A5522F60012E800 /* MAAnalyticsInfoView.swift */; };
 		1CD1591829421FDF001E0E21 /* UniversalBridgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CD1591729421FDF001E0E21 /* UniversalBridgeView.swift */; };
@@ -155,6 +156,7 @@
 		1C0A785A29C3417500433A38 /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
 		1C0C5C882A0C973300CB1F63 /* HostAppThemeColorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostAppThemeColorsView.swift; sourceTree = "<group>"; };
 		1C2E06AD293A6A99003C6380 /* MiniAppSecureStorageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniAppSecureStorageView.swift; sourceTree = "<group>"; };
+		1C3FCFEA2A666DB3003C7A05 /* SettingsParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsParams.swift; sourceTree = "<group>"; };
 		1C6BAB462A5519340012E800 /* MAAnalyticsInfoLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MAAnalyticsInfoLogger.swift; sourceTree = "<group>"; };
 		1C6BAB4A2A5522F60012E800 /* MAAnalyticsInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MAAnalyticsInfoView.swift; sourceTree = "<group>"; };
 		1CD1591729421FDF001E0E21 /* UniversalBridgeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalBridgeView.swift; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 			children = (
 				38920AD5251D9C57004C5DDD /* UserProfileModel.swift */,
 				A13C249726A15048003ADC6D /* UserPointsModel.swift */,
+				1C3FCFEA2A666DB3003C7A05 /* SettingsParams.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -877,6 +880,7 @@
 				F70DD8EC28D417C4003EF1F1 /* MiniAppSettingsQAView.swift in Sources */,
 				F70DD8EA28D417C4003EF1F1 /* MiniAppSettingsProfileView.swift in Sources */,
 				F70DD8E828D417C4003EF1F1 /* MiniAppSettingsView+Config.swift in Sources */,
+				1C3FCFEB2A666DB3003C7A05 /* SettingsParams.swift in Sources */,
 				F70DD8F628D417C4003EF1F1 /* MiniAppWithTermsView.swift in Sources */,
 				A13198012918A45C00B839E8 /* View+Events.swift in Sources */,
 				F70DD8EE28D417C4003EF1F1 /* MiniAppSettingsAccessTokenView.swift in Sources */,


### PR DESCRIPTION
# Description
Enable passing the Project ID and subscription key using deep link
For eg., miniappdemo://miniapp/settings?projectid=abc&subscription=def
If the Demo app is closed and it is opened using the above Deeplink, then it can open the default state of the settings page OR the last known state of the settings page with the value of the above deep-link parameters in the text field.

## Links
[MINI-5899](https://jira.rakuten-it.com/jira/browse/MINI-5899)
[MINI-5899.MP4 Box demo video link](https://rak.box.com/s/uzhxkaxohu48pxkn1h2pbqzjw8zojaz9)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
