### PR TITLE
Fix character escaping

### DIFF
--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -831,7 +831,11 @@ extension MiniAppViewHandler: MiniAppCallbackDelegate {
     }
 
     func didReceiveEvent(_ event: MiniAppEvent, message: String) {
-        let messageBody = Constants.JavaScript.eventCallback + "('\(event.rawValue)'," + "'\(message)')"
+        var encodedMessage = message
+        if event == .miniappReceiveJsonString {
+            encodedMessage = message.base64Encoded() ?? ""
+        }
+        let messageBody = Constants.JavaScript.eventCallback + "('\(event.rawValue)'," + "'\(encodedMessage)')"
         messageBodies.append(messageBody)
         MiniAppLogger.d(messageBody, "♨️️")
         webView?.evaluateJavaScript(messageBody)
@@ -933,3 +937,9 @@ extension MiniAppViewHandler {
     }
 }
 // swiftlint:enable file_length function_body_length
+
+extension String {
+   func base64Encoded() -> String? {
+      data(using: .utf8)?.base64EncodedString()
+   }
+}

--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -939,7 +939,8 @@ extension MiniAppViewHandler {
 // swiftlint:enable file_length function_body_length
 
 extension String {
-   func base64Encoded() -> String? {
-      data(using: .utf8)?.base64EncodedString()
-   }
+    func base64Encoded() -> String? {
+        guard let data = data(using: .nonLossyASCII) else { return "" }
+        return data.base64EncodedString()
+    }
 }

--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 import WebKit
 
 // swiftlint:disable file_length function_body_length
-
+// swiftlint:disable file_length
 // MARK: - MiniAppViewHandler
 class MiniAppViewHandler: NSObject {
 
@@ -944,3 +944,4 @@ extension String {
         return data.base64EncodedString()
     }
 }
+// swiftlint:enable file_length

--- a/Sources/Classes/core/View/MiniAppViewHandler.swift
+++ b/Sources/Classes/core/View/MiniAppViewHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 import WebKit
 
 // swiftlint:disable file_length function_body_length
-// swiftlint:disable file_length
+
 // MARK: - MiniAppViewHandler
 class MiniAppViewHandler: NSObject {
 
@@ -936,7 +936,6 @@ extension MiniAppViewHandler {
         self.didReceiveEvent(MiniAppEvent.miniappReceiveJsonString, message: jsonString ?? "")
     }
 }
-// swiftlint:enable file_length function_body_length
 
 extension String {
     func base64Encoded() -> String? {
@@ -944,4 +943,4 @@ extension String {
         return data.base64EncodedString()
     }
 }
-// swiftlint:enable file_length
+// swiftlint:enable file_length function_body_length


### PR DESCRIPTION
# Description
* Several characters are not escaped properly. This will encode the string that will be sent to MiniApp (MiniApp Bridge will decode it)
And we are encoding this only for miniappreceivejsoninfo not to break other things

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
