### PR TITLE
[No-Ticket] [iOS SDK] - Enable webview inspectable in debug mode.

### DIFF
--- a/Sources/Classes/core/View/MiniAppView.swift
+++ b/Sources/Classes/core/View/MiniAppView.swift
@@ -98,6 +98,12 @@ public class MiniAppView: UIView, MiniAppViewable {
 
     internal func setupWebView(webView: MiniAppWebView) {
         self.webView = webView
+#if DEBUG
+        if #available(iOS 16.4, *) {
+            self.webView?.isInspectable = true
+        }
+#endif
+        
         webView.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(webView)
         NSLayoutConstraint.activate([

--- a/Sources/Classes/core/View/MiniAppView.swift
+++ b/Sources/Classes/core/View/MiniAppView.swift
@@ -103,7 +103,6 @@ public class MiniAppView: UIView, MiniAppViewable {
             self.webView?.isInspectable = true
         }
 #endif
-        
         webView.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(webView)
         NSLayoutConstraint.activate([


### PR DESCRIPTION
# Description
This PR will Fix issue of unable to perform inspect miniapp webview from safari developer tools in iOS 16.4 and above.
The miniapp webview will be inspectable only in the debug mode.

## Links
N/A

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
